### PR TITLE
Fix typo in style.css for bigbutton class

### DIFF
--- a/style.css
+++ b/style.css
@@ -391,7 +391,7 @@ button {
   margin-left: 3px;
   padding: 4px;
   font-size: 18px;
-  mix-height:30px;
+  min-height:30px;
   background-color: var(--color-button-bg);
   color: var(--color-text-primary);
   border: none;


### PR DESCRIPTION
Define `min-height` instead of `mix-height`

Defining `max-height` instead would make certain buttons irregular (i.e. 35x30 instead of 35x35)