### PR TITLE
Rename set pivot block to anchor across locales

### DIFF
--- a/locale/de.js
+++ b/locale/de.js
@@ -287,7 +287,7 @@ export default {
   rotate_to: "Rotiere %1 zu x: %2 y: %3 z: %4",
   look_at: "Lass %1 auf %2 sehen y? %3",
   move_forward: "Bewege %1 %2 Geschwindigkeit %3",
-  set_pivot: "Setze Pivot von %1 x: %2 y: %3 z: %4",
+  set_pivot: "Setze Anker von %1\nx: %2 y: %3 z: %4",
   min_centre_max: "%1",
 
   _0_option: "0",
@@ -598,7 +598,7 @@ export default {
   rotate_to_tooltip: "Drehe das Objekt in Richtung der angegebenen Koordinaten.\nSchlüsselwort: rotateto",
   look_at_tooltip: "Dreht das erste Objekt so, dass es auf die Position des zweiten zeigt.\nSchlüsselwort: look",
   move_forward_tooltip: "Bewegt das Objekt in die gewählte Richtung: 'Vorwärts' entlang Blickrichtung, 'Seitlich' relativ zur Kamera, 'Strafe' quer zur Kamerarichtung.\nSchlüsselwort: push",
-  set_pivot_tooltip: "Setze den Pivotpunkt eines Objekts in X-, Y- und Z-Richtung.\nSchlüsselwort: pivot",
+  set_pivot_tooltip: "Setze den Ankerpunkt eines Objekts in X-, Y- und Z-Richtung.\nSchlüsselwort: Anker",
   min_centre_max_tooltip: "Wähle min, center oder max als Pivotpunkt.\nSchlüsselwort: minmax",
 
   // XR tooltips

--- a/locale/en.js
+++ b/locale/en.js
@@ -290,7 +290,7 @@ export default {
   rotate_to: "rotate %1 to x: %2 y: %3 z: %4",
   look_at: "look %1 at %2 y? %3",
   move_forward: "move %1 %2 speed: %3",
-  set_pivot: "set pivot of %1 x: %2 y: %3 z: %4",
+  set_pivot: "set anchor of %1\nx: %2 y: %3 z: %4",
   min_centre_max: "%1",
   
   // Custom block translations - XR blocks
@@ -480,7 +480,7 @@ export default {
   rotate_to_tooltip: "Rotate the mesh to point towards the  coordinates.\nKeyword: rotateto",
   look_at_tooltip: "Rotate the first mesh towards the position of the second mesh.\nKeyword: look",
   move_forward_tooltip: "Move the mesh in the specified direction. 'Forward' moves it in the direction it's pointing, 'sideways' moves it relative to the camera's direction, and 'strafe' moves it sideways relative to the camera's direction.\nKeyword: push",
-  set_pivot_tooltip: "Set the pivot point for a mesh on the X, Y, and Z axes\nKeyword: pivot",
+  set_pivot_tooltip: "Set the anchor point for a mesh on the X, Y, and Z axes\nKeyword: anchor",
   min_centre_max_tooltip: "Choose min, center, or max for the pivot point\nKeyword: minmax",
   
   // Tooltip translations - XR blocks

--- a/locale/es.js
+++ b/locale/es.js
@@ -283,7 +283,7 @@ export default {
   rotate_to: "rotar %1 a x: %2 y: %3 z: %4",
   look_at: "hacer que %1 mire a %2 ¿eje y? %3",
   move_forward: "mover %1 %2 velocidad %3",
-  set_pivot: "establecer pivote de %1 x: %2 y: %3 z: %4",
+  set_pivot: "establecer ancla de %1\nx: %2 y: %3 z: %4",
   min_centre_max: "%1",
 
   // Custom block translations - XR blocks
@@ -471,7 +471,7 @@ export default {
   rotate_to_tooltip: "Rota la malla para apuntar hacia las coordenadas.\nPalabra clave: rotateto",
   look_at_tooltip: "Rota la primera malla hacia la posición de la segunda.\nPalabra clave: look",
   move_forward_tooltip: "Mueve la malla en la dirección especificada. 'Forward' sigue su dirección, 'sideways' y 'strafe' se basan en la cámara.\nPalabra clave: push",
-  set_pivot_tooltip: "Establece el punto de pivote para una malla en los ejes X, Y y Z.\nPalabra clave: pivot",
+  set_pivot_tooltip: "Establece el punto de anclaje para una malla en los ejes X, Y y Z.\nPalabra clave: ancla",
   min_centre_max_tooltip: "Elige min, centro o max para el punto de pivote.\nPalabra clave: minmax",
 
   // Tooltip translations - XR blocks

--- a/locale/fr.js
+++ b/locale/fr.js
@@ -283,7 +283,7 @@ export default {
                                       rotate_to: "pivoter %1 vers x: %2 y: %3 z: %4",
                                       look_at: "regarder %1 vers %2 y ? %3",
                                       move_forward: "avancer %1 %2 vitesse %3",
-                                      set_pivot: "définir le pivot de %1 x: %2 y: %3 z: %4",
+                                      set_pivot: "définir l’ancre de %1\nx: %2 y: %3 z: %4",
                                       min_centre_max: "%1",
 
                                       // Custom block translations - XR blocks
@@ -471,7 +471,7 @@ export default {
                                       rotate_to_tooltip: "Fait tourner le maillage pour pointer vers les coordonnées.\nMot-clé: rotateto",
                                       look_at_tooltip: "Fait pivoter le premier maillage pour regarder vers la position du second.\nMot-clé: look",
                                       move_forward_tooltip: "Déplace le maillage dans la direction spécifiée. 'Forward' le fait avancer, 'sideways' le fait se déplacer par rapport à la caméra, 'strafe' le fait se déplacer latéralement.\nMot-clé: push",
-                                      set_pivot_tooltip: "Définit le point de pivot d’un maillage selon les axes X, Y et Z\nMot-clé: pivot",
+                                      set_pivot_tooltip: "Définit le point d’ancrage d’un maillage selon les axes X, Y et Z\nMot-clé: ancre",
                                       min_centre_max_tooltip: "Choisit min, centre ou max comme point de pivot\nMot-clé: minmax",
 
                                       // Tooltip translations - XR blocks

--- a/locale/it.js
+++ b/locale/it.js
@@ -313,7 +313,7 @@ export default {
   rotate_to: "ruota %1 a x: %2 y: %3 z: %4",
   look_at: "fai guardare %1 a %2 y? %3",
   move_forward: "muovi %1 %2 velocità %3",
-  set_pivot: "imposta perno di %1 x: %2 y: %3 z: %4",
+  set_pivot: "imposta ancoraggio di %1\nx: %2 y: %3 z: %4",
   min_centre_max: "%1",
 
   // Custom block translations - XR blocks
@@ -596,7 +596,7 @@ export default {
   move_forward_tooltip:
     "Muove la mesh nella direzione specificata. 'Avanti' segue la direzione in cui punta; 'laterale' si muove rispetto alla camera; 'strafe' si muove di lato rispetto alla camera.\nParola chiave: push",
   set_pivot_tooltip:
-    "Imposta il punto di perno di una mesh sugli assi X, Y e Z\nParola chiave: pivot",
+    "Imposta il punto di ancoraggio di una mesh sugli assi X, Y e Z\nParola chiave: ancora",
   min_centre_max_tooltip:
     "Scegli min, centro o max per il punto di perno\nParola chiave: minmax",
 

--- a/locale/pl.js
+++ b/locale/pl.js
@@ -283,7 +283,7 @@ export default {
   rotate_to: "obróć %1 do x: %2, y: %3, z: %4",
   look_at: "spójrz %1 na %2 y? %3",
   move_forward: "przesuń %1 %2 prędkość: %3",
-  set_pivot: "ustaw punkt obrotu %1 x: %2, y: %3, z: %4",
+  set_pivot: "ustaw punkt kotwiczenia %1\nx: %2, y: %3, z: %4",
   min_centre_max: "%1",
 
   // Custom block translations - XR blocks
@@ -473,7 +473,7 @@ export default {
   rotate_to_tooltip: "Obróć siatkę, by wskazywała na dane współrzędne.\nSłowo kluczowe: rotateto",
   look_at_tooltip: "Obróć pierwszą siatkę w stronę pozycji drugiej.\nSłowo kluczowe: look",
   move_forward_tooltip: "Przesuń siatkę: 'forward' = w kierunku, 'sideways' = względem kamery, 'strafe' = bocznie.\nSłowo kluczowe: push",
-  set_pivot_tooltip: "Ustaw punkt obrotu siatki na osiach X, Y i Z.\nSłowo kluczowe: pivot",
+  set_pivot_tooltip: "Ustaw punkt kotwiczenia siatki na osiach X, Y i Z.\nSłowo kluczowe: kotwica",
   min_centre_max_tooltip: "Wybierz min, centre lub max jako punkt obrotu.\nSłowo kluczowe: minmax",
 
   // Tooltip translations - XR blocks

--- a/locale/pt.js
+++ b/locale/pt.js
@@ -306,7 +306,7 @@ export default {
   rotate_to: "girar %1 para x: %2 y: %3 z: %4",
   look_at: "fazer %1 olhar para %2 y? %3",
   move_forward: "mover %1 %2 velocidade %3",
-  set_pivot: "definir pivô de %1 x: %2 y: %3 z: %4",
+  set_pivot: "definir âncora de %1\nx: %2 y: %3 z: %4",
   min_centre_max: "%1",
 
   // Custom block translations - XR blocks
@@ -591,7 +591,7 @@ export default {
   move_forward_tooltip:
     "Move o mesh na direção especificada. 'Frente' o move na direção que está apontando, 'lateral' move em relação à câmera e 'deslocamento' move lateralmente em relação à câmera.\nPalavra-chave: empurrar",
   set_pivot_tooltip:
-    "Define o ponto de pivô de um mesh nos eixos X, Y e Z.\nPalavra-chave: pivô",
+    "Define o ponto de âncora de um mesh nos eixos X, Y e Z.\nPalavra-chave: âncora",
   min_centre_max_tooltip:
     "Escolhe mínimo, centro ou máximo como ponto de pivô.\nPalavra-chave: minmax",
 

--- a/locale/sv.js
+++ b/locale/sv.js
@@ -306,7 +306,7 @@ export default {
       rotate_to: "rotera %1 till x: %2 y: %3 z: %4",
       look_at: "titta %1 på %2 y? %3",
       move_forward: "flytta %1 %2 hastighet %3",
-      set_pivot: "ställ in pivot för %1 x: %2 y: %3 z: %4",
+      set_pivot: "ställ in ankare för %1\nx: %2 y: %3 z: %4",
       min_centre_max: "%1",
 
       // Custom block translations - XR blocks
@@ -592,8 +592,8 @@ export default {
             "Rotera det första mesh-objektet mot det andra objektets position.\nKeyword: look",
       move_forward_tooltip:
             "Flytta mesh-objektet i angiven riktning. 'Framåt' flyttar det i riktningen det pekar, 'sida' i kamerans riktning och 'strafe' i sidled relativt kameran.\nKeyword: push",
-      set_pivot_tooltip:
-            "Ställ in pivotpunkten för ett mesh längs X-, Y- och Z-axeln\nKeyword: pivot",
+  set_pivot_tooltip:
+        "Ställ in ankarpunkten för ett mesh längs X-, Y- och Z-axeln\nKeyword: ankare",
       min_centre_max_tooltip:
             "Välj min, center eller max som pivotpunkt\nKeyword: minmax",
 


### PR DESCRIPTION
## Summary
- update the set pivot block labels across locales to use “anchor” and place coordinate labels on a new line
- adjust corresponding tooltips to reference anchor terminology

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936d659b9708326b42907987964f4a8)