### PR TITLE
Enable focus on fast tests

### DIFF
--- a/tests/animate.test.js
+++ b/tests/animate.test.js
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 
 export function runAnimateTests(flock) {
-	describe("Animation API Tests", function () {
+	describe("Animation API Tests @slow", function () {
 		const boxIds = [];
 
 		beforeEach(async function () {

--- a/tests/boxes.test.js
+++ b/tests/boxes.test.js
@@ -2,7 +2,7 @@ import { expect } from "chai";
 
 // Stress test for handling many boxes with dynamic inputs
 export function runStressTests(flock) {
-	describe("Stress test for many boxes", function () {
+	describe("Stress test for many boxes @slow", function () {
 		const boxCount = 50; // Number of boxes to create
 		const boxIds = [];
 		const boxColors = ["#FF0000", "#00FF00", "#0000FF", "#FFFF00", "#FF00FF", "#00FFFF"];

--- a/tests/concurrency.test.js
+++ b/tests/concurrency.test.js
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 
 export function runConcurrencyTests(flock) {
-	describe("Concurrency and Stress Tests", function () {
+	describe("Concurrency and Stress Tests @slow", function () {
 		this.timeout(30000); // Extended timeout for stress tests
 		const createdObjects = [];
 

--- a/tests/glide.test.js
+++ b/tests/glide.test.js
@@ -8,7 +8,7 @@ function checkXPosition(box, pos) {
 
 // Test suite for glideTo function
 export function runGlideToTests(flock) {
-	describe("glideTo function tests", function () {
+	describe("glideTo function tests @slow", function () {
 		let box1;
 
 		// Set up the box before each test
@@ -29,7 +29,7 @@ export function runGlideToTests(flock) {
 			flock.dispose(box1);
 		});
 
-		it("should move the box to the correct position", function (done) {
+		it("should move the box to the correct position @slow", function (done) {
 			this.timeout(15000); // Increase the timeout forthis test
 			// Call glideTo to move the
 
@@ -44,7 +44,7 @@ export function runGlideToTests(flock) {
 			});
 		});
 
-		it("should handle reverse movement", function (done) {
+		it("should handle reverse movement @slow", function (done) {
 			this.timeout(10000); // Increase the timeout for this test
 
 			// Move the box with loop enabled

--- a/tests/objects.test.js
+++ b/tests/objects.test.js
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 
 export function runCreateObjectTests(flock) {
-	describe("createObject tests", function () {
+	describe("createObject tests @slow", function () {
 		this.timeout(5000);
 
 		it("should create one object then create another", async function () {

--- a/tests/physics.test.js
+++ b/tests/physics.test.js
@@ -148,7 +148,7 @@ export function runPhysicsTests(flock) {
 			boxIds.length = 0;
 		});
 
-		it("should apply force to a mesh with default values (no movement)", async function () {
+		it("should apply force to a mesh with default values (no movement) @slow", async function () {
 			const id = "boxApplyForceDefault";
 			await flock.createBox(id, {
 				width: 1,

--- a/tests/sound.test.js
+++ b/tests/sound.test.js
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 
 export function runSoundTests(flock) {
-	describe("Sound playback @sound", function () {
+	describe("Sound playback @sound @slow", function () {
 	  this.timeout(10000); // Allow time for async sound to start/stop
 
 	  let boxId;
@@ -158,7 +158,7 @@ export function runSoundTests(flock) {
 	  });
 	});
 
-	describe("Play notes @sound", function () {
+	describe("Play notes @sound @slow", function () {
 		this.timeout(10000); // Allow time for async sound to start/stop
 		let boxId;
 		beforeEach(() => {

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -95,7 +95,7 @@
       <button id="clearTestBtn" style="padding: 5px 15px; margin-left: 5px;">Clear Results</button>
     </div>
     <div  style="margin: 20px 0;">
-      <p>Test Filter: <span id="mochaFilter"></span></p>
+      <p>Test Filter (mocha grep): <span id="mochaFilter"></span></p>
     </div>
 
     <!-- Mocha test results will be displayed here -->
@@ -112,6 +112,8 @@
       // alternatively, the array can be customised to run tagged tests or subsets of tests
       const testSuiteDefinitions = [
         { id: "@new", name: ":Run Tests tagged @new", importPath: "", importFn: "", pattern: "@new" },
+        { id: "@notslow", name: ":Run all except @slow", importPath: "", importFn: "", pattern: "/^(?!.*@slow).*$/" },
+        { id: "@onlyslow", name: ":Run only @slow", importPath: "", importFn: "", pattern: "@slow" },
         { id: "babylon", name: "Basic Babylon Tests", importPath: "./babylon.test.js", importFn: "runTests", pattern: "Flock API Tests" },
         { id: "glide", name: "Glide Animation Tests", importPath: "./glide.test.js", importFn: "runGlideToTests", pattern: "glideTo function tests" },
         { id: "ui", name: "UI Text/Button Tests", importPath: "./uitextbutton.test.js", importFn: "runUITests", pattern: "UIText, UIButton, UIInput, and UISlider function tests" },
@@ -212,10 +214,15 @@
       // set up (global for this script) selectedTest variable
       let selectedTest = null;
 
-      function setMochaFiter(pattern) {
-        mocha.grep(pattern);
+      function mentionMochaFilter(pattern, name) {
+        const info = `${pattern || "None"}`
         const filterSpan = document.getElementById('mochaFilter');
-        filterSpan.textContent = pattern ? pattern : "None";
+        filterSpan.textContent = info ;
+      }
+
+      function setMochaFiter(pattern, name=null) {
+        mocha.grep(pattern);
+        mentionMochaFilter(pattern, name);
       }
 
       function clearMochaFilter() {
@@ -278,8 +285,6 @@
 
       testSelect.addEventListener('change', () => {
         selectedTest = testSelect.value;
-        //console.log("Selected test suite:", selectedTest);
-        //console.log("Pattern being used:", testSuiteDefinitions.find(suite => suite.id === selectedTest)?.pattern);
         
         // Clear previous results
         document.getElementById('mocha').innerHTML = '';
@@ -293,7 +298,7 @@
           const testSuite = testSuiteDefinitions.find(suite => suite.id === selectedTest);
           if (testSuite && testSuite.pattern) {
             // Apply the grep pattern to filter tests
-            setMochaFiter(testSuite.pattern);
+            setMochaFiter(testSuite.pattern, testSuite.name);
           }
         }
       });
@@ -310,7 +315,9 @@
       });
 
       clearTestBtn.addEventListener('click', () => {
+        // workroomprds says: let's clarify what this is for. I'm concerned that we're introducing a covert state – and that may mean re-running tests produces different behavior becuase the tests are in a slightly different state
         document.getElementById('mocha').innerHTML = '';
+        testSelect.selectedIndex = 0;
         clearMochaFilter();
       });
 

--- a/tests/transform.translate.test.js
+++ b/tests/transform.translate.test.js
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 
 export function runTranslationTests(flock) {
-  describe("Translation API Tests @translation", function () {
+  describe("Translation API Tests @translation @slow", function () {
 	let boxId;
 
 	beforeEach(async function () {
@@ -145,7 +145,7 @@ export function runTranslationTests(flock) {
 		  expect(box1.getAbsolutePosition().z).to.be.closeTo(box2.getAbsolutePosition().z, 0.01);
 		});
 
-	  it("should move a box to the target box centre position without changing Y when useY is false", function (done) {
+	  it("should move a box to the target box centre position without changing Y when useY is false @slow", function (done) {
 		flock.positionAt(box1Id, { x: 0, y: 10, z: 0 });
 
 		setTimeout(() => {

--- a/tests/uitextbutton.test.js
+++ b/tests/uitextbutton.test.js
@@ -72,7 +72,7 @@ export function runUITests(flock) {
 		expect(textBlock.isVisible).to.be.true;
 	  });
 
-	  it("should hide the text block after the specified duration", function (done) {
+	  it("should hide the text block after the specified duration @slow", function (done) {
 		this.timeout(5000);
 
 		flock.UIText({
@@ -92,7 +92,7 @@ export function runUITests(flock) {
 		}, 2500);
 	  });
 
-	  it("should show the text block again using the show function", function (done) {
+	  it("should show the text block again using the show function @slow", function (done) {
 		this.timeout(5000);
 
 		flock.UIText({


### PR DESCRIPTION
A good portion of the suite now can be run in a few seconds (134 tests run in ~2s on my machine).
Changed test runner to allow tests tagged '@slow' to be excluded, or run exclusively.
Tagged particularly slow tests / suites with @slow. These 95 tests take ~2 mins on my machine.
"all" still runs all
Page still runs _none_ on open