### PR TITLE
Prevent flyout blocks from creating meshes

### DIFF
--- a/ui/blockmesh.js
+++ b/ui/blockmesh.js
@@ -339,6 +339,9 @@ export function updateOrCreateMeshFromBlock(block, changeEvent) {
       block.type,
       changeEvent.type,
     );
+  const inFlyout =
+    typeof block.isInFlyout === "function" ? block.isInFlyout() : block.isInFlyout;
+  if (inFlyout) return;
   if (
     [
       "set_sky_color",


### PR DESCRIPTION
## Summary
- prevent blocks inside the flyout (such as snippets) from triggering mesh creation
- keep ground creation limited to blocks placed on the workspace

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929cf12a6cc8326ac37ee89af4bb088)