### PR TITLE
Update gizmo scale behavior to use resize blocks

### DIFF
--- a/blocks/transform.js
+++ b/blocks/transform.js
@@ -9,19 +9,20 @@ import { updateOrCreateMeshFromBlock } from "../ui/blockmesh.js";
 import { flock } from "../flock.js";
 
 export function defineTransformBlocks() {
-	function handleBlockChange(block, changeEvent) {
-		// if (flock.blockDebug) console.log("TODO: Buy Matrix DVD");
-		const changeEventBlock = Blockly.getMainWorkspace().getBlockById(changeEvent.blockId);
-		if (!changeEventBlock) return;
-		if (flock.blockDebug) console.log("The ID of this change event is", changeEventBlock.id);
-		const changeEventParentBlock = changeEventBlock.getParent();
-		if (!changeEventParentBlock) return;
-		const changeEventBlockType = changeEventParentBlock.type;
-		if (flock.blockDebug) console.log("The type of this change event is", changeEventBlockType);
-		if (changeEventBlockType != "rotate_to") return;
-		const handleChange = handleFieldOrChildChange(block, changeEvent)
-		if (flock.blockDebug) console.log(handleChange);
-	}
+        function handleBlockChange(block, changeEvent) {
+                // if (flock.blockDebug) console.log("TODO: Buy Matrix DVD");
+                const changeEventBlock = Blockly.getMainWorkspace().getBlockById(changeEvent.blockId);
+                if (!changeEventBlock) return;
+                if (flock.blockDebug) console.log("The ID of this change event is", changeEventBlock.id);
+                const changeEventParentBlock = changeEventBlock.getParent();
+                if (
+                        changeEventBlock === block ||
+                        changeEventParentBlock === block
+                ) {
+                        const handleChange = handleFieldOrChildChange(block, changeEvent)
+                        if (flock.blockDebug) console.log(handleChange);
+                }
+        }
 	Blockly.Blocks["move_by_xyz"] = {
 		init: function () {
 			this.jsonInit({

--- a/ui/blockmesh.js
+++ b/ui/blockmesh.js
@@ -81,7 +81,7 @@ export function getMeshFromBlock(block) {
     return flock?.scene?.getMeshByName("ground");
   }
 
-  if (block && block.type === "rotate_to") {
+  if (block && (block.type === "rotate_to" || block.type === "resize")) {
     block = block.getParent();
   }
 
@@ -378,6 +378,8 @@ export function updateMeshFromBlock(mesh, block, changeEvent) {
       changed = "MODELS";
     } else if (block.type === "create_map" && changeEvent.name === "MAP_NAME") {
       changed = "MAP_NAME";
+    } else if (block.type === "resize") {
+      changed = changeEvent.name;
     }
   }
 
@@ -495,6 +497,27 @@ export function updateMeshFromBlock(mesh, block, changeEvent) {
 
     const read = readColourFromInputOrShadow(block, "COLOR");
     flock.setSky(read.value);
+    return;
+  }
+
+  if (block.type === "resize") {
+    if (!mesh) return;
+
+    const sizeFallback = mesh
+      ?.getBoundingInfo()
+      ?.boundingBox?.extendSize?.scale(2) ??
+      flock.BABYLON.Vector3.One();
+
+    const resizeArgs = {
+      width: readNumberInput(block, "X", sizeFallback.x),
+      height: readNumberInput(block, "Y", sizeFallback.y),
+      depth: readNumberInput(block, "Z", sizeFallback.z),
+      xOrigin: block.getFieldValue("X_ORIGIN") || "CENTRE",
+      yOrigin: block.getFieldValue("Y_ORIGIN") || "BASE",
+      zOrigin: block.getFieldValue("Z_ORIGIN") || "CENTRE",
+    };
+
+    flock.resize(mesh.name, resizeArgs);
     return;
   }
 

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -1376,16 +1376,16 @@ export function toggleGizmo(gizmoType) {
                 addedDoSection = true;
               }
 
-              let scaleBlock = null;
+              let resizeBlock = null;
               let modelVariable = block.getFieldValue("ID_VAR");
               const statementConnection = block.getInput("DO").connection;
               if (statementConnection && statementConnection.targetBlock()) {
                 let currentBlock = statementConnection.targetBlock();
                 while (currentBlock) {
-                  if (currentBlock.type === "scale") {
+                  if (currentBlock.type === "resize") {
                     const modelField = currentBlock.getFieldValue("BLOCK_NAME");
                     if (modelField === modelVariable) {
-                      scaleBlock = currentBlock;
+                      resizeBlock = currentBlock;
                       break;
                     }
                   }
@@ -1393,14 +1393,14 @@ export function toggleGizmo(gizmoType) {
                 }
               }
 
-              if (!scaleBlock) {
-                scaleBlock = Blockly.getMainWorkspace().newBlock("scale");
-                scaleBlock.setFieldValue(modelVariable, "BLOCK_NAME");
-                scaleBlock.initSvg();
-                scaleBlock.render();
+              if (!resizeBlock) {
+                resizeBlock = Blockly.getMainWorkspace().newBlock("resize");
+                resizeBlock.setFieldValue(modelVariable, "BLOCK_NAME");
+                resizeBlock.initSvg();
+                resizeBlock.render();
 
                 ["X", "Y", "Z"].forEach((axis) => {
-                  const input = scaleBlock.getInput(axis);
+                  const input = resizeBlock.getInput(axis);
                   const shadowBlock =
                     Blockly.getMainWorkspace().newBlock("math_number");
                   shadowBlock.setFieldValue("1", "NUM");
@@ -1410,22 +1410,22 @@ export function toggleGizmo(gizmoType) {
                   input.connection.connect(shadowBlock.outputConnection);
                 });
 
-                scaleBlock.render();
+                resizeBlock.render();
                 block
                   .getInput("DO")
-                  .connection.connect(scaleBlock.previousConnection);
+                  .connection.connect(resizeBlock.previousConnection);
 
                 // Track this block for DO section cleanup
                 const timestamp = Date.now();
-                gizmoCreatedBlocks.set(scaleBlock.id, {
+                gizmoCreatedBlocks.set(resizeBlock.id, {
                   parentId: block.id,
                   createdDoSection: addedDoSection,
                   timestamp: timestamp,
                 });
               }
 
-              function setScaleValue(inputName, value) {
-                const input = scaleBlock.getInput(inputName);
+              function setResizeValue(inputName, value) {
+                const input = resizeBlock.getInput(inputName);
                 const connectedBlock = input.connection.targetBlock();
 
                 if (connectedBlock) {
@@ -1437,9 +1437,9 @@ export function toggleGizmo(gizmoType) {
               const scaleY = Math.round(mesh.scaling.y * 10) / 10;
               const scaleZ = Math.round(mesh.scaling.z * 10) / 10;
 
-              setScaleValue("X", scaleX);
-              setScaleValue("Y", scaleY);
-              setScaleValue("Z", scaleZ);
+              setResizeValue("X", scaleX);
+              setResizeValue("Y", scaleY);
+              setResizeValue("Z", scaleZ);
 
               // End undo group
               Blockly.Events.setGroup(null);


### PR DESCRIPTION
## Summary
- create resize blocks instead of scale blocks when using the scale gizmo
- ensure resize block changes propagate updates to meshes via the resize API
- allow transform block change handling for resize blocks

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692612e56a48832681114c6d9402c490)