### PR TITLE
Use resize block for scale gizmo

### DIFF
--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -1468,11 +1468,11 @@ export function toggleGizmo(gizmoType) {
                   (Math.round(value * 10) / 10).toFixed(1);
 
                 const width =
-                  boundingBox.maximum.x - boundingBox.minimum.x;
+                  boundingBox.maximumWorld.x - boundingBox.minimumWorld.x;
                 const height =
-                  boundingBox.maximum.y - boundingBox.minimum.y;
+                  boundingBox.maximumWorld.y - boundingBox.minimumWorld.y;
                 const depth =
-                  boundingBox.maximum.z - boundingBox.minimum.z;
+                  boundingBox.maximumWorld.z - boundingBox.minimumWorld.z;
 
                 setBlockValue(resizeBlock, "X", formatDimension(width));
                 setBlockValue(resizeBlock, "Y", formatDimension(height));


### PR DESCRIPTION
## Summary
- update the scale gizmo logic to create a resize block when scaling loaded models
- reuse any existing resize block tied to the model instead of creating a new scale block

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69247cd7c408832695134f57675198bc)