### PR TITLE
Undo padding on loading screen text

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,7 +122,6 @@
         font-size: 18px;
         font-weight: 500;
         margin: 0;
-        padding: 1em;
         font-family: "Atkinson Hyperlegible Next", "Asap", Helvetica, Arial, Lucida, sans-serif;
         order: 4;
       }


### PR DESCRIPTION
While I was working on #136, it was decided that I should undo the padding on the loading screen text, as the text padding is meant to be applied elsewhere. I thought I undid it before the PR got merged, but I didn't, so I'm doing it now.