### PR TITLE
Add snippets for showing off physics mesh capabilities (and create dedicated subcategory for said snippets)

### DIFF
--- a/toolbox.js
+++ b/toolbox.js
@@ -3429,7 +3429,6 @@ const toolboxSnippetsPhysics = {
                                 DO: {
                                         block: {
                                                 type: "create_box",
-                                                id: "s~usd339iO-mEZRyDZ6i",
                                                 extraState: "<mutation xmlns=\"http://www.w3.org/1999/xhtml\" has_do=\"false\"></mutation>",
                                                 fields: {
                                                         ID_VAR: {


### PR DESCRIPTION
As discussed privately.

Marking this as a draft as it is not fully ready, but opening it early to allow opportunities for early feedback.

Currently I only have one snippet that somehow isn't showing properly, and isn't even showing all the blocks. Right now it's showing this:

<img width="508" height="147" alt="image" src="https://github.com/user-attachments/assets/e5a1bf77-58cd-40df-b718-51121f7d6e2e" />

When it should _really_ be showing this:

<img width="483" height="234" alt="image" src="https://github.com/user-attachments/assets/4147d323-a818-4a53-9268-5368a99be382" />

I'd appreciate if anyone else has any advice on what's going wrong here. I _did_ look at the code behind the other snippets, but if I'm still missing something, please let me know.