### PR TITLE
Add colour arguments for light intensity and colour block to other locales

### DIFF
--- a/locale/de.js
+++ b/locale/de.js
@@ -193,7 +193,7 @@ export default {
   get_lexical_variable: "%1",
 
   // Custom block translations - Effects blocks
-  light_intensity_and_color: "Lichtintensität auf %1 setzen",
+  light_intensity_and_color: "Lichtintensität auf %1 setzen %2 %3",
   set_fog: "Nebel setzen Farbe %1 Modus %2 Dichte %3\nStart %4 Ende %5",
 
   // Custom block translation - Events blocks

--- a/locale/es.js
+++ b/locale/es.js
@@ -189,7 +189,7 @@ export default {
   get_lexical_variable: "%1",
 
   // Custom block translations - Effects blocks
-  light_intensity_and_color: "establecer intensidad de luz a %1",
+  light_intensity_and_color: "establecer intensidad de luz a %1 %2 %3",
   set_fog: "establecer niebla color %1 modo %2 densidad %3\ninicio %4 fin %5",
 
   // Custom block translation - Events blocks

--- a/locale/fr.js
+++ b/locale/fr.js
@@ -189,7 +189,7 @@ export default {
                                       get_lexical_variable: "%1",
 
                                       // Custom block translations - Effects blocks
-                                      light_intensity_and_color: "régler l'intensité de la lumière à %1",
+                                      light_intensity_and_color: "régler l'intensité de la lumière à %1 %2 %3",
                                       set_fog: "définir la couleur du brouillard %1 mode %2 densité %3\ndébut %4 fin %5",
 
                                       // Custom block translation - Events blocks

--- a/locale/it.js
+++ b/locale/it.js
@@ -202,7 +202,7 @@ export default {
   get_lexical_variable: "%1",
 
   // Custom block translations - Effects blocks
-  light_intensity_and_color: "imposta intensità luce a %1",
+  light_intensity_and_color: "imposta intensità luce a %1 %2 %3",
   set_fog: "imposta nebbia colore %1 modalità %2 densità %3\ninizio %4 fine %5",
 
   // Custom block translation - Events blocks

--- a/locale/pl.js
+++ b/locale/pl.js
@@ -189,7 +189,7 @@ export default {
   get_lexical_variable: "%1",
 
   // Custom block blocks - Effects blocks
-  light_intensity_and_color: "ustaw intensywność światła na %1",
+  light_intensity_and_color: "ustaw intensywność światła na %1 %2 %3",
   set_fog: "ustaw mgłę, kolor: %1, tryb: %2, gęstość: %3\npoczątek %4 koniec %5",
 
   // Custom block translation - Events blocks

--- a/locale/pt.js
+++ b/locale/pt.js
@@ -197,7 +197,7 @@ export default {
   get_lexical_variable: "%1",
 
   // Custom block translations - Effects blocks
-  light_intensity_and_color: "definir intensidade da luz para %1",
+  light_intensity_and_color: "definir intensidade da luz para %1 %2 %3",
   set_fog: "definir cor da névoa %1 modo %2 densidade %3\ninício %4 fim %5",
 
   // Custom block translation - Events blocks

--- a/locale/sv.js
+++ b/locale/sv.js
@@ -198,7 +198,7 @@ export default {
       get_lexical_variable: "%1",
 
       // Custom block translations - Effects blocks
-      light_intensity_and_color: "ställ in ljusintensitet till %1",
+      light_intensity_and_color: "ställ in ljusintensitet till %1 %2 %3",
       set_fog: "ställ in dimma färg %1 läge %2 densitet %3\nstart %4 slut %5",
 
       // Custom block translation - Events blocks


### PR DESCRIPTION
At the moment, I just added the colours without any additional text, to make sure that, if we were to use the block, it doesn't break when we switch languages.

I plan to start translating the messages for both _this_ light intensity and colours block and also the block for retrieving the light as a variable (hopefully after this PR gets merged).