### PR TITLE
Localize untranslated user-facing messages

### DIFF
--- a/flock.js
+++ b/flock.js
@@ -66,6 +66,7 @@ import {
 import { flockScene, setFlockReference as setFlockScene } from "./api/scene";
 import { flockMesh, setFlockReference as setFlockMesh } from "./api/mesh";
 import { flockCamera, setFlockReference as setFlockCamera } from "./api/camera";
+import { translate } from "./main/translation.js";
 // Helper functions to make flock.BABYLON js easier to use in Flock
 console.log("Flock helpers loading");
 
@@ -195,7 +196,7 @@ export const flock = {
 
                 if (meshCount >= max) {
                         flock.printText?.({
-                                text: `⚠️ Limit reached: You can only have ${max} meshes in your world.`,
+                                text: translate("max_mesh_limit_reached").replace("{max}", max),
                                 duration: 30,
                                 color: "#ff0000",
                         });
@@ -232,7 +233,10 @@ export const flock = {
                         );
                         // Show user warning in your UI
                         this.printText({
-                                text: `Warning: High memory usage (${usagePercent.toFixed(1)}%)`,
+                                text: translate("high_memory_usage_warning").replace(
+                                        "{percent}",
+                                        usagePercent.toFixed(1),
+                                ),
                                 duration: 3,
                                 color: "#ff9900",
                         });
@@ -773,7 +777,10 @@ export const flock = {
                         console.error("Enhanced error details:", enhancedError);
 
                         this.printText?.({
-                                text: `Error: ${error.message}`,
+                                text: translate("runtime_error_message").replace(
+                                        "{message}",
+                                        error.message,
+                                ),
                                 duration: 5,
                                 color: "#ff0000",
                         });
@@ -2450,7 +2457,7 @@ export const flock = {
         async setXRMode(mode) {
                 await flock.initializeXR(mode);
                 flock.printText({
-                        text: "XR Mode!",
+                        text: translate("xr_mode_message"),
                         duration: 5,
                         color: "white",
                 });

--- a/locale/de.js
+++ b/locale/de.js
@@ -863,6 +863,25 @@ export default {
   invalid_project_alert: "Diese Datei ist kein gültiges Flock XR-Projekt.",
   failed_to_read_file_alert: "Datei konnte nicht gelesen werden.",
 
+  // UI status messages
+  max_mesh_limit_reached:
+    "⚠️ Limit erreicht: Du kannst nur {max} Meshes in deiner Welt haben.",
+  high_memory_usage_warning: "Warnung: Hoher Speicherverbrauch ({percent}%)",
+  runtime_error_message: "Fehler: {message}",
+  xr_mode_message: "XR-Modus!",
+  fly_camera_instructions:
+    "ℹ️ Flugkamera, nutze Pfeiltasten und Bild auf/ab",
+  select_mesh_delete_prompt:
+    "⚠️ Wähle ein Mesh aus und klicke dann auf Löschen.",
+  select_mesh_duplicate_prompt:
+    "⚠️ Wähle ein Mesh aus, klicke auf Duplizieren und klicke dann, um Kopien zu platzieren.",
+  position_readout: "Position: {position}",
+  eyedropper_not_supported_alert:
+    "Das Pipettenwerkzeug wird in diesem Browser nicht unterstützt. Versuche es mit Chrome oder Edge.",
+  blocks_copied_alert: "Blöcke in den lokalen Speicher kopiert!",
+  no_blocks_to_copy_alert: "Keine Blöcke zum Kopieren verfügbar.",
+  copy_blocks_failed_alert: "Kopieren der Blöcke fehlgeschlagen.",
+
   export_JSON_snippet: "Block als Snippet exportieren",
   import_snippet: "Snippet importieren",
   export_PNG_snippet: "Als PNG exportieren",

--- a/locale/en.js
+++ b/locale/en.js
@@ -880,6 +880,23 @@ export default {
   invalid_project_alert: "This file isn't a valid Flock XR project.",
   failed_to_read_file_alert: "Failed to read file.",
 
+  // UI status messages
+  max_mesh_limit_reached:
+    "⚠️ Limit reached: You can only have {max} meshes in your world.",
+  high_memory_usage_warning: "Warning: High memory usage ({percent}%)",
+  runtime_error_message: "Error: {message}",
+  xr_mode_message: "XR Mode!",
+  fly_camera_instructions: "ℹ️ Fly camera, use arrow keys and page up/down",
+  select_mesh_delete_prompt: "⚠️ Select a mesh then click delete.",
+  select_mesh_duplicate_prompt:
+    "⚠️ Select a mesh then click duplicate, then click to place copies.",
+  position_readout: "Position: {position}",
+  eyedropper_not_supported_alert:
+    "Color picker tool is not supported in this browser. Try using Chrome or Edge.",
+  blocks_copied_alert: "Blocks copied to local storage!",
+  no_blocks_to_copy_alert: "No blocks available to copy.",
+  copy_blocks_failed_alert: "Failed to copy blocks.",
+
   // Context menu option translations
   export_JSON_snippet: "Export block as snippet",
   import_snippet: "Import snippet",

--- a/locale/es.js
+++ b/locale/es.js
@@ -875,6 +875,25 @@ export default {
   invalid_project_alert: "Este archivo no es un proyecto válido de Flock XR.",
   failed_to_read_file_alert: "No se pudo leer el archivo.",
 
+  // UI status messages
+  max_mesh_limit_reached:
+    "⚠️ Límite alcanzado: solo puedes tener {max} mallas en tu mundo.",
+  high_memory_usage_warning: "Advertencia: uso de memoria alto ({percent}%)",
+  runtime_error_message: "Error: {message}",
+  xr_mode_message: "¡Modo XR!",
+  fly_camera_instructions:
+    "ℹ️ Cámara en vuelo, usa las flechas y Page Up/Down",
+  select_mesh_delete_prompt:
+    "⚠️ Selecciona una malla y luego haz clic en eliminar.",
+  select_mesh_duplicate_prompt:
+    "⚠️ Selecciona una malla y haz clic en duplicar, luego haz clic para colocar las copias.",
+  position_readout: "Posición: {position}",
+  eyedropper_not_supported_alert:
+    "La herramienta cuentagotas no es compatible con este navegador. Prueba con Chrome o Edge.",
+  blocks_copied_alert: "¡Bloques copiados al almacenamiento local!",
+  no_blocks_to_copy_alert: "No hay bloques para copiar.",
+  copy_blocks_failed_alert: "No se pudieron copiar los bloques.",
+
   // Context menu option translations
   export_JSON_snippet: "Exportar bloque como fragmento JSON",
   import_snippet: "Importar fragmento",

--- a/locale/fr.js
+++ b/locale/fr.js
@@ -874,6 +874,26 @@ export default {
                                       invalid_project_alert: "Ce fichier n'est pas un projet Flock XR valide.",
                                       failed_to_read_file_alert: "Échec de lecture du fichier.",
 
+                                      // UI status messages
+                                      max_mesh_limit_reached:
+                                        "⚠️ Limite atteinte : vous pouvez avoir seulement {max} maillages dans votre monde.",
+                                      high_memory_usage_warning:
+                                        "Avertissement : utilisation mémoire élevée ({percent}%)",
+                                      runtime_error_message: "Erreur : {message}",
+                                      xr_mode_message: "Mode XR !",
+                                      fly_camera_instructions:
+                                        "ℹ️ Caméra en vol, utilisez les flèches et Page haut/bas",
+                                      select_mesh_delete_prompt:
+                                        "⚠️ Sélectionnez un maillage puis cliquez sur supprimer.",
+                                      select_mesh_duplicate_prompt:
+                                        "⚠️ Sélectionnez un maillage puis cliquez sur dupliquer, puis cliquez pour placer les copies.",
+                                      position_readout: "Position : {position}",
+                                      eyedropper_not_supported_alert:
+                                        "L'outil pipette n'est pas pris en charge dans ce navigateur. Essayez d'utiliser Chrome ou Edge.",
+                                      blocks_copied_alert: "Blocs copiés dans le stockage local !",
+                                      no_blocks_to_copy_alert: "Aucun bloc à copier.",
+                                      copy_blocks_failed_alert: "Échec de la copie des blocs.",
+
                                       // Context menu option translations
                                       export_JSON_snippet: "Exporter le bloc comme extrait JSON",
                                       import_snippet: "Importer un extrait",

--- a/locale/it.js
+++ b/locale/it.js
@@ -1002,6 +1002,25 @@ export default {
   invalid_project_alert: "Questo file non è un progetto Flock XR valido.",
   failed_to_read_file_alert: "Impossibile leggere il file.",
 
+  // UI status messages
+  max_mesh_limit_reached:
+    "⚠️ Limite raggiunto: puoi avere solo {max} mesh nel tuo mondo.",
+  high_memory_usage_warning: "Avviso: uso di memoria elevato ({percent}%)",
+  runtime_error_message: "Errore: {message}",
+  xr_mode_message: "Modalità XR!",
+  fly_camera_instructions:
+    "ℹ️ Telecamera volante, usa le frecce e Pag su/giù",
+  select_mesh_delete_prompt:
+    "⚠️ Seleziona una mesh e poi fai clic su elimina.",
+  select_mesh_duplicate_prompt:
+    "⚠️ Seleziona una mesh, fai clic su duplica e poi fai clic per posizionare le copie.",
+  position_readout: "Posizione: {position}",
+  eyedropper_not_supported_alert:
+    "Lo strumento contagocce non è supportato in questo browser. Prova a usare Chrome o Edge.",
+  blocks_copied_alert: "Blocchi copiati nella memoria locale!",
+  no_blocks_to_copy_alert: "Nessun blocco disponibile da copiare.",
+  copy_blocks_failed_alert: "Copia dei blocchi non riuscita.",
+
   // Context menu option translations
   export_JSON_snippet: "Esporta blocco come frammento JSON",
   import_snippet: "Importa frammento",

--- a/locale/pl.js
+++ b/locale/pl.js
@@ -882,6 +882,25 @@ export default {
   invalid_project_alert: "Ten plik nie jest prawidłowym projektem Flock XR.",
   failed_to_read_file_alert: "Nie udało się odczytać pliku.",
 
+  // UI status messages
+  max_mesh_limit_reached:
+    "⚠️ Osiągnięto limit: możesz mieć tylko {max} siatek w swoim świecie.",
+  high_memory_usage_warning: "Ostrzeżenie: wysokie użycie pamięci ({percent}%)",
+  runtime_error_message: "Błąd: {message}",
+  xr_mode_message: "Tryb XR!",
+  fly_camera_instructions:
+    "ℹ️ Kamera lotu, użyj klawiszy strzałek i Page Up/Down",
+  select_mesh_delete_prompt:
+    "⚠️ Wybierz siatkę, a następnie kliknij usuń.",
+  select_mesh_duplicate_prompt:
+    "⚠️ Wybierz siatkę, kliknij duplikuj, a potem kliknij, aby umieścić kopie.",
+  position_readout: "Pozycja: {position}",
+  eyedropper_not_supported_alert:
+    "Narzędzie próbnika kolorów nie jest obsługiwane w tej przeglądarce. Spróbuj użyć Chrome lub Edge.",
+  blocks_copied_alert: "Bloki skopiowane do pamięci lokalnej!",
+  no_blocks_to_copy_alert: "Brak bloków do skopiowania.",
+  copy_blocks_failed_alert: "Nie udało się skopiować bloków.",
+
   // Context menu option translations
   export_JSON_snippet: "Eksportuj blok jako fragment JSON",
   import_snippet: "Importuj fragment",

--- a/locale/pt.js
+++ b/locale/pt.js
@@ -996,6 +996,25 @@ export default {
   invalid_project_alert: "Este arquivo não é um projeto Flock XR válido.",
   failed_to_read_file_alert: "Falha ao ler o arquivo.",
 
+  // UI status messages
+  max_mesh_limit_reached:
+    "⚠️ Limite alcançado: você só pode ter {max} malhas no seu mundo.",
+  high_memory_usage_warning: "Aviso: uso de memória alto ({percent}%)",
+  runtime_error_message: "Erro: {message}",
+  xr_mode_message: "Modo XR!",
+  fly_camera_instructions:
+    "ℹ️ Câmera de voo, use as setas e Page Up/Down",
+  select_mesh_delete_prompt:
+    "⚠️ Selecione uma malha e clique em apagar.",
+  select_mesh_duplicate_prompt:
+    "⚠️ Selecione uma malha, clique em duplicar e depois clique para posicionar as cópias.",
+  position_readout: "Posição: {position}",
+  eyedropper_not_supported_alert:
+    "A ferramenta conta-gotas não é suportada neste navegador. Tente usar o Chrome ou Edge.",
+  blocks_copied_alert: "Blocos copiados para o armazenamento local!",
+  no_blocks_to_copy_alert: "Nenhum bloco disponível para copiar.",
+  copy_blocks_failed_alert: "Falha ao copiar os blocos.",
+
   // Context menu option translations
   export_JSON_snippet: "Exportar bloco como excerto JSON",
   import_snippet: "Importar excerto",

--- a/locale/sv.js
+++ b/locale/sv.js
@@ -999,6 +999,25 @@ export default {
       invalid_project_alert: "Den här filen är inte ett giltigt Flock XR-projekt.",
       failed_to_read_file_alert: "Det gick inte att läsa filen.",
 
+      // UI status messages
+      max_mesh_limit_reached:
+        "⚠️ Gräns nådd: du kan bara ha {max} mesh i din värld.",
+      high_memory_usage_warning: "Varning: hög minnesanvändning ({percent}%)",
+      runtime_error_message: "Fel: {message}",
+      xr_mode_message: "XR-läge!",
+      fly_camera_instructions:
+        "ℹ️ Flygkamera, använd piltangenterna och Page Up/Down",
+      select_mesh_delete_prompt:
+        "⚠️ Välj ett mesh och klicka sedan på ta bort.",
+      select_mesh_duplicate_prompt:
+        "⚠️ Välj ett mesh och klicka på duplicera, klicka sedan för att placera kopior.",
+      position_readout: "Position: {position}",
+      eyedropper_not_supported_alert:
+        "Färgväljaren stöds inte i den här webbläsaren. Prova Chrome eller Edge.",
+      blocks_copied_alert: "Block kopierade till lokal lagring!",
+      no_blocks_to_copy_alert: "Inga block att kopiera.",
+      copy_blocks_failed_alert: "Det gick inte att kopiera blocken.",
+
       // Context menu option translations
       export_JSON_snippet: "Exportera block som JSON-utdrag",
       import_snippet: "Importera utdrag",

--- a/tutorial.js
+++ b/tutorial.js
@@ -5,6 +5,7 @@ import { defineBlocks, CustomZelosRenderer } from "./blocks.js";
 import { defineBaseBlocks } from "./blocks/base";
 import { defineShapeBlocks } from "./blocks/shapes";
 import { registerFieldColour } from "@blockly/field-colour";
+import { translate } from "./main/translation.js";
 
 defineBaseBlocks();
 defineBlocks();
@@ -64,17 +65,17 @@ crossTabCopyPaste.init({ contextMenu: true, shortcut: true });
 
 document.getElementById('copyButton').addEventListener('click', () => {
   try {
-	const topBlock = workspace.getTopBlocks(false)[0]; // Get the first top-level block
-	if (topBlock) {
-	  // Use the plugin's storage mechanism to copy the block
-	  localStorage.setItem('blocklyStash', JSON.stringify(topBlock.toCopyData()));
-	  alert('Blocks copied to local storage!');
-	} else {
-	  alert('No blocks available to copy.');
-	}
+        const topBlock = workspace.getTopBlocks(false)[0]; // Get the first top-level block
+        if (topBlock) {
+          // Use the plugin's storage mechanism to copy the block
+          localStorage.setItem('blocklyStash', JSON.stringify(topBlock.toCopyData()));
+          alert(translate("blocks_copied_alert"));
+        } else {
+          alert(translate("no_blocks_to_copy_alert"));
+        }
   } catch (err) {
-	console.error('Error copying blocks:', err);
-	alert('Failed to copy blocks.');
+        console.error('Error copying blocks:', err);
+        alert(translate("copy_blocks_failed_alert"));
   }
 });
 let blocklyJson = {

--- a/ui/colourpicker-compact.js
+++ b/ui/colourpicker-compact.js
@@ -1099,7 +1099,7 @@ class CustomColorPicker {
   async startEyedropper() {
     if (!window.EyeDropper) {
       alert(
-        "Color picker tool is not supported in this browser. Try using Chrome or Edge.",
+        translate("eyedropper_not_supported_alert"),
       );
       return;
     }

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -1,6 +1,7 @@
 import * as Blockly from "blockly";
 import { meshMap, meshBlockIdMap } from "../generators";
 import { flock } from "../flock.js";
+import { translate } from "../main/translation.js";
 import { setPositionValues } from "./addmeshes.js";
 import {
   getMeshFromBlockKey,
@@ -622,7 +623,7 @@ export function toggleGizmo(gizmoType) {
       if (cameraMode === "play") {
         cameraMode = "fly";
         flock.printText({
-          text: "ℹ️ Fly camera, use arrow keys and page up/down",
+          text: translate("fly_camera_instructions"),
           duration: 15,
           color: "white",
         });
@@ -638,7 +639,7 @@ export function toggleGizmo(gizmoType) {
     case "delete":
       if (!gizmoManager.attachedMesh) {
         flock.printText({
-          text: "⚠️ Select a mesh then click delete.",
+          text: translate("select_mesh_delete_prompt"),
           duration: 30,
           color: "black",
         });
@@ -653,7 +654,7 @@ export function toggleGizmo(gizmoType) {
     case "duplicate":
       if (!gizmoManager.attachedMesh) {
         flock.printText({
-          text: "⚠️ Select a mesh then click duplicate, then click to place copies.",
+          text: translate("select_mesh_duplicate_prompt"),
           duration: 30,
           color: "black",
         });
@@ -780,7 +781,10 @@ export function toggleGizmo(gizmoType) {
               parseFloat(position.z.toFixed(2)),
             );
             flock.printText({
-              text: "Position: " + roundedPosition,
+              text: translate("position_readout").replace(
+                "{position}",
+                String(roundedPosition),
+              ),
               duration: 30,
               color: "black",
             });
@@ -813,7 +817,10 @@ export function toggleGizmo(gizmoType) {
                 parseFloat(position.z.toFixed(2)),
               );
               flock.printText({
-                text: "Position: " + roundedPosition,
+                text: translate("position_readout").replace(
+                  "{position}",
+                  String(roundedPosition),
+                ),
                 duration: 30,
                 color: "black",
               });


### PR DESCRIPTION
## Summary
- route remaining user-facing printText notices through translation helpers and add locale strings
- translate UI alerts in the color picker and tutorial copy workflow
- extend all locales with the new user-facing phrases and placeholders

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921bbe02cb883268d6d3b9fd45b279b)