### PR TITLE
Refine test runner

### DIFF
--- a/tests/materials.test.js
+++ b/tests/materials.test.js
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 
 export function runMaterialsTests(flock) {
-	describe("Effects methods", function () {
+	describe("Effects methods @materials", function () {
 		const boxIds = [];
 		const colors = ["#FF0000", "#00FF00", "#0000FF", "#FFFF00"];
 		const alphas = [0.1, 0.5, 0.9];
@@ -135,7 +135,7 @@ export function runMaterialsTests(flock) {
 		});
 	});
 
-	describe("changeColor method", function () {
+	describe("changeColor method @materials", function () {
 	  const boxIds = [];
 	  const colors = ["#FF0000", "#00FF00", "#0000FF", "#FFFF00"];
 
@@ -220,7 +220,7 @@ export function runMaterialsTests(flock) {
 	  });
 	});
 
-	describe("createMaterial method", function () {
+	describe("createMaterial method @materials", function () {
 	  const boxIds = [];
 
 	  async function createTestBox(id) {
@@ -304,7 +304,7 @@ export function runMaterialsTests(flock) {
 	  });
 	});
   
-	describe("setting a material scenarios", function () {
+	describe("setting a material scenarios @materials", function () {
 	  const boxIds = [];
 
 	  async function createTestBox(id) {
@@ -411,7 +411,7 @@ export function runMaterialsTests(flock) {
 	  });
 	});
 
-	describe("combine blocks dispose of old materials", function () {
+	describe("combine blocks dispose of old materials @materials", function () {
 	  const boxIds = [];
 
 	  beforeEach(async function () {

--- a/tests/physics.test.js
+++ b/tests/physics.test.js
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 
 export function runPhysicsTests(flock) {
-	describe("onTrigger", function () {
+	describe("onTrigger @physics", function () {
 		const boxIds = [];
 
 		beforeEach(async function () {
@@ -78,7 +78,7 @@ export function runPhysicsTests(flock) {
 		});
 	});
 
-	describe("onIntersect", function () {
+	describe("onIntersect @physics", function () {
 		const boxIds = [];
 
 		beforeEach(async function () {
@@ -133,7 +133,7 @@ export function runPhysicsTests(flock) {
 		});
 	});
 
-	describe("applyForce method", function () {
+	describe("applyForce method @physics", function () {
 		const boxIds = [];
 
 		beforeEach(async function () {

--- a/tests/sound.test.js
+++ b/tests/sound.test.js
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 
 export function runSoundTests(flock) {
-	describe("Sound playback", function () {
+	describe("Sound playback @sound", function () {
 	  this.timeout(10000); // Allow time for async sound to start/stop
 
 	  let boxId;
@@ -158,7 +158,7 @@ export function runSoundTests(flock) {
 	  });
 	});
 
-	describe("Play notes", function () {
+	describe("Play notes @sound", function () {
 		this.timeout(10000); // Allow time for async sound to start/stop
 		let boxId;
 		beforeEach(() => {

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -48,22 +48,6 @@
       <label for="testSelect" style="font-weight: bold; margin-right: 10px;">Select Test Suite:</label>
       <select id="testSelect" style="padding: 5px; margin-right: 10px;">
         <option value="">-- Choose a test suite --</option>
-        <option value="babylon">Basic Babylon Tests</option>
-        <option value="glide">Glide Animation Tests</option>
-        <option value="ui">UI Text/Button Tests</option>
-        <option value="stress">Stress Tests (Boxes)</option>
-        <option value="objects">Object Creation Tests</option>
-        <option value="sound">Sound Tests</option>
-        <option value="translation">Translation/Movement Tests</option>
-        <option value="rotation">Rotation Tests</option>
-        <option value="scale">Scale Tests</option>
-        <option value="materials">Materials Tests</option>
-        <option value="physics">Physics Tests</option>
-        <option value="effects">Effects Tests</option>
-        <option value="animate">Animation API Tests</option>
-        <option value="concurrency">Concurrency Tests</option>
-        <option value="blocks">Block Tests</option>
-        <option value="@new">:Run Tests tagged @new</option>
         <option value="all">:Run All Tests</option>
       </select>
       <button id="runTestBtn" style="padding: 5px 15px;">Run Tests</button>
@@ -83,6 +67,7 @@
       // if the tests were standardised and imported with a glob, (most of) the array could be generated automatically, reducing maintenance
       // alternatively, the array can be customised to run tagged tests or subsets of tests
       const testSuiteDefinitions = [
+        { id: "@new", name: ":Run Tests tagged @new", importPath: "", importFn: "", pattern: "@new" },
         { id: "babylon", name: "Basic Babylon Tests", importPath: "./babylon.test.js", importFn: "runTests", pattern: "Flock API Tests" },
         { id: "glide", name: "Glide Animation Tests", importPath: "./glide.test.js", importFn: "runGlideToTests", pattern: "glideTo function tests" },
         { id: "ui", name: "UI Text/Button Tests", importPath: "./uitextbutton.test.js", importFn: "runUITests", pattern: "UIText, UIButton, UIInput, and UISlider function tests" },
@@ -97,8 +82,7 @@
         { id: "effects", name: "Effects Tests", importPath: "./effects.test.js", importFn: "runEffectsTests", pattern: "Effects API" },
         { id: "animate", name: "Animation API Tests", importPath: "./animate.test.js", importFn: "runAnimateTests", pattern: "Animation API Tests" },
         { id: "concurrency", name: "Concurrency Tests", importPath: "./concurrency.test.js", importFn: "runConcurrencyTests", pattern: "Concurrency and Stress Tests" },
-        { id: "blocks", name: "Block Tests", importPath: "./blocks.test.js", importFn: "runBlocksTests", pattern: "blocks.js tests" },
-        { id: "@new", name: ":Run Tests tagged @new", importPath: "", importFn: "", pattern: "@new" }
+        { id: "blocks", name: "Block Tests", importPath: "./blocks.test.js", importFn: "runBlocksTests", pattern: "blocks.js tests" }
       ];
 
       import * as flockmodule from "../flock.js";
@@ -149,6 +133,11 @@
       async function loadAllTests() {
         // First, load all test modules
         for (const suite of testSuiteDefinitions) {
+          // add a new option element to testSelect with value=suite.id and text=suite.name
+          const option = document.createElement('option');
+          option.value = suite.id;
+          option.text = suite.name;
+          document.getElementById('testSelect').appendChild(option);   
           try { // for now, expect failures for Mocha tags only - like @new – as there's no import path
             const module = await import(suite.importPath);
             // Call the function to register tests with mocha, but don't run them yet

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -12,19 +12,20 @@
     </style>
     <style>
       /* CSS Variables for test filtering */
-      :root {
-        --test-pass-display: block;
-        --test-fail-display: block;
+
+      #mocha-report[data-filter="failures"] .test.pass {
+        display: none !important;
       }
 
-      /* Apply the variables to control visibility */
-      #mocha-report .test.pass {
-        display: var(--test-pass-display) !important;
+      #mocha-report[data-filter="passes"] .test.fail {
+        display: none !important;
       }
 
-      #mocha-report .test.fail {
-        display: var(--test-fail-display) !important;
+      #mocha-report[data-filter="all"] .test.fail, 
+      #mocha-report[data-filter="all"] .test.pass {
+        display: block !important;
       }
+
     </style>
   </head>
   <body>
@@ -205,14 +206,14 @@
       const clearTestBtn = document.getElementById('clearTestBtn');
 
       function setupFailuresLink() {
+        const mochaReport = document.getElementById('mocha-report');
         const failuresLink = document.querySelector('#mocha-stats .failures a');
         const passesLink = document.querySelector('#mocha-stats .passes a');
-        const root = document.documentElement;
+
         if (failuresLink) {
           failuresLink.onclick = function() {
             // Show only failures
-            root.style.setProperty('--test-pass-display', 'none');
-            root.style.setProperty('--test-fail-display', 'block');
+            mochaReport.dataset.filter = 'failures';
             
             // Scroll to first failure
             const firstFailure = document.querySelector('#mocha-report .test.fail');
@@ -220,16 +221,22 @@
               firstFailure.scrollIntoView({ behavior: 'smooth', block: 'start' });
             }
             
+            // toggle back to all results on next click
+            const oldText = failuresLink.innerHTML;
+            failuresLink.innerHTML = "(toggle) "+oldText;
+            failuresLink.onclick = function() { mochaReport.dataset.filter = 'all'; failuresLink.innerHTML = oldText ;return false; };
+
             return false;
           };
         }
         if (passesLink) {
           passesLink.onclick = function() {
             // Show only passes
-            root.style.setProperty('--test-pass-display', 'block');
-            root.style.setProperty('--test-fail-display', 'none');
-            root.style.setProperty('--test-pending-display', 'none');
-            
+            mochaReport.dataset.filter = 'passes';
+            // toggle back to all results on next click
+            const oldText = passesLink.innerHTML;
+            passesLink.innerHTML = "(toggle) "+oldText;
+            passesLink.onclick = function() { mochaReport.dataset.filter = 'all'; passesLink.innerHTML = oldText; return false; };
             return false;
           };
         }

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -57,24 +57,34 @@
 
     <!-- Import the test suite -->
     <script type="module">
+
+      // Define test suites in an array
+      // note: this array will change as test suites are refined
+      // some test files (materials, physics, sound, 3xtransform) have several top-level describe blocks
+      // the importFn is the function to call to register the tests with mocha - but if standardised the column could be removed
+      // if the tests were standardised and imported with a glob, (most of) the array could be generated automatically, reducing maintenance
+      // alternatively, the array can be customised to run tagged tests or subsets of tests
+      const testSuiteDefinitions = [
+        { id: "babylon", name: "Basic Babylon Tests", importPath: "./babylon.test.js", importFn: "runTests", pattern: "Flock API Tests" },
+        { id: "glide", name: "Glide Animation Tests", importPath: "./glide.test.js", importFn: "runGlideToTests", pattern: "glideTo function tests" },
+        { id: "ui", name: "UI Text/Button Tests", importPath: "./uitextbutton.test.js", importFn: "runUITests", pattern: "UIText, UIButton, UIInput, and UISlider function tests" },
+        { id: "stress", name: "Stress Tests (Boxes)", importPath: "./boxes.test.js", importFn: "runStressTests", pattern: "Stress test for many boxes" },
+        { id: "objects", name: "Object Creation Tests", importPath: "./objects.test.js", importFn: "runCreateObjectTests", pattern: "createObject tests" },
+        { id: "sound", name: "Sound Tests", importPath: "./sound.test.js", importFn: "runSoundTests", pattern: "@sound" },
+        { id: "translation", name: "Translation/Movement Tests", importPath: "./transform.translate.test.js", importFn: "runTranslationTests", pattern: "@translation" },
+        { id: "rotation", name: "Rotation Tests", importPath: "./transform.rotate.test.js", importFn: "runRotationTests", pattern: "@rotation" },
+        { id: "scale", name: "Scale Tests", importPath: "./transform.scale.test.js", importFn: "runScaleTests", pattern: "@scale" },
+        { id: "materials", name: "Materials Tests", importPath: "./materials.test.js", importFn: "runMaterialsTests", pattern: "@materials" },
+        { id: "physics", name: "Physics Tests", importPath: "./physics.test.js", importFn: "runPhysicsTests", pattern: "@physics" },
+        { id: "effects", name: "Effects Tests", importPath: "./effects.test.js", importFn: "runEffectsTests", pattern: "Effects API" },
+        { id: "animate", name: "Animation API Tests", importPath: "./animate.test.js", importFn: "runAnimateTests", pattern: "Animation API Tests" },
+        { id: "concurrency", name: "Concurrency Tests", importPath: "./concurrency.test.js", importFn: "runConcurrencyTests", pattern: "Concurrency and Stress Tests" },
+        { id: "blocks", name: "Block Tests", importPath: "./blocks.test.js", importFn: "runBlocksTests", pattern: "blocks.js tests" }
+      ];
+
       import * as flockmodule from "../flock.js";
       import "@babylonjs/core/Debug/debugLayer";
       import "@babylonjs/inspector";
-      import { runTests } from "./babylon.test.js"; // Import the test suite
-      import { runGlideToTests } from "./glide.test.js";
-      import { runUITests } from "./uitextbutton.test.js";
-      import { runStressTests } from "./boxes.test.js";
-      import { runCreateObjectTests } from "./objects.test.js";
-      import { runSoundTests } from "./sound.test.js";
-      import { runTranslationTests } from "./transform.translate.test.js";
-      import { runRotationTests } from "./transform.rotate.test.js";
-      import { runScaleTests } from "./transform.scale.test.js";
-      import { runMaterialsTests } from "./materials.test.js";
-      import { runPhysicsTests } from "./physics.test.js";
-      import { runEffectsTests } from "./effects.test.js";
-      import { runAnimateTests } from "./animate.test.js";
-	    import { runConcurrencyTests } from "./concurrency.test.js";
-	    import { runBlocksTests } from "./blocks.test.js";
 
       const flock = flockmodule.flock;
       flock.modelPath = "../models/";
@@ -83,6 +93,7 @@
 
       mocha.setup({
         ui: "bdd",
+        reporter: 'html',
         cleanReferencesAfterRun: false
       });
 
@@ -115,40 +126,62 @@
       }
 
       // Test suite mapping
-      const testSuites = {
-        babylon: () => runTests(flock, chai.expect),
-        glide: () => runGlideToTests(flock),
-        ui: () => runUITests(flock),
-        stress: () => runStressTests(flock),
-        objects: () => runCreateObjectTests(flock),
-        sound: () => runSoundTests(flock),
-        translation: () => runTranslationTests(flock),
-        rotation: () => runRotationTests(flock),
-        scale: () => runScaleTests(flock),
-        materials: () => runMaterialsTests(flock),
-        physics: () => runPhysicsTests(flock),
-        effects: () => runEffectsTests(flock),
-        animate: () => runAnimateTests(flock),
-		    concurrency: () => runConcurrencyTests(flock),
-        blocks: () => runBlocksTests(),
-        all: () => {
-          runTests(flock, chai.expect);
-          runGlideToTests(flock);
-          runUITests(flock);
-          runStressTests(flock);
-          runCreateObjectTests(flock);
-          runSoundTests(flock);
-          runTranslationTests(flock);
-          runRotationTests(flock);
-          runScaleTests(flock);
-          runMaterialsTests(flock);
-          runPhysicsTests(flock);
-          runEffectsTests(flock);
-          runAnimateTests(flock);
-		      runConcurrencyTests(flock);
-          runBlocksTests();
+      // Import all test modules and run them to register tests
+      async function loadAllTests() {
+        // First, load all test modules
+        for (const suite of testSuiteDefinitions) {
+          try {
+            const module = await import(suite.importPath);
+            // Call the function to register tests with mocha, but don't run them yet
+            if (suite.id === "babylon") {
+              module[suite.importFn](flock, chai.expect);
+            } else {
+              module[suite.importFn](flock);  
+            }
+          } catch (error) {
+            console.error(`Error loading test suite ${suite.id}:`, error);
+          }
         }
-      };
+
+        let returnableTestSuites = {
+          babylon: () => runTests(flock, chai.expect),
+          glide: () => runGlideToTests(flock),
+          ui: () => runUITests(flock),
+          stress: () => runStressTests(flock),
+          objects: () => runCreateObjectTests(flock),
+          sound: () => runSoundTests(flock),
+          translation: () => runTranslationTests(flock),
+          rotation: () => runRotationTests(flock),
+          scale: () => runScaleTests(flock),
+          materials: () => runMaterialsTests(flock),
+          physics: () => runPhysicsTests(flock),
+          effects: () => runEffectsTests(flock),
+          animate: () => runAnimateTests(flock),
+          concurrency: () => runConcurrencyTests(flock),
+          blocks: () => runBlocksTests(),
+          all: () => {
+            runTests(flock, chai.expect);
+            runGlideToTests(flock);
+            runUITests(flock);
+            runStressTests(flock);
+            runCreateObjectTests(flock);
+            runSoundTests(flock);
+            runTranslationTests(flock);
+            runRotationTests(flock);
+            runScaleTests(flock);
+            runMaterialsTests(flock);
+            runPhysicsTests(flock);
+            runEffectsTests(flock);
+            runAnimateTests(flock);
+            runConcurrencyTests(flock);
+            runBlocksTests();
+          }
+        }
+      return(returnableTestSuites);
+      }
+
+      // Load all tests immediately, and get test suite mapping
+      const testSuites = await loadAllTests();
 
       // Setup test selection interface
       const testSelect = document.getElementById('testSelect');
@@ -157,6 +190,8 @@
 
       runTestBtn.addEventListener('click', () => {
         const selectedTest = testSelect.value;
+        //console.log("Selected test suite:", selectedTest);
+        //console.log("Pattern being used:", testSuiteDefinitions.find(suite => suite.id === selectedTest)?.pattern);
         if (!selectedTest) {
           alert('Please select a test suite to run');
           return;
@@ -165,11 +200,21 @@
         // Clear previous results
         document.getElementById('mocha').innerHTML = '';
 
-        // Run selected test suite
-        if (testSuites[selectedTest]) {
-          testSuites[selectedTest]();
-          mocha.run();
+        // Reset any previous grep pattern
+        mocha.grep(null);
+        
+        // If a specific test suite is selected (not "all")
+        if (selectedTest !== "all") {
+          // Find the pattern for the selected test suite
+          const testSuite = testSuiteDefinitions.find(suite => suite.id === selectedTest);
+          if (testSuite && testSuite.pattern) {
+            // Apply the grep pattern to filter tests
+            mocha.grep(testSuite.pattern);
+          }
         }
+        
+        // Run the filtered tests
+        mocha.run();
       });
 
       clearTestBtn.addEventListener('click', () => {

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -63,7 +63,8 @@
         <option value="animate">Animation API Tests</option>
         <option value="concurrency">Concurrency Tests</option>
         <option value="blocks">Block Tests</option>
-        <option value="all">Run All Tests</option>
+        <option value="@new">:Run Tests tagged @new</option>
+        <option value="all">:Run All Tests</option>
       </select>
       <button id="runTestBtn" style="padding: 5px 15px;">Run Tests</button>
       <button id="clearTestBtn" style="padding: 5px 15px; margin-left: 5px;">Clear Results</button>
@@ -96,7 +97,8 @@
         { id: "effects", name: "Effects Tests", importPath: "./effects.test.js", importFn: "runEffectsTests", pattern: "Effects API" },
         { id: "animate", name: "Animation API Tests", importPath: "./animate.test.js", importFn: "runAnimateTests", pattern: "Animation API Tests" },
         { id: "concurrency", name: "Concurrency Tests", importPath: "./concurrency.test.js", importFn: "runConcurrencyTests", pattern: "Concurrency and Stress Tests" },
-        { id: "blocks", name: "Block Tests", importPath: "./blocks.test.js", importFn: "runBlocksTests", pattern: "blocks.js tests" }
+        { id: "blocks", name: "Block Tests", importPath: "./blocks.test.js", importFn: "runBlocksTests", pattern: "blocks.js tests" },
+        { id: "@new", name: ":Run Tests tagged @new", importPath: "", importFn: "", pattern: "@new" }
       ];
 
       import * as flockmodule from "../flock.js";
@@ -147,7 +149,7 @@
       async function loadAllTests() {
         // First, load all test modules
         for (const suite of testSuiteDefinitions) {
-          try {
+          try { // for now, expect failures for Mocha tags only - like @new – as there's no import path
             const module = await import(suite.importPath);
             // Call the function to register tests with mocha, but don't run them yet
             if (suite.id === "babylon") {
@@ -159,46 +161,10 @@
             console.error(`Error loading test suite ${suite.id}:`, error);
           }
         }
-
-        let returnableTestSuites = {
-          babylon: () => runTests(flock, chai.expect),
-          glide: () => runGlideToTests(flock),
-          ui: () => runUITests(flock),
-          stress: () => runStressTests(flock),
-          objects: () => runCreateObjectTests(flock),
-          sound: () => runSoundTests(flock),
-          translation: () => runTranslationTests(flock),
-          rotation: () => runRotationTests(flock),
-          scale: () => runScaleTests(flock),
-          materials: () => runMaterialsTests(flock),
-          physics: () => runPhysicsTests(flock),
-          effects: () => runEffectsTests(flock),
-          animate: () => runAnimateTests(flock),
-          concurrency: () => runConcurrencyTests(flock),
-          blocks: () => runBlocksTests(),
-          all: () => {
-            runTests(flock, chai.expect);
-            runGlideToTests(flock);
-            runUITests(flock);
-            runStressTests(flock);
-            runCreateObjectTests(flock);
-            runSoundTests(flock);
-            runTranslationTests(flock);
-            runRotationTests(flock);
-            runScaleTests(flock);
-            runMaterialsTests(flock);
-            runPhysicsTests(flock);
-            runEffectsTests(flock);
-            runAnimateTests(flock);
-            runConcurrencyTests(flock);
-            runBlocksTests();
-          }
-        }
-      return(returnableTestSuites);
       }
 
       // Load all tests immediately, and get test suite mapping
-      const testSuites = await loadAllTests();
+      await loadAllTests();
 
       // Setup test selection interface
       const testSelect = document.getElementById('testSelect');
@@ -257,7 +223,7 @@
         // Reset any previous grep pattern
         mocha.grep(null);
         
-        // If a specific test suite is selected (not "all")
+        // If a specific test suite / tag is selected (not "all")
         if (selectedTest !== "all") {
           // Find the pattern for the selected test suite
           const testSuite = testSuiteDefinitions.find(suite => suite.id === selectedTest);

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -131,14 +131,17 @@
       // Test suite mapping
       // Import all test modules and run them to register tests
       async function loadAllTests() {
-        // First, load all test modules
+        // Add an option for each test tag / suite, and try to import the module for a suite
         for (const suite of testSuiteDefinitions) {
           // add a new option element to testSelect with value=suite.id and text=suite.name
           const option = document.createElement('option');
           option.value = suite.id;
           option.text = suite.name;
-          document.getElementById('testSelect').appendChild(option);   
-          try { // for now, expect failures for Mocha tags only - like @new – as there's no import path
+          document.getElementById('testSelect').appendChild(option);  
+
+          // import the test module if an importPath is defined
+          // for now, expect (and accept) failures for Mocha tags only - like @new – as there's no import path
+          try { 
             const module = await import(suite.importPath);
             // Call the function to register tests with mocha, but don't run them yet
             if (suite.id === "babylon") {

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -10,6 +10,22 @@
         padding: 20px;
       }
     </style>
+    <style>
+      /* CSS Variables for test filtering */
+      :root {
+        --test-pass-display: block;
+        --test-fail-display: block;
+      }
+
+      /* Apply the variables to control visibility */
+      #mocha-report .test.pass {
+        display: var(--test-pass-display) !important;
+      }
+
+      #mocha-report .test.fail {
+        display: var(--test-fail-display) !important;
+      }
+    </style>
   </head>
   <body>
     <h1>Flock Test Example</h1>
@@ -188,6 +204,37 @@
       const runTestBtn = document.getElementById('runTestBtn');
       const clearTestBtn = document.getElementById('clearTestBtn');
 
+      function setupFailuresLink() {
+        const failuresLink = document.querySelector('#mocha-stats .failures a');
+        const passesLink = document.querySelector('#mocha-stats .passes a');
+        const root = document.documentElement;
+        if (failuresLink) {
+          failuresLink.onclick = function() {
+            // Show only failures
+            root.style.setProperty('--test-pass-display', 'none');
+            root.style.setProperty('--test-fail-display', 'block');
+            
+            // Scroll to first failure
+            const firstFailure = document.querySelector('#mocha-report .test.fail');
+            if (firstFailure) {
+              firstFailure.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
+            
+            return false;
+          };
+        }
+        if (passesLink) {
+          passesLink.onclick = function() {
+            // Show only passes
+            root.style.setProperty('--test-pass-display', 'block');
+            root.style.setProperty('--test-fail-display', 'none');
+            root.style.setProperty('--test-pending-display', 'none');
+            
+            return false;
+          };
+        }
+      }
+
       runTestBtn.addEventListener('click', () => {
         const selectedTest = testSelect.value;
         //console.log("Selected test suite:", selectedTest);
@@ -214,7 +261,8 @@
         }
         
         // Run the filtered tests
-        mocha.run();
+        let runner = mocha.run();
+        runner.on("end", setupFailuresLink);
       });
 
       clearTestBtn.addEventListener('click', () => {

--- a/tests/transform.rotate.test.js
+++ b/tests/transform.rotate.test.js
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 
 export function runRotationTests(flock) {
-	describe("rotate API Tests", function () {
+	describe("rotate API Tests @rotation", function () {
 	  let boxId;
 	  beforeEach(function () {
 		boxId = `box_${Date.now()}`;
@@ -143,7 +143,7 @@ export function runRotationTests(flock) {
 	  });*/
 	});
 
-	describe("rotate Camera API Tests", function () {
+	describe("rotate Camera API Tests @rotation", function () {
 	  it("should handle camera rotation without throwing errors", async function () {
 		// This test assumes there's an active camera
 		try {
@@ -170,7 +170,7 @@ export function runRotationTests(flock) {
 	  });*/
 	});
 
-	describe("rotateTo API Tests", function () {
+	describe("rotateTo API Tests @rotation", function () {
 	  let boxId;
 	  beforeEach(function () {
 		boxId = `box_${Date.now()}`;
@@ -298,7 +298,7 @@ export function runRotationTests(flock) {
 	  });
 	});
 
-	describe("lookAt API Tests", function () {
+	describe("lookAt API Tests @rotation", function () {
 	  let mesh1Id, mesh2Id;
 
 	  beforeEach(function () {

--- a/tests/transform.scale.test.js
+++ b/tests/transform.scale.test.js
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 
 export function runScaleTests(flock) {
-	describe("Scale function tests", function () {
+	describe("Scale function tests @scale", function () {
 		const testBoxIds = [];
 		const testColors = ["#FF0000", "#00FF00", "#0000FF", "#FFFF00"];
 		const scaleFactors = [0.5, 1.0, 1.5, 2.0, 3.0];
@@ -128,7 +128,7 @@ export function runScaleTests(flock) {
 		});
 	});
 
-	describe("Resize function tests", function () {
+	describe("Resize function tests @scale", function () {
 		const testBoxIds = [];
 		const testColors = ["#FF6600", "#66FF00", "#0066FF", "#FF0066"];
 		const targetSizes = [1, 2, 5, 10, 0.5];
@@ -316,7 +316,7 @@ export function runScaleTests(flock) {
 		});
 	});
 
-	describe("setPivotPoint function tests", function () {
+	describe("setPivotPoint function tests @scale", function () {
 		const testBoxIds = [];
 		const testColors = ["#FF0000", "#00FF00", "#0000FF", "#FFFF00"];
 		const pivotPositions = ["MIN", "CENTER", "MAX"];

--- a/tests/transform.translate.test.js
+++ b/tests/transform.translate.test.js
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 
 export function runTranslationTests(flock) {
-  describe("Translation API Tests", function () {
+  describe("Translation API Tests @translation", function () {
 	let boxId;
 
 	beforeEach(async function () {
@@ -105,7 +105,7 @@ export function runTranslationTests(flock) {
 
   });
 
-	describe("moveTo API Tests", function () {
+	describe("moveTo API Tests @translation", function () {
 	  let box1Id, box2Id;
 
 	  beforeEach(function () {
@@ -167,7 +167,7 @@ export function runTranslationTests(flock) {
 	  });
 	});
 
-	describe("moveByVector API Tests", function () {
+	describe("moveByVector API Tests @translation", function () {
 	  let boxId;
 	  beforeEach(function () {
 		boxId = `box_${Date.now()}`;
@@ -240,7 +240,7 @@ export function runTranslationTests(flock) {
 	  });
 	});
 
-	describe("distanceTo API Tests", function () {
+	describe("distanceTo API Tests @translation", function () {
 	  let box1Id, box2Id, box3Id;
 	  beforeEach(function () {
 		box1Id = `box1_${Date.now()}`;


### PR DESCRIPTION
Fix for #97 , enhancement to runner

Changed the unit test runner [tests/tests.html](https://github.com/flipcomputing/flock/blob/400d8afd420b2c5e39b88bda106d4529c74aa5d1/tests/tests.html) to:
- move away from registering tests on demand (which led to multiple registration)
- register all tests, and use Mocha.grep() to run suites selected in dropdown
- build dropdown from a configuration array, reducing need to keep things in sync
- set up facility for tagged tests – example in code is for @new, allowing any tests tagged with @new to be run together
- set up filter links in Mocha's HTML report to show (only failed) / (only passed) tests (toggled)

Changes to several unit tests
- where one file contains several `describe` blocks, each has been tagged to allow them to be executed together, so that existing behaviour of the test runner is followed.

_@workroomprds note for further work – format Mocha's HTML report so that it no longer pushes panel off-screen, check effect on vite, address special case for Babylon import (perhaps chai for all?)_
