### PR TITLE
Add basic support for focusing camera on selected mesh using F key

### DIFF
--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -24,7 +24,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
   window.addEventListener("keydown", (event) => {
     // Check if both Ctrl and the comma key (,) are pressed
-    if (event.ctrlKey && event.code === "Comma") {
+    if ((event.ctrlKey && event.code === "Comma") || (event.code === "KeyF")) {
       focusCameraOnMesh();
     }
   });


### PR DESCRIPTION
As discussed privately. "F" is the default key for similar purpose in Unity and some other game engines.