### PR TITLE
Handle Havok out-of-memory errors

### DIFF
--- a/flock.js
+++ b/flock.js
@@ -313,10 +313,7 @@ export const flock = {
                 }
 
                 flock.havokAbortHandled = true;
-                console.error(
-                        "Havok physics aborted, likely due to running out of memory.",
-                        error,
-                );
+                console.error(translate("physics_out_of_memory_log"), error);
 
                 try {
                         if (flock._renderLoop) {
@@ -339,8 +336,7 @@ export const flock = {
 
                 const banner = doc.createElement("div");
                 banner.id = warningId;
-                banner.textContent =
-                        "Physics engine ran out of memory. Try reducing the number of physics objects or reloading your project.";
+                banner.textContent = translate("physics_out_of_memory_banner_ui");
                 banner.style.position = "fixed";
                 banner.style.top = "0";
                 banner.style.left = "0";

--- a/locale/de.js
+++ b/locale/de.js
@@ -891,6 +891,10 @@ export default {
   max_mesh_limit_reached:
     "⚠️ Limit erreicht: Du kannst nur {max} Meshes in deiner Welt haben.",
   high_memory_usage_warning: "Warnung: Hoher Speicherverbrauch ({percent}%)",
+  physics_out_of_memory_log:
+    "Havok-Physik wurde abgebrochen, wahrscheinlich wegen zu wenig Speicher.", // AI-generated; needs validation
+  physics_out_of_memory_banner_ui:
+    "Der Physik-Engine ging der Speicher aus. Reduziere die Anzahl der Physikobjekte oder lade dein Projekt neu.", // AI-generated; needs validation
   runtime_error_message: "Fehler: {message}",
   xr_mode_message: "XR-Modus!",
   fly_camera_instructions:

--- a/locale/en.js
+++ b/locale/en.js
@@ -912,6 +912,10 @@ export default {
   max_mesh_limit_reached:
     "⚠️ Limit reached: You can only have {max} meshes in your world.",
   high_memory_usage_warning: "Warning: High memory usage ({percent}%)",
+  physics_out_of_memory_log:
+    "Havok physics aborted, likely due to running out of memory.",
+  physics_out_of_memory_banner_ui:
+    "Physics engine ran out of memory. Try reducing the number of physics objects or reloading your project.",
   runtime_error_message: "Error: {message}",
   xr_mode_message: "XR Mode!",
   fly_camera_instructions: "ℹ️ Fly camera, use arrow keys and page up/down",

--- a/locale/es.js
+++ b/locale/es.js
@@ -903,6 +903,10 @@ export default {
   max_mesh_limit_reached:
     "⚠️ Límite alcanzado: solo puedes tener {max} mallas en tu mundo.",
   high_memory_usage_warning: "Advertencia: uso de memoria alto ({percent}%)",
+  physics_out_of_memory_log:
+    "La física de Havok se abortó, probablemente por falta de memoria.", // AI-generated; needs validation
+  physics_out_of_memory_banner_ui:
+    "El motor de física se quedó sin memoria. Intenta reducir el número de objetos físicos o recargar el proyecto.", // AI-generated; needs validation
   runtime_error_message: "Error: {message}",
   xr_mode_message: "¡Modo XR!",
   fly_camera_instructions:

--- a/locale/fr.js
+++ b/locale/fr.js
@@ -899,12 +899,16 @@ export default {
                                       failed_to_read_file_alert: "Échec de lecture du fichier.",
 
                                       // UI status messages
-                                      max_mesh_limit_reached:
-                                        "⚠️ Limite atteinte: vous pouvez avoir seulement {max} maillages dans votre monde.",
-                                      high_memory_usage_warning:
-                                        "Avertissement: utilisation mémoire élevée ({percent}%)",
-                                      runtime_error_message: "Erreur: {message}",
-                                      xr_mode_message: "Mode XR !",
+  max_mesh_limit_reached:
+    "⚠️ Limite atteinte: vous pouvez avoir seulement {max} maillages dans votre monde.",
+  high_memory_usage_warning:
+    "Avertissement: utilisation mémoire élevée ({percent}%)",
+  physics_out_of_memory_log:
+    "La physique Havok s'est arrêtée, probablement par manque de mémoire.", // AI-generated; needs validation
+  physics_out_of_memory_banner_ui:
+    "Le moteur physique n'a plus de mémoire. Réduisez le nombre d'objets physiques ou rechargez votre projet.", // AI-generated; needs validation
+  runtime_error_message: "Erreur: {message}",
+  xr_mode_message: "Mode XR !",
                                       fly_camera_instructions:
                                         "ℹ️ Caméra en vol, utilisez les flèches et Page haut/bas",
                                       select_mesh_delete_prompt:

--- a/locale/it.js
+++ b/locale/it.js
@@ -1033,6 +1033,10 @@ export default {
   max_mesh_limit_reached:
     "⚠️ Limite raggiunto: puoi avere solo {max} mesh nel tuo mondo.",
   high_memory_usage_warning: "Avviso: uso di memoria elevato ({percent}%)",
+  physics_out_of_memory_log:
+    "La fisica Havok si è interrotta, probabilmente per esaurimento della memoria.", // AI-generated; needs validation
+  physics_out_of_memory_banner_ui:
+    "Il motore fisico ha esaurito la memoria. Prova a ridurre il numero di oggetti fisici o a ricaricare il progetto.", // AI-generated; needs validation
   runtime_error_message: "Errore: {message}",
   xr_mode_message: "Modalità XR!",
   fly_camera_instructions:

--- a/locale/pl.js
+++ b/locale/pl.js
@@ -910,6 +910,10 @@ export default {
   max_mesh_limit_reached:
     "⚠️ Osiągnięto limit: możesz mieć tylko {max} siatek w swoim świecie.",
   high_memory_usage_warning: "Ostrzeżenie: wysokie użycie pamięci ({percent}%)",
+  physics_out_of_memory_log:
+    "Silnik fizyki Havok został przerwany, prawdopodobnie z powodu braku pamięci.", // AI-generated; needs validation
+  physics_out_of_memory_banner_ui:
+    "Silnik fizyczny zabrakło pamięci. Spróbuj zmniejszyć liczbę obiektów fizycznych lub ponownie wczytać projekt.", // AI-generated; needs validation
   runtime_error_message: "Błąd: {message}",
   xr_mode_message: "Tryb XR!",
   fly_camera_instructions:

--- a/locale/pt.js
+++ b/locale/pt.js
@@ -1027,6 +1027,10 @@ export default {
   max_mesh_limit_reached:
     "⚠️ Limite alcançado: você só pode ter {max} malhas no seu mundo.",
   high_memory_usage_warning: "Aviso: uso de memória alto ({percent}%)",
+  physics_out_of_memory_log:
+    "A física Havok foi abortada, provavelmente por falta de memória.", // AI-generated; needs validation
+  physics_out_of_memory_banner_ui:
+    "O motor de física ficou sem memória. Tente reduzir o número de objetos físicos ou recarregar o projeto.", // AI-generated; needs validation
   runtime_error_message: "Erro: {message}",
   xr_mode_message: "Modo XR!",
   fly_camera_instructions:

--- a/locale/sv.js
+++ b/locale/sv.js
@@ -1030,6 +1030,10 @@ export default {
       max_mesh_limit_reached:
         "⚠️ Gräns nådd: du kan bara ha {max} mesh i din värld.",
       high_memory_usage_warning: "Varning: hög minnesanvändning ({percent}%)",
+      physics_out_of_memory_log:
+        "Havok-fysiken avbröts, troligen på grund av minnesbrist.", // AI-generated; needs validation
+      physics_out_of_memory_banner_ui:
+        "Fysikmotorn fick slut på minne. Försök minska antalet fysikobjekt eller ladda om projektet.", // AI-generated; needs validation
       runtime_error_message: "Fel: {message}",
       xr_mode_message: "XR-läge!",
       fly_camera_instructions:


### PR DESCRIPTION
## Summary
- wrap the render loop to detect Havok/wasm aborts and stop the engine safely
- surface a user-facing banner with guidance when physics runs out of memory
- reset Havok abort state and warning banner when creating a new scene

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935ac79e10883269f912289e8054cbd)