### PR TITLE
Implement live updates for sky block when list of colours is added

### DIFF
--- a/blocks/scene.js
+++ b/blocks/scene.js
@@ -17,6 +17,7 @@ import {
 	getOption,
 	getDropdownOption,
 } from "../main/translation.js";
+import { flock } from "../flock.js";
 
 export function defineSceneBlocks() {
 	Blockly.Blocks["set_sky_color"] = {
@@ -40,6 +41,7 @@ export function defineSceneBlocks() {
 			this.setHelpUrl(getHelpUrlFor(this.type));
 			this.setStyle("scene_blocks");
 			this.setOnChange((changeEvent) => {
+				if (flock.eventDebug) console.log(changeEvent.type);
 				if (
 					changeEvent.type === Blockly.Events.BLOCK_CREATE ||
 					changeEvent.type === Blockly.Events.BLOCK_CHANGE ||

--- a/blocks/scene.js
+++ b/blocks/scene.js
@@ -42,7 +42,8 @@ export function defineSceneBlocks() {
 			this.setOnChange((changeEvent) => {
 				if (
 					changeEvent.type === Blockly.Events.BLOCK_CREATE ||
-					changeEvent.type === Blockly.Events.BLOCK_CHANGE
+					changeEvent.type === Blockly.Events.BLOCK_CHANGE ||
+					changeEvent.type === Blockly.Events.BLOCK_MOVE
 				) {
 					const parent = findCreateBlock(
 						Blockly.getMainWorkspace().getBlockById(

--- a/flock.js
+++ b/flock.js
@@ -71,6 +71,7 @@ export const flock = {
         texturePath: "./textures/",
         engine: null,
         engineReady: false,
+        eventDebug: false,
         modelReadyPromises: new Map(),
         pendingMeshCreations: 0,
         pendingTriggers: new Map(),


### PR DESCRIPTION
A simple fix, this one: Adding a list of colours block directly from the menu to a sky colour block did not register live because the `changeEvent` wasn't a `create` or `change` event for some reason (it theoretically _should_ be, but that's besides the point). Matter of fact, I'm not _exactly_ sure what it is, but I found that detecting a `move` event changed the sky colour to the appropriate gradient appropriately, so I used that and it worked.