### PR TITLE
Implement missing coordinate option keys in locales other than English

### DIFF
--- a/locale/de.js
+++ b/locale/de.js
@@ -355,6 +355,10 @@ export default {
   f_icon_option: "F ✱",
   q_icon_option: "Q ■",
 
+  x_coordinate_option: "x",
+  y_coordinate_option: "y",
+  z_coordinate_option: "z",
+
   FLAT_option: "Flach",
 
   SMALL_option: "klein",

--- a/locale/es.js
+++ b/locale/es.js
@@ -628,6 +628,10 @@ export default {
   e_icon_option: "E ✿", // Duplicate key e
   f_icon_option: "F ✱", // Duplicate key f
 
+  x_coordinate_option: "x",
+  y_coordinate_option: "y",
+  z_coordinate_option: "z",
+
   POSITION_X_option: "posición x",
   POSITION_Y_option: "posición y",
   POSITION_Z_option: "posición z",

--- a/locale/fr.js
+++ b/locale/fr.js
@@ -628,6 +628,10 @@ export default {
                                       e_icon_option: "E ✿",
                                       f_icon_option: "F ✱",
 
+                                      x_coordinate_option: "x",
+                                      y_coordinate_option: "y",
+                                      z_coordinate_option: "z",
+
                                       POSITION_X_option: "position x",
                                       POSITION_Y_option: "position y",
                                       POSITION_Z_option: "position z",

--- a/locale/it.js
+++ b/locale/it.js
@@ -753,6 +753,10 @@ export default {
   e_icon_option: "E ✿", // Duplicate key e
   f_icon_option: "F ✱", // Duplicate key f
 
+  x_coordinate_option: "x",
+  y_coordinate_option: "y",
+  z_coordinate_option: "z",
+
   POSITION_X_option: "posizione x",
   POSITION_Y_option: "posizione y",
   POSITION_Z_option: "posizione z",

--- a/locale/pl.js
+++ b/locale/pl.js
@@ -630,6 +630,10 @@ export default {
   e_icon_option: "E ✿",
   f_icon_option: "F ✱",
 
+  x_coordinate_option: "x",
+  y_coordinate_option: "y",
+  z_coordinate_option: "z",
+
   POSITION_X_option: "pozycja x",
   POSITION_Y_option: "pozycja y",
   POSITION_Z_option: "pozycja z",

--- a/locale/pt.js
+++ b/locale/pt.js
@@ -748,6 +748,10 @@ export default {
   e_icon_option: "E ✿",
   f_icon_option: "F ✱",
 
+  x_coordinate_option: "x",
+  y_coordinate_option: "y",
+  z_coordinate_option: "z",
+
   POSITION_X_option: "posição x",
   POSITION_Y_option: "posição y",
   POSITION_Z_option: "posição z",

--- a/locale/sv.js
+++ b/locale/sv.js
@@ -750,6 +750,10 @@ export default {
       e_icon_option: "E ✿", // Duplicate key e
       f_icon_option: "F ✱", // Duplicate key f
 
+      x_coordinate_option: "x",
+      y_coordinate_option: "y",
+      z_coordinate_option: "z",
+
       POSITION_X_option: "position x",
       POSITION_Y_option: "position y",
       POSITION_Z_option: "position z",


### PR DESCRIPTION
The English locale has option keys for the X, Y and Z coordinates that get used by blocks I defined in #169. These keys weren't defined in the other locales at the time. This PR fixes that.