### PR TITLE
Translate remaining messages in index.html

### DIFF
--- a/blocks/condition.js
+++ b/blocks/condition.js
@@ -86,7 +86,7 @@ export function defineConditionBlocks() {
 			// IF0 row
 			const if0Input = this.appendValueInput('IF0').setCheck('Boolean').appendField('if');
 			this.appendDummyInput('ICONS_IF0')
-			  .setAlign(Blockly.ALIGN_RIGHT)
+                    .setAlign(Blockly.inputs.Align.RIGHT)
 			  .appendField(this.makePlusIcon_(() => this.addElseIfAt(0)));
 			this.appendStatementInput('DO0').appendField(new Blockly.FieldLabel(''));
 
@@ -94,7 +94,7 @@ export function defineConditionBlocks() {
 			for (let i = 1; i <= this.elseifCount_; i++) {
 			  const input = this.appendValueInput('IF' + i).setCheck('Boolean').appendField('else if');
 			  this.appendDummyInput('ICONS_' + i)
-				.setAlign(Blockly.ALIGN_RIGHT)
+                          .setAlign(Blockly.inputs.Align.RIGHT)
 				.appendField(this.makePlusIcon_(() => this.addElseIfAt(i)))
 				.appendField(this.makeMinusIcon_(() => this.removeElseIf_(i)));
 			  this.appendStatementInput('DO' + i).appendField(new Blockly.FieldLabel(''));
@@ -112,7 +112,7 @@ export function defineConditionBlocks() {
 			}
 
 			const bottom = this.appendDummyInput('BOTTOM_ADD');
-			bottom.setAlign(Blockly.ALIGN_RIGHT)
+                   bottom.setAlign(Blockly.inputs.Align.RIGHT)
 			  .appendField(this.makePlusIcon_(() => this.addElseOrElseIf()));
 
 			this.restoreConnections_(savedConnections);

--- a/index.html
+++ b/index.html
@@ -200,13 +200,13 @@
         <img src="images/flock-bird-mascot.svg" alt="Flock XR Bird mascot" class="loading-bird" width="120" height="120" />
         <img src="images/inline-flock-xr.svg" alt="Flock XR Logo" class="loading-logo"/>
         <div class="loading-spinner" role="img" aria-label="Loading animation"></div>
-        <h1 id="loading-title" class="sr-only">Loading Flock XR</h1>
+        <h1 id="loading-title" class="sr-only" data-i18n="loading_title">Loading Flock XR</h1>
         <p id="loading-description" data-i18n="loading" class="loading-text" aria-live="polite">Loading Flock XR...</p>
       </div>
     </div>
 
     <h1 class="sr-only">FlockXR</h1>
-    <label for="importFile" class="sr-only">Import project file</label>
+    <label for="importFile" class="sr-only" data-i18n="import_project_file">Import project file</label>
     <input
       type="file"
       id="importFile"
@@ -229,8 +229,10 @@
                   aria-label="Main menu"
                   aria-expanded="false"
                   aria-haspopup="true"
+                  data-i18n="main_menu"
+                  data-i18n-attrs="title,aria-label"
               >
-                  <span class="sr-only">Menu</span>
+                  <span class="sr-only" data-i18n="menu_button_sr_label">Menu</span>
                   <div class="icon" style="width: 1.25em; height: 1.25em" aria-hidden="true">
                       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" fill="#511D91">
                           <path fill="#511D91" d="M0 96C0 78.3 14.3 64 32 64h384c17.7 0 32 14.3 32 32s-14.3 32-32 32H32C14.3 128 0 113.7 0 96zm0 160c0-17.7 14.3-32 32-32h384c17.7 0 32 14.3 32 32s-14.3 32-32 32H32c-17.7 0-32-14.3-32-32zm448 160c0 17.7-14.3 32-32 32H32c-17.7 0-32-14.3-32-32s14.3-32 32-32h384c17.7 0 32-14.3 32 32z"/>
@@ -790,7 +792,7 @@
             aria-label="Open a project from a file on your computer"
             tabindex="0"
           >
-            <label for="fileInput" class="sr-only">Select project file to open</label>
+            <label for="fileInput" class="sr-only" data-i18n="open_file_input_label">Select project file to open</label>
             <input type="file" id="fileInput" style="display: none" disabled />
             <div class="icon" style="width: 1.25em; height: 1.25em" aria-hidden="true">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--!Font Awesome Free v6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.--><path fill="#511D91" d="M288 109.3L288 352c0 17.7-14.3 32-32 32s-32-14.3-32-32l0-242.7-73.4 73.4c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3l128-128c12.5-12.5 32.8-12.5 45.3 0l128 128c12.5 12.5 12.5 32.8 0 45.3s-32.8 12.5-45.3 0L288 109.3zM64 352l128 0c0 35.3 28.7 64 64 64s64-28.7 64-64l128 0c35.3 0 64 28.7 64 64l0 32c0 35.3-28.7 64-64 64L64 512c-35.3 0-64-28.7-64-64l0-32c0-35.3 28.7-64 64-64zM432 456a24 24 0 1 0 0-48 24 24 0 1 0 0 48z"/></svg>

--- a/locale/de.js
+++ b/locale/de.js
@@ -762,6 +762,8 @@ export default {
 
   loading_ui: "Flock XR wird geladen...",
   loading_success_ui: "Flock XR erfolgreich geladen",
+  loading_title_ui: "Flock XR wird geladen",
+  import_project_file_ui: "Projektdatei importieren",
 
   demo_ui: "Demo",
   new_ui: "Neu",
@@ -790,6 +792,7 @@ export default {
   microbit_monkey_ui: "🐵 micro:bit-Affe",
 
   main_menu_ui: "Hauptmenü",
+  menu_button_sr_label_ui: "Menü",
   project_submenu_ui: "Projekt",
   project_new_ui: "Neu",
   project_open_ui: "Öffnen",
@@ -804,6 +807,7 @@ export default {
   run_code_button_ui: "Code ausführen",
   stop_code_button_ui: "Code stoppen",
   open_button_ui: "Projekt von Datei öffnen",
+  open_file_input_label_ui: "Projektdatei zum Öffnen auswählen",
   export_code_button_ui: "Projekt speichern",
   example_select_ui: "Beispielprojekt auswählen",
   toggle_design_ui: "Projekt designen",

--- a/locale/en.js
+++ b/locale/en.js
@@ -758,6 +758,8 @@ export default {
   // HTML translations
   loading_ui: "Loading Flock XR...",
   loading_success_ui: "Flock XR loaded successfully",
+  loading_title_ui: "Loading Flock XR",
+  import_project_file_ui: "Import project file",
 
   demo_ui: "Demo",
   new_ui: "New",
@@ -786,6 +788,7 @@ export default {
   microbit_monkey_ui: "🐵 micro:bit monkey",
   
   main_menu_ui: "Main menu",
+  menu_button_sr_label_ui: "Menu",
   project_submenu_ui: "Project",
   project_new_ui: "New",
   project_open_ui: "Open",
@@ -802,6 +805,7 @@ export default {
   run_code_button_ui: "Run your code",
   stop_code_button_ui: "Stop your code",
   open_button_ui: "Open a project from a file on your computer",
+  open_file_input_label_ui: "Select project file to open",
   export_code_button_ui: "Save this project to a file on your computer.",
   example_select_ui: "Choose an example project to load",
 

--- a/locale/es.js
+++ b/locale/es.js
@@ -753,6 +753,8 @@ export default {
   // HTML translations
   loading_ui: "Cargando Flock XR...",
   loading_success_ui: "Flock XR se cargó correctamente",
+  loading_title_ui: "Cargando Flock XR",
+  import_project_file_ui: "Importar archivo de proyecto",
 
   demo_ui: "Demostración",
   new_ui: "Nuevo",
@@ -781,6 +783,7 @@ export default {
   sit_down_ui: "🪑 Siéntate",
 
   main_menu_ui: "Abrir menú para más opciones",
+  menu_button_sr_label_ui: "Menú",
   project_submenu_ui: "Proyecto",
   project_new_ui: "Nuevo",
   project_open_ui: "Abrir",
@@ -796,6 +799,7 @@ export default {
   run_code_button_ui: "Ejecutar tu código",
   stop_code_button_ui: "Detener tu código",
   open_button_ui: "Abrir un proyecto desde un archivo en tu computadora",
+  open_file_input_label_ui: "Selecciona el archivo de proyecto para abrir",
   export_code_button_ui: "Guardar este proyecto en un archivo en tu computadora.",
   example_select_ui: "Elige un proyecto de ejemplo para cargar",
 

--- a/locale/fr.js
+++ b/locale/fr.js
@@ -753,6 +753,8 @@ export default {
                                       // HTML translations
                                       loading_ui: "Chargement de Flock XR...",
                                       loading_success_ui: "Flock XR chargé avec succès",
+                                      loading_title_ui: "Chargement de Flock XR",
+                                      import_project_file_ui: "Importer un fichier de projet",
 
                                       demo_ui: "Démo",
                                       new_ui: "Nouveau",
@@ -782,6 +784,7 @@ export default {
                                       sit_down_ui: "🪑 Assieds-toi",
 
                                       main_menu_ui: "Ouvrir le menu pour plus d'options",
+                                      menu_button_sr_label_ui: "Menu",
                                       project_submenu_ui: "Projet",
                                       project_new_ui: "Nouveau",
                                       project_open_ui: "Ouvrir",
@@ -797,6 +800,7 @@ export default {
                                       run_code_button_ui: "Exécuter votre code",
                                       stop_code_button_ui: "Arrêter votre code",
                                       open_button_ui: "Ouvrir un projet depuis un fichier sur votre ordinateur",
+                                      open_file_input_label_ui: "Sélectionnez le fichier projet à ouvrir",
                                       export_code_button_ui: "Enregistrer ce projet dans un fichier sur votre ordinateur.",
                                       example_select_ui: "Choisir un projet exemple à charger",
 

--- a/locale/it.js
+++ b/locale/it.js
@@ -878,6 +878,8 @@ export default {
   // HTML translations
   loading_ui: "Caricamento di Flock XR...",
   loading_success_ui: "Flock XR caricato con successo",
+  loading_title_ui: "Caricamento di Flock XR",
+  import_project_file_ui: "Importa file di progetto",
 
   demo_ui: "Demo",
   new_ui: "Nuovo",
@@ -906,6 +908,7 @@ export default {
   microbit_monkey_ui: "🐵 micro:bit scimmia",
 
   main_menu_ui: "Menu principale",
+  menu_button_sr_label_ui: "Menu",
   project_submenu_ui: "Progetto",
   project_new_ui: "Nuovo",
   project_open_ui: "Apri",
@@ -922,6 +925,7 @@ export default {
   run_code_button_ui: "Esegui il tuo codice",
   stop_code_button_ui: "Ferma il tuo codice",
   open_button_ui: "Apri un progetto da un file sul tuo computer",
+  open_file_input_label_ui: "Seleziona il file di progetto da aprire",
   export_code_button_ui: "Salva questo progetto in un file sul tuo computer.",
   example_select_ui: "Scegli un progetto di esempio da caricare",
 

--- a/locale/pl.js
+++ b/locale/pl.js
@@ -760,6 +760,8 @@ export default {
   // HTML translations
   loading_ui: "Ładowanie Flock XR…",
   loading_success_ui: "Flock XR został pomyślnie załadowany",
+  loading_title_ui: "Ładowanie Flock XR",
+  import_project_file_ui: "Importuj plik projektu",
 
   demo_ui: "Demo",
   new_ui: "Nowy",
@@ -788,6 +790,7 @@ export default {
   sit_down_ui: "🪑 Usiądź",
 
   main_menu_ui: "Menu główne",
+  menu_button_sr_label_ui: "Menu",
   project_submenu_ui: "Projekt",
   project_new_ui: "Nowy",
   project_open_ui: "Otwórz",
@@ -803,6 +806,7 @@ export default {
   run_code_button_ui: "Uruchom kod",
   stop_code_button_ui: "Zatrzymaj kod",
   open_button_ui: "Otwórz projekt z pliku na komputerze",
+  open_file_input_label_ui: "Wybierz plik projektu do otwarcia",
   export_code_button_ui: "Zapisz projekt do pliku na komputerze",
   example_select_ui: "Wybierz przykład do załadowania",
 

--- a/locale/pt.js
+++ b/locale/pt.js
@@ -873,6 +873,8 @@ export default {
   // HTML translations
   loading_ui: "A carregar o Flock XR...",
   loading_success_ui: "Flock XR carregado com sucesso",
+  loading_title_ui: "Carregando o Flock XR",
+  import_project_file_ui: "Importar arquivo de projeto",
 
   demo_ui: "Demonstração",
   new_ui: "Novo",
@@ -901,6 +903,7 @@ export default {
   sit_down_ui: "🪑 Senta-te",
 
   main_menu_ui: "Menu Principal",
+  menu_button_sr_label_ui: "Menu",
   project_submenu_ui: "Projeto",
   project_new_ui: "Novo",
   project_open_ui: "Abrir",
@@ -916,6 +919,7 @@ export default {
   run_code_button_ui: "Executar o teu código",
   stop_code_button_ui: "Parar o teu código",
   open_button_ui: "Abrir um projeto a partir de um ficheiro no teu computador",
+  open_file_input_label_ui: "Selecione o arquivo de projeto para abrir",
   export_code_button_ui: "Guardar este projeto num ficheiro no teu computador.",
   example_select_ui: "Escolher um projeto de exemplo para carregar",
 

--- a/locale/sv.js
+++ b/locale/sv.js
@@ -875,6 +875,8 @@ export default {
       // HTML translations
       loading_ui: "Laddar Flock XR...",
       loading_success_ui: "Flock XR laddades framgångsrikt",
+      loading_title_ui: "Laddar Flock XR",
+      import_project_file_ui: "Importera projektfil",
 
       demo_ui: "Demo",
       new_ui: "Ny",
@@ -903,6 +905,7 @@ export default {
       sit_down_ui: "🪑 Sätt dig",
 
       main_menu_ui: "Huvudmeny",
+      menu_button_sr_label_ui: "Meny",
       project_submenu_ui: "Projekt",
       project_new_ui: "Nytt",
       project_open_ui: "Öppna",
@@ -918,6 +921,7 @@ export default {
       run_code_button_ui: "Kör din kod",
       stop_code_button_ui: "Stoppa din kod",
       open_button_ui: "Öppna ett projekt från en fil på din dator",
+      open_file_input_label_ui: "Välj projektfil att öppna",
       export_code_button_ui: "Spara detta projekt till en fil på din dator.",
       example_select_ui: "Välj ett exempelprojekt att ladda",
 

--- a/main/blocklyinit.js
+++ b/main/blocklyinit.js
@@ -914,10 +914,7 @@ export function createBlocklyWorkspace() {
                         if (!data) return;
 
                         // Selected block (if any, and not from flyout)
-                        const selected =
-                                Blockly.common?.getSelected?.() ||
-                                Blockly.selected ||
-                                null;
+                        const selected = Blockly.common?.getSelected?.() || null;
                         if (selected && selected.isInFlyout) return; // never paste in the flyout
 
                         e.preventDefault();

--- a/main/translation.js
+++ b/main/translation.js
@@ -54,7 +54,7 @@ async function loadSavedLanguage() {
 async function applySavedLanguageTranslations() {
   if (currentLanguage === "fr") {
     // Apply Blockly's French translations
-    const frMessages = fr.default || fr;
+    const frMessages = fr;
     Object.keys(frMessages).forEach((key) => {
       if (typeof frMessages[key] === "string") {
         Blockly.Msg[key] = frMessages[key];
@@ -62,7 +62,7 @@ async function applySavedLanguageTranslations() {
     });
   } else if (currentLanguage === "es") {
     // Apply Blockly's Spanish translations
-    const esMessages = es.default || es;
+    const esMessages = es;
     Object.keys(esMessages).forEach((key) => {
       if (typeof esMessages[key] === "string") {
         Blockly.Msg[key] = esMessages[key];
@@ -70,7 +70,7 @@ async function applySavedLanguageTranslations() {
     });
   } else if (currentLanguage === "it") {
     // Apply Blockly's Italian translations
-    const itMessages = it.default || it;
+    const itMessages = it;
     Object.keys(itMessages).forEach((key) => {
       if (typeof itMessages[key] === "string") {
         Blockly.Msg[key] = itMessages[key];
@@ -78,7 +78,7 @@ async function applySavedLanguageTranslations() {
     });
   } else if (currentLanguage === "sv") {
     // Apply Blockly's Swedish translations
-    const svMessages = sv.default || sv;
+    const svMessages = sv;
     Object.keys(svMessages).forEach((key) => {
       if (typeof svMessages[key] === "string") {
         Blockly.Msg[key] = svMessages[key];
@@ -86,7 +86,7 @@ async function applySavedLanguageTranslations() {
     });
   } else if (currentLanguage === "pt") {
     // Apply Blockly's Portuguese translations
-    const ptMessages = pt.default || pt;
+    const ptMessages = pt;
     Object.keys(ptMessages).forEach((key) => {
       if (typeof ptMessages[key] === "string") {
         Blockly.Msg[key] = ptMessages[key];
@@ -94,7 +94,7 @@ async function applySavedLanguageTranslations() {
     });
   } else if (currentLanguage === "pl") {
     // Apply Blockly's Polish translations
-    const plMessages = pl.default || pl;
+    const plMessages = pl;
     Object.keys(plMessages).forEach((key) => {
       if (typeof plMessages[key] === "string") {
         Blockly.Msg[key] = plMessages[key];
@@ -102,7 +102,7 @@ async function applySavedLanguageTranslations() {
     });
   } else if (currentLanguage === "de") {
     // Apply Blockly's German translations
-    const deMessages = de.default || de;
+    const deMessages = de;
     Object.keys(deMessages).forEach((key) => {
       if (typeof deMessages[key] === "string") {
         Blockly.Msg[key] = deMessages[key];
@@ -337,6 +337,15 @@ export function getOption(key) {
 export function applyTranslations() {
   document.querySelectorAll("[data-i18n]").forEach((el) => {
     const key = el.dataset.i18n + "_ui";
+    const translation = translate(key) || key;
+
+    if (el.dataset.i18nAttrs) {
+      el.dataset.i18nAttrs
+        .split(",")
+        .map((attr) => attr.trim())
+        .filter(Boolean)
+        .forEach((attr) => el.setAttribute(attr, translation));
+    }
 
     let contents = "";
     for (const element of el.childNodes) {
@@ -346,11 +355,17 @@ export function applyTranslations() {
     }
     contents = contents.trim();
     if (contents != "") {
-      el.innerHTML = translate(key) || key;
-    } else if (el.hasAttribute("title")) {
-      el.title = translate(key) || key;
-    } else if (el.hasAttribute("placeholder")) {
-      el.setAttribute("placeholder", translate(key) || key);
+      el.innerHTML = translation;
+    } else {
+      if (el.hasAttribute("title")) {
+        el.title = translation;
+      }
+      if (el.hasAttribute("aria-label")) {
+        el.setAttribute("aria-label", translation);
+      }
+      if (el.hasAttribute("placeholder")) {
+        el.setAttribute("placeholder", translation);
+      }
     }
   });
 }


### PR DESCRIPTION
## Summary
- add missing messages for translation in index.html
- remove default export fallbacks when loading Blockly locale modules to match actual exports
- update block alignment constants and selection lookup to use supported Blockly APIs

## Testing
- npm run build -- --clearScreen false

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691eed6bd0a08326a49a55b2e14246d3)