### PR TITLE
Switch scale gizmo to resize block with live updates

### DIFF
--- a/blocks.js
+++ b/blocks.js
@@ -259,8 +259,8 @@ export function findCreateBlock(block) {
   let parent = block;
 
   while (parent) {
-    if (parent.type === "scale" || parent.type === "rotate_to") {
-      // Don't update parent if we're modifying a nested scale or rotate
+    if (["scale", "rotate_to", "resize"].includes(parent.type)) {
+      // Don't update parent if we're modifying a nested transform block
       return null;
     }
 

--- a/blocks/transform.js
+++ b/blocks/transform.js
@@ -18,10 +18,11 @@ export function defineTransformBlocks() {
 		if (!changeEventParentBlock) return;
 		const changeEventBlockType = changeEventParentBlock.type;
 		if (flock.blockDebug) console.log("The type of this change event is", changeEventBlockType);
-		if (changeEventBlockType != "rotate_to") return;
-		const handleChange = handleFieldOrChildChange(block, changeEvent)
-		if (flock.blockDebug) console.log(handleChange);
-	}
+                if (!["rotate_to", "resize"].includes(changeEventBlockType))
+                        return;
+                const handleChange = handleFieldOrChildChange(block, changeEvent)
+                if (flock.blockDebug) console.log(handleChange);
+        }
 	Blockly.Blocks["move_by_xyz"] = {
 		init: function () {
 			this.jsonInit({

--- a/ui/blockmesh.js
+++ b/ui/blockmesh.js
@@ -81,7 +81,7 @@ export function getMeshFromBlock(block) {
     return flock?.scene?.getMeshByName("ground");
   }
 
-  if (block && block.type === "rotate_to") {
+  if (block && ["rotate_to", "resize"].includes(block.type)) {
     block = block.getParent();
   }
 
@@ -983,6 +983,24 @@ export function updateMeshFromBlock(mesh, block, changeEvent) {
   if (["X", "Y", "Z"].includes(changed)) {
     if (block.type === "rotate_to") {
       flock.rotateTo(mesh.name, position);
+    } else if (block.type === "resize") {
+      const size =
+        mesh.getBoundingInfo?.().boundingBox.extendSizeWorld ||
+        mesh.getBoundingInfo?.().boundingBox.extendSize ||
+        flock.BABYLON.Vector3.Zero();
+
+      const getNumericInput = (blk, name, fallback) => {
+        const input = blk.getInput(name);
+        const targetBlock = input?.connection?.targetBlock?.();
+        const value = Number(targetBlock?.getFieldValue("NUM"));
+        return Number.isFinite(value) ? value : fallback;
+      };
+
+      const width = getNumericInput(block, "X", size.x * 2);
+      const height = getNumericInput(block, "Y", size.y * 2);
+      const depth = getNumericInput(block, "Z", size.z * 2);
+
+      setAbsoluteSize(mesh, width, height, depth);
     } else {
       flock.positionAt(mesh.name, { ...position, useY: true });
     }


### PR DESCRIPTION
## Summary
- update the scale gizmo to create and update resize blocks with absolute dimensions
- enable resize blocks to drive live mesh updates similar to rotate_to
- ensure blockmesh lookup and updates handle resize blocks and set absolute sizes

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69260e05506c83268ac57afff91b23ed)