### PR TITLE
Add Noto Color Emoji font support

### DIFF
--- a/api/ui.js
+++ b/api/ui.js
@@ -1,6 +1,7 @@
 let flock;
 //let fontFamily = "Asap";
-let fontFamily = "Atkinson Hyperlegible Next";
+let fontFamily =
+  "Atkinson Hyperlegible Next, Asap, Noto Color Emoji, Apple Color Emoji, Segoe UI Emoji, EmojiOne Color, Twemoji Mozilla, Helvetica, Arial, Lucida, sans-serif";
 
 export function setFlockReference(ref) {
   flock = ref;

--- a/example.html
+++ b/example.html
@@ -7,7 +7,12 @@
 
 		 <style>
 			 body {
-				 font-family: "Atkinson Hyperlegible Next", "Asap", Helvetica, Arial, Lucida, sans-serif !important;
+                              font-family: var(
+                                --font-family-base,
+                                "Atkinson Hyperlegible Next", "Asap", "Noto Color Emoji",
+                                "Apple Color Emoji", "Segoe UI Emoji", "EmojiOne Color",
+                                "Twemoji Mozilla", Helvetica, Arial, Lucida, sans-serif
+                              ) !important;
 			   }
 			 </style>
 	</head>

--- a/flockdemo.html
+++ b/flockdemo.html
@@ -7,7 +7,12 @@
 
 		 <style>
 			 body {
-				 font-family: "Atkinson Hyperlegible Next", "Asap", Helvetica, Arial, Lucida, sans-serif !important;
+                              font-family: var(
+                                --font-family-base,
+                                "Atkinson Hyperlegible Next", "Asap", "Noto Color Emoji",
+                                "Apple Color Emoji", "Segoe UI Emoji", "EmojiOne Color",
+                                "Twemoji Mozilla", Helvetica, Arial, Lucida, sans-serif
+                              ) !important;
 			   }
 			 </style>
 	</head>

--- a/index.html
+++ b/index.html
@@ -122,7 +122,12 @@
         font-size: 18px;
         font-weight: 500;
         margin: 0;
-        font-family: "Atkinson Hyperlegible Next", "Asap", Helvetica, Arial, Lucida, sans-serif;
+        font-family: var(
+          --font-family-base,
+          "Atkinson Hyperlegible Next", "Asap", "Noto Color Emoji",
+          "Apple Color Emoji", "Segoe UI Emoji", "EmojiOne Color",
+          "Twemoji Mozilla", Helvetica, Arial, Lucida, sans-serif
+        );
         order: 4;
       }
 

--- a/main/export.js
+++ b/main/export.js
@@ -294,14 +294,22 @@ async function generateSVG(block) {
 		"style",
 	);
 	style.textContent = `
-	@font-face {
-	  font-family: "Atkinson Hyperlegible Next";
-	  src: url('data:font/woff2;base64,${fontBase64}') format('woff2');
-	}
-	.blocklyText {
-	  font-family: "Atkinson Hyperlegible Next", sans-serif;
-	  font-weight: 500;
-	}
+        @font-face {
+          font-family: "Atkinson Hyperlegible Next";
+          src: url('data:font/woff2;base64,${fontBase64}') format('woff2');
+        }
+        @font-face {
+          font-family: "Noto Color Emoji";
+          src: url('https://fonts.gstatic.com/s/notoemoji/latest/NotoColorEmoji-Regular.woff2')
+            format('woff2');
+          font-weight: 400;
+          font-display: swap;
+        }
+        .blocklyText {
+          font-family: "Atkinson Hyperlegible Next", "Noto Color Emoji",
+            "Apple Color Emoji", "Segoe UI Emoji", sans-serif;
+          font-weight: 500;
+        }
 	.blocklyEditableText rect.blocklyFieldRect:not(.blocklyDropdownRect) {
 	  fill: #ffffff !important; 
 	}

--- a/style.css
+++ b/style.css
@@ -1,6 +1,15 @@
 @import url("./style/blockly.css");
 @import url("./ui/colourpicker.css");
 
+@font-face {
+  font-family: "Noto Color Emoji";
+  src: url("https://fonts.gstatic.com/s/notoemoji/latest/NotoColorEmoji-Regular.woff2")
+    format("woff2");
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+}
+
 :root {
   /* Primary Brand Colors */
   --color-primary: #511D91;
@@ -47,6 +56,10 @@
   --color-menu-item: #511D91;
   --color-menu:  #f9f9f9;
   --color-button-bg:  #f0f0f0;
+
+  --font-family-base: "Atkinson Hyperlegible Next", "Asap",
+    "Noto Color Emoji", "Apple Color Emoji", "Segoe UI Emoji",
+    "EmojiOne Color", "Twemoji Mozilla", Helvetica, Arial, Lucida, sans-serif;
 
   /* Shadow Colors */
   --color-shadow: rgba(0, 0, 0, 0.1);
@@ -308,7 +321,12 @@
   font-size: 18px;
   font-weight: 500;
   margin: 0;
-  font-family:  "Atkinson Hyperlegible Next", "Asap", Helvetica, Arial, Lucida, sans-serif;
+  font-family: var(
+    --font-family-base,
+    "Atkinson Hyperlegible Next", "Asap", "Noto Color Emoji",
+    "Apple Color Emoji", "Segoe UI Emoji", "EmojiOne Color",
+    "Twemoji Mozilla", Helvetica, Arial, Lucida, sans-serif
+  );
   order: 4;
 }
 
@@ -364,7 +382,12 @@ body {
   display: flex;
   gap: 0;
   box-sizing: border-box;
-  font-family:  "Atkinson Hyperlegible Next", "Asap", Helvetica, Arial, Lucida, sans-serif !important;
+  font-family: var(
+    --font-family-base,
+    "Atkinson Hyperlegible Next", "Asap", "Noto Color Emoji",
+    "Apple Color Emoji", "Segoe UI Emoji", "EmojiOne Color",
+    "Twemoji Mozilla", Helvetica, Arial, Lucida, sans-serif
+  ) !important;
   background: var(--color-bg);
   color: var(--color-text-primary);
 }
@@ -480,7 +503,12 @@ button {
 
 /* Gizmo Buttons */
 .gizmo-buttons {
-  font-family: "Atkinson Hyperlegible Next", "Asap", Helvetica, Arial, Lucida, sans-serif;
+  font-family: var(
+    --font-family-base,
+    "Atkinson Hyperlegible Next", "Asap", "Noto Color Emoji",
+    "Apple Color Emoji", "Segoe UI Emoji", "EmojiOne Color",
+    "Twemoji Mozilla", Helvetica, Arial, Lucida, sans-serif
+  );
   display: flex;
   flex-wrap: wrap;
   gap: 5px;
@@ -490,7 +518,12 @@ button {
 }
 
 .gizmo-button {
-  font-family: "Atkinson Hyperlegible Next", "Asap", Helvetica, Arial, Lucida, sans-serif;
+  font-family: var(
+    --font-family-base,
+    "Atkinson Hyperlegible Next", "Asap", "Noto Color Emoji",
+    "Apple Color Emoji", "Segoe UI Emoji", "EmojiOne Color",
+    "Twemoji Mozilla", Helvetica, Arial, Lucida, sans-serif
+  );
   padding: 5px;
   font-size: 12px;
   cursor: pointer;

--- a/style/blockly.css
+++ b/style/blockly.css
@@ -406,48 +406,93 @@ color: var(--color-menu-item-text) !important;
 }
 
 body .blocklyHtmlInput {
-   font-family:  "Atkinson Hyperlegible Next", "Asap", Helvetica, Arial, Lucida, sans-serif !important;
+   font-family: var(
+     --font-family-base,
+     "Atkinson Hyperlegible Next", "Asap", "Noto Color Emoji",
+     "Apple Color Emoji", "Segoe UI Emoji", "EmojiOne Color",
+     "Twemoji Mozilla", Helvetica, Arial, Lucida, sans-serif
+   ) !important;
 }
 
 body .blocklyText {
   font-weight: 500 !important;
-  font-family:  "Atkinson Hyperlegible Next", "Asap", Helvetica, Arial, Lucida, sans-serif !important;
+  font-family: var(
+    --font-family-base,
+    "Atkinson Hyperlegible Next", "Asap", "Noto Color Emoji",
+    "Apple Color Emoji", "Segoe UI Emoji", "EmojiOne Color",
+    "Twemoji Mozilla", Helvetica, Arial, Lucida, sans-serif
+  ) !important;
 }
 
 body .blocklyTreeLabel {
   font-weight: 500 !important;
-  font-family:  "Atkinson Hyperlegible Next", "Asap", Helvetica, Arial, Lucida, sans-serif !important;
+  font-family: var(
+    --font-family-base,
+    "Atkinson Hyperlegible Next", "Asap", "Noto Color Emoji",
+    "Apple Color Emoji", "Segoe UI Emoji", "EmojiOne Color",
+    "Twemoji Mozilla", Helvetica, Arial, Lucida, sans-serif
+  ) !important;
 }
 
 body[data-theme="contrast"] .blocklyText {
    font-weight: 600 !important;
-  font-family:  "Atkinson Hyperlegible Next", "Asap", Helvetica, Arial, Lucida, sans-serif !important;
+  font-family: var(
+    --font-family-base,
+    "Atkinson Hyperlegible Next", "Asap", "Noto Color Emoji",
+    "Apple Color Emoji", "Segoe UI Emoji", "EmojiOne Color",
+    "Twemoji Mozilla", Helvetica, Arial, Lucida, sans-serif
+  ) !important;
 
 }
 
 body[data-theme="dark-contrast"] .blocklyText {
   font-weight: 600 !important;
-  font-family:  "Atkinson Hyperlegible Next", "Asap", Helvetica, Arial, Lucida, sans-serif !important;
+  font-family: var(
+    --font-family-base,
+    "Atkinson Hyperlegible Next", "Asap", "Noto Color Emoji",
+    "Apple Color Emoji", "Segoe UI Emoji", "EmojiOne Color",
+    "Twemoji Mozilla", Helvetica, Arial, Lucida, sans-serif
+  ) !important;
 
 }
 
 body[data-theme="dark-contrast"] .blocklyTreeLabel {
   font-weight: 500 !important;
-  font-family:  "Atkinson Hyperlegible Next", "Asap", Helvetica, Arial, Lucida, sans-serif !important;
+  font-family: var(
+    --font-family-base,
+    "Atkinson Hyperlegible Next", "Asap", "Noto Color Emoji",
+    "Apple Color Emoji", "Segoe UI Emoji", "EmojiOne Color",
+    "Twemoji Mozilla", Helvetica, Arial, Lucida, sans-serif
+  ) !important;
 }
 
 body[data-theme="contrast"] .blocklyTreeLabel {
   font-weight: 500 !important;
-  font-family:  "Atkinson Hyperlegible Next", "Asap", Helvetica, Arial, Lucida, sans-serif !important;
+  font-family: var(
+    --font-family-base,
+    "Atkinson Hyperlegible Next", "Asap", "Noto Color Emoji",
+    "Apple Color Emoji", "Segoe UI Emoji", "EmojiOne Color",
+    "Twemoji Mozilla", Helvetica, Arial, Lucida, sans-serif
+  ) !important;
 }
 
 body[data-theme="dark"] .blocklyText {
   font-weight: 500 !important;
-  font-family:  "Atkinson Hyperlegible Next", "Asap", Helvetica, Arial, Lucida, sans-serif !important;
+  font-family: var(
+    --font-family-base,
+    "Atkinson Hyperlegible Next", "Asap", "Noto Color Emoji",
+    "Apple Color Emoji", "Segoe UI Emoji", "EmojiOne Color",
+    "Twemoji Mozilla", Helvetica, Arial, Lucida, sans-serif
+  ) !important;
 }
 
 body[data-theme="dark"] .blocklyTreeLabel {
-   font-family:  "Atkinson Hyperlegible Next", "Asap", Helvetica, Arial, Lucida, sans-serif !important;
+   font-family: var(
+     --font-family-base,
+     "Atkinson Hyperlegible Next", "Asap", "Noto Color Emoji",
+     "Apple Color Emoji", "Segoe UI Emoji", "EmojiOne Color",
+     "Twemoji Mozilla", Helvetica, Arial, Lucida, sans-serif
+   ) !important;
 }
 
 .blocklyFlyoutBackground {

--- a/ui/colourpicker.css
+++ b/ui/colourpicker.css
@@ -3,7 +3,11 @@
 .custom-color-picker {
   position: fixed;
   z-index: 10000;
-  font-family: 'Asap', sans-serif;
+  font-family: var(
+    --font-family-base,
+    "Asap", "Noto Color Emoji", "Apple Color Emoji", "Segoe UI Emoji",
+    "EmojiOne Color", "Twemoji Mozilla", sans-serif
+  );
 }
 
 .color-picker-backdrop {
@@ -43,7 +47,12 @@
 .palette-dropdown {
   max-width: 50%;
   padding: 3px;
-  font-family:  "Atkinson Hyperlegible Next", "Asap", Helvetica, Arial, Lucida, sans-serif;
+  font-family: var(
+    --font-family-base,
+    "Atkinson Hyperlegible Next", "Asap", "Noto Color Emoji",
+    "Apple Color Emoji", "Segoe UI Emoji", "EmojiOne Color",
+    "Twemoji Mozilla", Helvetica, Arial, Lucida, sans-serif
+  );
   font-size: 14px;
 }
 

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -113,6 +113,31 @@ export default {
               },
             },
           },
+          {
+            urlPattern: /^https:\/\/fonts\.googleapis\.com\/.*$/i,
+            handler: 'StaleWhileRevalidate',
+            options: {
+              cacheName: 'google-fonts-stylesheets',
+              expiration: {
+                maxEntries: 20,
+                maxAgeSeconds: 365 * 24 * 60 * 60,
+              },
+            },
+          },
+          {
+            urlPattern: /^https:\/\/fonts\.gstatic\.com\/.*$/i,
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'google-fonts-webfonts',
+              cacheableResponse: {
+                statuses: [0, 200],
+              },
+              expiration: {
+                maxEntries: 50,
+                maxAgeSeconds: 365 * 24 * 60 * 60,
+              },
+            },
+          },
           // Optional: keep your fine-grained caches
           {
             urlPattern: /\/models\/.*/,


### PR DESCRIPTION
## Summary
- add a Noto Color Emoji webfont and reuse a shared font stack across the UI
- ensure emoji glyphs are available during exports and runtime by including the font in relevant styles
- cache Google Fonts requests in the PWA service worker for offline emoji rendering

## Testing
- npm run build *(fails: ui/addmenu.js reports "selected" is not exported by blockly/index.mjs)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fe88e5f188326923044dddeaa84c9)