### PR TITLE
Fix double increment of object variable counter

### DIFF
--- a/blocks/models.js
+++ b/blocks/models.js
@@ -229,15 +229,8 @@ export function defineModelBlocks() {
 
 			updateColorField();
 
-			this.setOnChange((changeEvent) => {
-				handleBlockCreateEvent(
-					this,
-					changeEvent,
-					variableNamePrefix,
-					nextVariableIndexes,
-				);
-
-				handleBlockChange(this, changeEvent, variableNamePrefix);
+                        this.setOnChange((changeEvent) => {
+                                handleBlockChange(this, changeEvent, variableNamePrefix);
 
 				if (
 					this.id !== changeEvent.blockId &&


### PR DESCRIPTION
## Summary
- ensure load_object blocks rely on the shared handler once so the object variable counter only increments once per creation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ae31b17c88326ae7d14ab9ede396f)