### PR TITLE
Use Zero and One methods consistently to return (0, 0, 0) and (1, 1, 1) 3D vectors

### DIFF
--- a/api/camera.js
+++ b/api/camera.js
@@ -125,9 +125,9 @@ export const flockCamera = {
 		);
 
 		const boxShape = new flock.BABYLON.PhysicsShapeBox(
-			new flock.BABYLON.Vector3.Zero(),
+			flock.BABYLON.Vector3.Zero(),
 			new flock.BABYLON.Quaternion(0, 0, 0, 1),
-			new flock.BABYLON.Vector3.One(),
+			flock.BABYLON.Vector3.One(),
 			flock.scene,
 		);
 

--- a/api/effects.js
+++ b/api/effects.js
@@ -96,7 +96,7 @@ export const flockEffects = {
           // Apply gravity if enabled
           particleSystem.gravity = gravity
             ? new flock.BABYLON.Vector3(0, -9.81, 0)
-            : new flock.BABYLON.Vector3.Zero();
+            : flock.BABYLON.Vector3.Zero();
 
           if (direction) {
             const { x, y, z } = direction;

--- a/api/mesh.js
+++ b/api/mesh.js
@@ -25,7 +25,7 @@ export const flockMesh = {
 
     const cylinderHeight = Math.max(0, height - 2 * radius);
 
-    const center = new flock.BABYLON.Vector3.Zero();
+    const center = flock.BABYLON.Vector3.Zero();
 
     const segmentStart = new flock.BABYLON.Vector3(
       center.x,

--- a/api/physics.js
+++ b/api/physics.js
@@ -59,7 +59,7 @@ export const flockPhysics = {
         const depth = boundingBox.maximumWorld.z - boundingBox.minimumWorld.z;
 
         const boxShape = new flock.BABYLON.PhysicsShapeBox(
-          new flock.BABYLON.Vector3.Zero(),
+          flock.BABYLON.Vector3.Zero(),
           new flock.BABYLON.Quaternion(0, 0, 0, 1), // No rotation
           new flock.BABYLON.Vector3(width, height, depth), // Updated dimensions
           flock.scene,

--- a/api/shapes.js
+++ b/api/shapes.js
@@ -62,7 +62,7 @@ export const flockShapes = {
 
     // Define and apply the physics shape
     const boxShape = new flock.BABYLON.PhysicsShapeBox(
-      new flock.BABYLON.Vector3.Zero(),
+      flock.BABYLON.Vector3.Zero(),
       new flock.BABYLON.Quaternion(0, 0, 0, 1),
       new flock.BABYLON.Vector3(width, height, depth),
       flock.scene,
@@ -136,7 +136,7 @@ export const flockShapes = {
 
     // Define and apply the physics shape
     const sphereShape = new flock.BABYLON.PhysicsShapeSphere(
-      new flock.BABYLON.Vector3.Zero(),
+      flock.BABYLON.Vector3.Zero(),
       Math.max(diameterX, diameterY, diameterZ) / 2,
       flock.scene,
     );
@@ -291,7 +291,7 @@ export const flockShapes = {
     newCapsule.metadata = newCapsule.metadata || {};
     newCapsule.metadata.blockKey = blockKey;
     // Define central point for the capsule
-    const center = new flock.BABYLON.Vector3.Zero();
+    const center = flock.BABYLON.Vector3.Zero();
 
     // Calculate physics shape parameters
     const capsuleRadius = radius;
@@ -376,7 +376,7 @@ export const flockShapes = {
 
     // Create physics shape - matching the mesh position
     const planeShape = new flock.BABYLON.PhysicsShapeBox(
-      new flock.BABYLON.Vector3.Zero(), // Center offset
+      flock.BABYLON.Vector3.Zero(), // Center offset
       new flock.BABYLON.Quaternion(0, 0, 0, 1),
       new flock.BABYLON.Vector3(width, height, 0.001),
       flock.scene,

--- a/ui/addmenu.js
+++ b/ui/addmenu.js
@@ -1035,7 +1035,7 @@ function triggerPlacement() {
   const syntheticEvent = {
     clientX: canvasRect.left + placementCirclePosition.x,
     clientY: canvasRect.top + placementCirclePosition.y,
-    defaultPosition: new flock.BABYLON.Vector3.Zero(),
+    defaultPosition: flock.BABYLON.Vector3.Zero(),
   };
 
   placementCallback(syntheticEvent);

--- a/ui/blockmesh.js
+++ b/ui/blockmesh.js
@@ -635,7 +635,7 @@ function setAbsoluteSize(mesh, width, height, depth) {
   mesh.bakeCurrentTransformIntoVertices();
 
   // Reset scaling to 1,1,1
-  mesh.scaling = new flock.BABYLON.Vector3.One();
+  mesh.scaling = flock.BABYLON.Vector3.One();
 
   // Restore original position and rotation from world matrix
   mesh.position = currentPosition;
@@ -651,7 +651,7 @@ function setAbsoluteSize(mesh, width, height, depth) {
     switch (shapeType) {
       case "Box":
         newShape = new flock.BABYLON.PhysicsShapeBox(
-          new flock.BABYLON.Vector3.Zero(),
+          flock.BABYLON.Vector3.Zero(),
           new flock.BABYLON.Quaternion(0, 0, 0, 1),
           new flock.BABYLON.Vector3(width, height, depth),
           mesh.getScene(),
@@ -670,7 +670,7 @@ function setAbsoluteSize(mesh, width, height, depth) {
         break;
       case "Sphere":
         newShape = new flock.BABYLON.PhysicsShapeSphere(
-          new flock.BABYLON.Vector3.Zero(),
+          flock.BABYLON.Vector3.Zero(),
           Math.max(width, depth, height) / 2,
           mesh.getScene(),
         );
@@ -721,7 +721,7 @@ function updateCylinderGeometry(
   // Temporarily reset mesh transform
   mesh.position = flock.BABYLON.Vector3.Zero();
   mesh.rotation = flock.BABYLON.Vector3.Zero();
-  mesh.scaling = new flock.BABYLON.Vector3.One();
+  mesh.scaling = flock.BABYLON.Vector3.One();
 
   // Create a temporary mesh with the provided dimensions (already in world space)
   const tempMesh = flock.BABYLON.MeshBuilder.CreateCylinder(
@@ -758,7 +758,7 @@ function updateCylinderGeometry(
   // Restore position and rotation only, keep scale at 1,1,1
   mesh.position = currentPosition;
   mesh.rotationQuaternion = currentRotationQuaternion;
-  mesh.scaling = new flock.BABYLON.Vector3.One();
+  mesh.scaling = flock.BABYLON.Vector3.One();
 
   // Ensure the world matrix is updated
   mesh.computeWorldMatrix(true);


### PR DESCRIPTION
Use Babylon.js methods provided in documentation to return (0, 0, 0) and (1, 1, 1) 3D vectors instead of hard coding them, leaving less room for human error. This was initially meant only for `ui/blockmesh.js` as I was reading it and preparing for future refactorings, but I ended up applying it elsewhere as well.

I will use this `refactor` branch to work on changes and open PRs for future refactoring done on `ui/gizmos.js`, `ui/blockmesh.js` and elsewhere.