### PR TITLE
Dispose ground mesh when deleting ground block

### DIFF
--- a/ui/blockmesh.js
+++ b/ui/blockmesh.js
@@ -35,7 +35,7 @@ export function deleteMeshFromBlock(blockId) {
 
   if (!blockKey) {
     const block = Blockly.getMainWorkspace().getBlockById(blockId);
-    if (block && block.type === "create_map") {
+    if (block && (block.type === "create_map" || block.type === "create_ground")) {
       const mesh = flock?.scene?.getMeshByName("ground");
       if (mesh) {
         flock.disposeMesh(mesh);


### PR DESCRIPTION
## Summary
- dispose the ground mesh when either create_map or create_ground blocks are deleted even if not tracked

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935df9dab208326a025f6818a65bad8)