### PR TITLE
Fix background fallback to existing sky

### DIFF
--- a/blocks/blocks.js
+++ b/blocks/blocks.js
@@ -99,21 +99,13 @@ export function handleBlockDelete(event) {
         deleteMeshFromBlock(blockJson.id);
       } else if (blockJson.type === "set_background_color") {
         deleteMeshFromBlock(blockJson.id);
-        if (
-          !applySceneBackgroundFromWorkspace(blockJson.id, {
-            allowSkyFallback: false,
-          })
-        ) {
+        if (!applySceneBackgroundFromWorkspace(blockJson.id)) {
           clearSkyMesh();
           setClearSkyToBlack();
         }
       } else if (blockJson.type === "set_sky_color") {
         clearSkyMesh();
-        if (
-          !applySceneBackgroundFromWorkspace(blockJson.id, {
-            allowSkyFallback: false,
-          })
-        ) {
+        if (!applySceneBackgroundFromWorkspace(blockJson.id)) {
           setClearSkyToBlack();
         }
       }
@@ -173,21 +165,13 @@ export function handleMeshLifecycleChange(block, changeEvent) {
     } else {
       deleteMeshFromBlock(block.id);
       if (block.type === "set_background_color") {
-        if (
-          !applySceneBackgroundFromWorkspace(block.id, {
-            allowSkyFallback: false,
-          })
-        ) {
+        if (!applySceneBackgroundFromWorkspace(block.id)) {
           clearSkyMesh();
           setClearSkyToBlack();
         }
       } else if (block.type === "set_sky_color") {
         clearSkyMesh();
-        if (
-          !applySceneBackgroundFromWorkspace(block.id, {
-            allowSkyFallback: false,
-          })
-        ) {
+        if (!applySceneBackgroundFromWorkspace(block.id)) {
           setClearSkyToBlack();
         }
       }

--- a/ui/blockmesh.js
+++ b/ui/blockmesh.js
@@ -260,7 +260,9 @@ export function extractMaterialInfo(materialBlock) {
 
 function applyBackgroundColorFromBlock(block) {
   if (!block.isEnabled()) {
-    setClearSkyToBlack();
+    if (!applySceneBackgroundFromWorkspace(block.id)) {
+      setClearSkyToBlack();
+    }
     return;
   }
 
@@ -429,7 +431,9 @@ function safeGetFieldValue(block, fieldName) {
 
 function updateSkyFromBlock(mesh, block, changeEvent) {
   if (!block.isEnabled()) {
-    setClearSkyToBlack();
+    if (!applySceneBackgroundFromWorkspace(block.id)) {
+      setClearSkyToBlack();
+    }
     return;
   }
 


### PR DESCRIPTION
## Summary
- keep existing sky or background when a background block is disabled or removed instead of defaulting to black
- reuse workspace background fallback logic for disabled sky blocks to avoid unnecessary black screens

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69315876f2848326869051adba0660dc)