### PR TITLE
Use shadow defaults for play notes lists

### DIFF
--- a/toolbox.js
+++ b/toolbox.js
@@ -3064,13 +3064,12 @@ const toolboxSound = {
                         inputsInline: true,
                         inputs: {
                                 NOTES: {
-                                        block: {
-                                                // Real block initially
+                                        shadow: {
                                                 type: "lists_create_with",
                                                 extraState: { itemCount: 1 },
                                                 inputs: {
                                                         ADD0: {
-                                                                block: {
+                                                                shadow: {
                                                                         type: "midi_note",
                                                                         fields: {
                                                                                 NOTE: 60,
@@ -3081,13 +3080,12 @@ const toolboxSound = {
                                         },
                                 },
                                 DURATIONS: {
-                                        block: {
-                                                // Real block initially
+                                        shadow: {
                                                 type: "lists_create_with",
                                                 extraState: { itemCount: 1 },
                                                 inputs: {
                                                         ADD0: {
-                                                                block: {
+                                                                shadow: {
                                                                         type: "math_number",
                                                                         fields: {
                                                                                 NUM: 1,


### PR DESCRIPTION
## Summary
- replace inline play-notes list defaults with shadow list blocks to avoid leaving detached blocks
- keep existing instrument default behavior

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a981515808326aec528f7692674a5)