### PR TITLE
Handle mesh updates for multi-block snippet creation

### DIFF
--- a/blocks.js
+++ b/blocks.js
@@ -288,14 +288,24 @@ export function handleParentLinkedUpdate(containerBlock, changeEvent) {
   )
     return false;
 
-  const changed = Blockly.getMainWorkspace().getBlockById(changeEvent.blockId);
-  const parent = findCreateBlock(changed);
+  const ws = Blockly.getMainWorkspace();
+  const changedBlocks =
+    changeEvent.type === Blockly.Events.BLOCK_CREATE &&
+    Array.isArray(changeEvent.ids)
+      ? changeEvent.ids
+          .map((id) => ws.getBlockById(id))
+          .filter(Boolean)
+      : [ws.getBlockById(changeEvent.blockId)].filter(Boolean);
 
-  if (parent === containerBlock && changed) {
-    if (!window.loadingCode) {
-      updateOrCreateMeshFromBlock(containerBlock, changeEvent);
+  for (const changed of changedBlocks) {
+    const parent = findCreateBlock(changed);
+
+    if (parent === containerBlock && changed) {
+      if (!window.loadingCode) {
+        updateOrCreateMeshFromBlock(containerBlock, changeEvent);
+      }
+      return true;
     }
-    return true;
   }
 
   return false;

--- a/blocks/scene.js
+++ b/blocks/scene.js
@@ -259,12 +259,14 @@ export function defineSceneBlocks() {
 					return inSubtree(matBlock, id);
 				};
 
-				const relevant =
-					touchesMap(evt.blockId) ||
-					touchesMap(evt.newParentId) ||
-					touchesMap(evt.oldParentId) ||
-					(evt.type === Blockly.Events.UI &&
-						evt.element === "dragStop");
+                                const relevant =
+                                        touchesMap(evt.blockId) ||
+                                        (Array.isArray(evt.ids) &&
+                                                evt.ids.some((id) => touchesMap(id))) ||
+                                        touchesMap(evt.newParentId) ||
+                                        touchesMap(evt.oldParentId) ||
+                                        (evt.type === Blockly.Events.UI &&
+                                                evt.element === "dragStop");
 
 				if (!relevant) return;
 


### PR DESCRIPTION
## Summary
- trigger mesh creation for all blocks included in multi-block creation events, such as snippet imports
- ensure newly added meshes/skies are initialized even when create events include multiple block IDs

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929c7f44b50832699baa8681e15b480)