### PR TITLE
Ensure map deletions dispose ground mesh

### DIFF
--- a/ui/blockmesh.js
+++ b/ui/blockmesh.js
@@ -649,6 +649,10 @@ function handleMaterialOrColorChange(
 }
 
 function updateGroundFromBlock(mesh, block, changeEvent) {
+  // Track ownership so deletions can dispose the ground mesh
+  meshMap["ground"] = block;
+  meshBlockIdMap["ground"] = block.id;
+
   const colorInput = block.getInputTargetBlock("COLOR");
 
   if (colorInput && colorInput.type === "material") {
@@ -695,6 +699,10 @@ function updateGroundFromBlock(mesh, block, changeEvent) {
 }
 
 function updateMapFromBlock(mesh, block, changeEvent) {
+  // Track ownership so deletions can dispose the ground mesh
+  meshMap["ground"] = block;
+  meshBlockIdMap["ground"] = block.id;
+
   const mapName = block.getFieldValue("MAP_NAME");
   const materialBlock = block.getInputTargetBlock("MATERIAL");
 


### PR DESCRIPTION
## Summary
- track the ground mesh ownership when updating ground and map blocks
- ensure ground meshes tied to map blocks are disposed when their blocks are deleted

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935e6d3d2d8832685bfa1aa46e92030)