### PR TITLE
Allow animation names to be replaced

### DIFF
--- a/blocks/animate.js
+++ b/blocks/animate.js
@@ -695,11 +695,11 @@ export function defineAnimateBlocks() {
 		},
 	};
 
-	Blockly.Blocks["stop_animations"] = {
-		init: function () {
-			this.jsonInit({
-				type: "stop_animations",
-				message0: translate("stop_animations"),
+        Blockly.Blocks["stop_animations"] = {
+                init: function () {
+                        this.jsonInit({
+                                type: "stop_animations",
+                                message0: translate("stop_animations"),
 				args0: [
 					{
 						type: "field_variable",
@@ -713,27 +713,47 @@ export function defineAnimateBlocks() {
 				colour: categoryColours["Animate"],
 				tooltip: getTooltip("stop_animations"),
 			});
-			this.setHelpUrl(getHelpUrlFor(this.type));
-			this.setStyle("animate_blocks");
-		},
-	};
+                        this.setHelpUrl(getHelpUrlFor(this.type));
+                        this.setStyle("animate_blocks");
+                },
+        };
 
-	Blockly.Blocks["switch_animation"] = {
-		init: function () {
-			this.jsonInit({
-				type: "switch_model_animation",
-				message0: translate("switch_animation"),
-				args0: [
-					{
-						type: "field_dropdown",
-						name: "ANIMATION_NAME",
-						options: animationNames(),
-					},
-					{
-						type: "field_variable",
-						name: "MODEL",
-						variable: window.currentMesh,
-					},		
+        Blockly.Blocks["animation_name"] = {
+                init: function () {
+                        this.jsonInit({
+                                type: "animation_name",
+                                message0: "%1",
+                                args0: [
+                                        {
+                                                type: "field_dropdown",
+                                                name: "ANIMATION_NAME",
+                                                options: animationNames(),
+                                        },
+                                ],
+                                output: "String",
+                                colour: categoryColours["Animate"],
+                                tooltip: getTooltip("play_animation"),
+                        });
+                        this.setStyle("animate_blocks");
+                },
+        };
+
+        Blockly.Blocks["switch_animation"] = {
+                init: function () {
+                        this.jsonInit({
+                                type: "switch_model_animation",
+                                message0: translate("switch_animation"),
+                                args0: [
+                                        {
+                                                type: "input_value",
+                                                name: "ANIMATION_NAME",
+                                                check: "String",
+                                        },
+                                        {
+                                                type: "field_variable",
+                                                name: "MODEL",
+                                                variable: window.currentMesh,
+                                        },
 				],
 				previousStatement: null,
 				nextStatement: null,
@@ -745,22 +765,22 @@ export function defineAnimateBlocks() {
 		},
 	};
 
-	Blockly.Blocks["play_animation"] = {
-		init: function () {
-			this.jsonInit({
-				type: "play_model_animation_once",
-				message0: translate("play_animation"),
-				args0: [
-					{
-						type: "field_dropdown",
-						name: "ANIMATION_NAME",
-						options: animationNames(),
-					},
-					{
-						type: "field_variable",
-						name: "MODEL",
-						variable: window.currentMesh,
-					},
+        Blockly.Blocks["play_animation"] = {
+                init: function () {
+                        this.jsonInit({
+                                type: "play_model_animation_once",
+                                message0: translate("play_animation"),
+                                args0: [
+                                        {
+                                                type: "input_value",
+                                                name: "ANIMATION_NAME",
+                                                check: "String",
+                                        },
+                                        {
+                                                type: "field_variable",
+                                                name: "MODEL",
+                                                variable: window.currentMesh,
+                                        },
 				],
 				previousStatement: null,
 				nextStatement: null,

--- a/generators.js
+++ b/generators.js
@@ -1901,13 +1901,23 @@ export function defineGenerators() {
                 return code;
         };
 
+        javascriptGenerator.forBlock["animation_name"] = function (block) {
+                const animationName = block.getFieldValue("ANIMATION_NAME");
+                return [`"${animationName}"`, javascriptGenerator.ORDER_ATOMIC];
+        };
+
         javascriptGenerator.forBlock["play_animation"] = function (block) {
                 var model = javascriptGenerator.nameDB_.getName(
                         block.getFieldValue("MODEL"),
                         Blockly.Names.NameType.VARIABLE,
                 );
-                var animationName = block.getFieldValue("ANIMATION_NAME");
-                var code = `await playAnimation(${model}, { animationName: "${animationName}" });\n`;
+                const animationName =
+                        javascriptGenerator.valueToCode(
+                                block,
+                                "ANIMATION_NAME",
+                                javascriptGenerator.ORDER_NONE,
+                        ) || '"Idle"';
+                var code = `await playAnimation(${model}, { animationName: ${animationName} });\n`;
                 return code;
         };
 
@@ -2338,8 +2348,13 @@ export function defineGenerators() {
                         block.getFieldValue("MODEL"),
                         Blockly.Names.NameType.VARIABLE,
                 );
-                var animationName = block.getFieldValue("ANIMATION_NAME");
-                var code = `switchAnimation(${model}, { animationName: "${animationName}" });\n`;
+                const animationName =
+                        javascriptGenerator.valueToCode(
+                                block,
+                                "ANIMATION_NAME",
+                                javascriptGenerator.ORDER_NONE,
+                        ) || '"Idle"';
+                var code = `switchAnimation(${model}, { animationName: ${animationName} });\n`;
                 return code;
         };
 

--- a/toolbox.js
+++ b/toolbox.js
@@ -1834,17 +1834,35 @@ const toolboxAnimate = {
         icon: "./images/animate.svg",
         //colour: categoryColours["Animate"],
         categorystyle: "animate_category",
-        contents: [
-                {
-                        kind: "block",
-                        type: "switch_animation",
-                        keyword: "switch",
-                },
-                {
-                        kind: "block",
-                        type: "play_animation",
-                        keyword: "play",
-                },
+                contents: [
+                        {
+                                kind: "block",
+                                type: "switch_animation",
+                                keyword: "switch",
+                                inputs: {
+                                        ANIMATION_NAME: {
+                                                shadow: {
+                                                        type: "animation_name",
+                                                },
+                                        },
+                                },
+                        },
+                        {
+                                kind: "block",
+                                type: "play_animation",
+                                keyword: "play",
+                                inputs: {
+                                        ANIMATION_NAME: {
+                                                shadow: {
+                                                        type: "animation_name",
+                                                },
+                                        },
+                                },
+                        },
+                        {
+                                kind: "block",
+                                type: "animation_name",
+                        },
                 {
                         kind: "block",
                         type: "glide_to_seconds",
@@ -4124,8 +4142,17 @@ const toolboxSnippets = {
                                                                                                         name: "player",
                                                                                                         type: "",
                                                                                                 },
-                                                                                                ANIMATION_NAME:
-                                                                                                        "Walk",
+                                                                                        },
+                                                                                        inputs: {
+                                                                                                ANIMATION_NAME: {
+                                                                                                        shadow: {
+                                                                                                                type: "animation_name",
+                                                                                                                fields: {
+                                                                                                                        ANIMATION_NAME:
+                                                                                                                                "Walk",
+                                                                                                                },
+                                                                                                        },
+                                                                                                },
                                                                                         },
                                                                                 },
                                                                         },
@@ -4166,8 +4193,17 @@ const toolboxSnippets = {
                                                                                                         name: "player",
                                                                                                         type: "",
                                                                                                 },
-                                                                                                ANIMATION_NAME:
-                                                                                                        "Walk",
+                                                                                        },
+                                                                                        inputs: {
+                                                                                                ANIMATION_NAME: {
+                                                                                                        shadow: {
+                                                                                                                type: "animation_name",
+                                                                                                                fields: {
+                                                                                                                        ANIMATION_NAME:
+                                                                                                                                "Walk",
+                                                                                                                },
+                                                                                                        },
+                                                                                                },
                                                                                         },
                                                                                 },
                                                                         },
@@ -4181,8 +4217,17 @@ const toolboxSnippets = {
                                                                                         name: "player",
                                                                                         type: "",
                                                                                 },
-                                                                                ANIMATION_NAME:
-                                                                                        "Idle",
+                                                                        },
+                                                                        inputs: {
+                                                                                ANIMATION_NAME: {
+                                                                                        shadow: {
+                                                                                                type: "animation_name",
+                                                                                                fields: {
+                                                                                                        ANIMATION_NAME:
+                                                                                                                "Idle",
+                                                                                                },
+                                                                                        },
+                                                                                },
                                                                         },
                                                                 },
                                                         },


### PR DESCRIPTION
## Summary
- Allow animations names to be replaced with a value block
- ensure the animation migration helper is scoped so validation can upgrade legacy play/switch animation blocks
- preserve existing workspace validation while keeping legacy animation names wrapped in the new shadow input

## Testing
- npm run lint
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69243115ebdc8326bdaeb9fcd80b7703)