### PR TITLE
Change Y-rotation of player in Sit Down example project from 180 to -180

### DIFF
--- a/examples/sit_down.json
+++ b/examples/sit_down.json
@@ -488,7 +488,7 @@
 																							"type": "math_number",
 																							"id": "3zW4Z,UIffbU^6%awX%[",
 																							"fields": {
-																								"NUM": 180
+																								"NUM": -180
 																							}
 																						}
 																					},


### PR DESCRIPTION
Fixes the case where the player character "over-rotates" when we click the block to make them sit on it upon starting the project:

https://github.com/user-attachments/assets/71facfe4-f911-4227-ba9b-c4e04dabb1f3

There are still further things to be done and considered, such as how much the character should rotate with respect to how far it has moved away from it.

I still plan to implement the rotation direction option to the `rotate_anim_seconds` block (as discussed privately).