### PR TITLE
Use exact group root matching for triggers

### DIFF
--- a/api/physics.js
+++ b/api/physics.js
@@ -294,9 +294,10 @@ export const flockPhysics = {
     meshName,
     { trigger, callback, mode = "wait", applyToGroup = false },
   ) {
-    const groupName = meshName.includes("__")
-      ? meshName.split("__")[0]
-      : meshName.split("_")[0];
+    const getGroupRoot = (name) =>
+      name.includes("__") ? name.split("__")[0] : name.split("_")[0];
+
+    const groupName = getGroupRoot(meshName);
 
     // 🛡 Scene not ready yet – queue for later
     if (!flock.scene) {
@@ -317,13 +318,14 @@ export const flockPhysics = {
       let matchingButtons = [];
       if (flock.scene.UITexture) {
         matchingButtons = flock.scene.UITexture._rootContainer._children.filter(
-          (control) => control.name && control.name.startsWith(groupName),
+          (control) =>
+            control.name && getGroupRoot(control.name) === groupName,
         );
       }
 
       // Check for 3D meshes
-      const matching = flock.scene.meshes.filter((m) =>
-        m.name.startsWith(groupName),
+      const matching = flock.scene.meshes.filter(
+        (m) => getGroupRoot(m.name) === groupName,
       );
 
       // Apply to existing GUI buttons

--- a/flock.js
+++ b/flock.js
@@ -2583,6 +2583,11 @@ export const flock = {
         announceMeshReady(meshName, groupName) {
                 //console.log(`[flock] Mesh ready: ${meshName} (group: ${groupName})`);
 
+                const getGroupRoot = (name) =>
+                        name.includes("__")
+                                ? name.split("__")[0]
+                                : name.split("_")[0];
+
                 if (!flock.pendingTriggers.has(groupName)) return;
 
                 //console.log(`[flock] Registering pending triggers for group: '${groupName}'`);
@@ -2593,15 +2598,15 @@ export const flock = {
                         callback,
                         mode,
                         applyToGroup,
-                } of triggers) {
-                        if (applyToGroup) {
-                                // 🔁 Reapply trigger across all matching meshes
-                                const matching = flock.scene.meshes.filter(
-                                        (m) => m.name.startsWith(groupName),
-                                );
-                                for (const m of matching) {
-                                        flock.onTrigger(m.name, {
-                                                trigger,
+                        } of triggers) {
+                                if (applyToGroup) {
+                                        // 🔁 Reapply trigger across all matching meshes
+                                        const matching = flock.scene.meshes.filter(
+                                                (m) => getGroupRoot(m.name) === groupName,
+                                        );
+                                        for (const m of matching) {
+                                                flock.onTrigger(m.name, {
+                                                        trigger,
                                                 callback,
                                                 mode,
                                                 applyToGroup: false, // prevent recursion


### PR DESCRIPTION
## Summary
- ensure trigger grouping compares exact name roots rather than prefix matching for meshes and GUI controls
- update pending trigger replay to use the same exact-root matching logic

## Testing
- npm test -- --runTestsByPath tests/physics.test.js *(fails: missing npm test script)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69358abfab708326a05e94b41aa111eb)