### PR TITLE
Add missing locale keys for animation controls and menus

### DIFF
--- a/locale/de.js
+++ b/locale/de.js
@@ -307,7 +307,9 @@ export default {
 
   // Transform blocks
   move_by_xyz: "Position von %1 ändern um x: %2 y: %3 z: %4",
+  move_by_xyz_single: "Position von %1 ändern um %2 %3",
   move_to_xyz: "Position von %1 setzen auf x: %2 y: %3 z: %4 y? %5",
+  move_to_xyz_single: "Position von %1 setzen auf %2 %3",
   move_to: "Position von %1 setzen auf %2 y? %3",
   scale: "Skaliere %1 x: %2 y: %3 z: %4\nUrsprung x: %5 y: %6 z: %7",
   resize: "Größe ändern %1 x: %2 y: %3 z: %4\nUrsprung x: %5 y: %6 z: %7",
@@ -707,8 +709,12 @@ export default {
   // Tooltip translations - Transform blocks
   move_by_xyz_tooltip:
     "Bewege ein Objekt um den angegebenen Wert in X-, Y- und Z-Richtung.\nSchlüsselwort: move",
+  move_by_xyz_single_tooltip:
+    "Bewege ein Objekt um einen bestimmten Wert in X-, Y- oder Z-Richtung.\nSchlüsselwort: move",
   move_to_xyz_tooltip:
     "Teleportiert das Objekt zu den angegebenen Koordinaten. Optional Y-Achse nutzen.\nSchlüsselwort: moveby",
+  move_to_xyz_single_tooltip:
+    "Teleportiert das Objekt zur angegebenen einzelnen Koordinate.\nSchlüsselwort: moveby",
   move_to_tooltip:
     "Teleportiert das erste Objekt zur Position des zweiten.\nSchlüsselwort: moveto",
   scale_tooltip:
@@ -899,8 +905,9 @@ export default {
   Dance2_option: "Tanz 2",
   Dance3_option: "Tanz 3",
   Dance4_option: "Tanz 4",
-  Jump_Idle_option: "Sprung-Idle",
-  Jump_Land_option: "Landen",
+  JumpUp_option: "Hochsprung",
+  JumpIdle_option: "Sprung-Idle",
+  JumpLand_option: "Landen",
   Punch_option: "Schlagen",
   HitReact_option: "Getroffen",
   Idle_Hold_option: "Ruhen (Halten)",
@@ -914,6 +921,7 @@ export default {
   Stand_Up_option: "Aufstehen",
   Wobble_option: "Wackeln",
   Clap_option: "Klatschen",
+  Climb_rope_option: "Am Seil klettern",
 
   loading_ui: "Flock XR wird geladen...",
   loading_success_ui: "Flock XR erfolgreich geladen",
@@ -945,6 +953,9 @@ export default {
   tent_lights_ui: "⛺ Zeltlichter",
   my_place_ui: "🏠 Mein Ort",
   microbit_monkey_ui: "🐵 micro:bit-Affe",
+  tree_jump_ui: "🌳 Baum-Sprung",
+  shape_push_ui: "🔶 Form schieben",
+  alien_planet_ui: "👽 Alien-Planet",
 
   main_menu_ui: "Hauptmenü",
   menu_button_sr_label_ui: "Menü",
@@ -954,6 +965,7 @@ export default {
   project_save_ui: "Speichern",
   language_submenu_ui: "Sprache",
   about_submenu_ui: "Über",
+  hub_submenu_ui: "Hub",
   theme_submenu_ui: "Thema",
   light_theme_ui: "Hell",
   dark_theme_ui: "Dunkel 2",
@@ -1063,7 +1075,7 @@ export default {
   about_description_disclaimer_ui:
     " Du kannst es gern ausprobieren, aber beachte, dass sich noch Dinge ändern können und manche Funktionen noch nicht fertig sind. Wir suchen derzeit Unterstützung, um Flock weiterzuentwickeln, sodass du dich darauf verlassen kannst.",
   about_run_intro_ui:
-    "Schau dir die Demos oben an, um zu sehen, was möglich ist. Mach ein paar Änderungen und klicke auf",
+    "Sieh dir die Demos oben an, um zu sehen, was möglich ist. Nimm ein paar Änderungen vor und klicke auf",
   about_run_action_ui: "Start.",
   about_links_privacy_prefix_ui: "Sieh dir die ",
   about_links_privacy_label_ui: "Datenschutzerklärung",

--- a/locale/es.js
+++ b/locale/es.js
@@ -301,7 +301,9 @@ export default {
 
   // Custom block translations - Transform blocks
   move_by_xyz: "cambiar posición de %1 en x: %2 y: %3 z: %4",
+  move_by_xyz_single: "cambiar posición de %1 por %2 %3",
   move_to_xyz: "establecer posición de %1 en x: %2 y: %3 z: %4 ¿eje y? %5",
+  move_to_xyz_single: "establecer posición de %1 en %2 %3",
   move_to: "establecer posición de %1 en %2 ¿eje y? %3",
   scale: "escalar %1 x: %2 y: %3 z: %4\norigen x: %5 y: %6 z: %7",
   resize: "redimensionar %1 x: %2 y: %3 z: %4\norigen x: %5 y: %6 z: %7",
@@ -580,8 +582,12 @@ export default {
   // Tooltip translations - Transform blocks
   move_by_xyz_tooltip:
     "Mueve una malla cierta cantidad en direcciones x, y y z.\nPalabra clave: move",
+  move_by_xyz_single_tooltip:
+    "Mover una malla una cantidad dada en la dirección x, y o z.\nPalabra clave: move",
   move_to_xyz_tooltip:
     "Teletransporta la malla a las coordenadas. Opcionalmente, usa el eje Y.\nPalabra clave: moveby",
+  move_to_xyz_single_tooltip:
+    "Teletransporta la malla a la coordenada única especificada.\nPalabra clave: moveby",
   move_to_tooltip:
     "Teletransporta la primera malla a la ubicación de la segunda.\nPalabra clave: moveto",
   scale_tooltip:
@@ -888,8 +894,9 @@ export default {
   Dance2_option: "Baile2",
   Dance3_option: "Baile3",
   Dance4_option: "Baile4",
-  Jump_Idle_option: "Saltar Inactivo",
-  Jump_Land_option: "Aterrizaje de Salto",
+  JumpUp_option: "Saltar arriba",
+  JumpIdle_option: "Saltar Inactivo",
+  JumpLand_option: "Aterrizaje de Salto",
   Punch_option: "Golpear",
   HitReact_option: "Reacción al Golpe",
   Idle_Hold_option: "Inactivo Sostener",
@@ -903,6 +910,7 @@ export default {
   Stand_Up_option: "Levantarse",
   Wobble_option: "Tambalearse",
   Clap_option: "Aplaudir",
+  Climb_rope_option: "Trepar la cuerda",
 
   // HTML translations
   loading_ui: "Cargando Flock XR...",
@@ -933,6 +941,9 @@ export default {
   tent_lights_ui: "⛺ Carpa de Festival",
   my_place_ui: "🏠 Mi Lugar",
   microbit_monkey_ui: "🐵 Mono micro:bit",
+  tree_jump_ui: "🌳 Salto de árbol",
+  shape_push_ui: "🔶 Empujar forma",
+  alien_planet_ui: "👽 Planeta alienígena",
   character_designer_ui: "👚 Diseñador de personajes",
   sit_down_ui: "🪑 Siéntate",
 
@@ -944,6 +955,7 @@ export default {
   project_save_ui: "Guardar",
   language_submenu_ui: "Idioma",
   about_submenu_ui: "Acerca de",
+  hub_submenu_ui: "Centro",
 
   theme_submenu_ui: "Tema",
   light_theme_ui: "Claro",
@@ -986,7 +998,7 @@ export default {
   about_description_disclaimer_ui:
     " Por favor pruébalo, pero ten en cuenta que las cosas pueden cambiar y algunas funciones aún no están terminadas. Actualmente estamos buscando apoyo para desarrollar Flock para que puedas confiar en él.",
   about_run_intro_ui:
-    "Echa un vistazo a las demos arriba para ver lo que puedes hacer. Haz algunos cambios y haz clic en",
+    "Mira las demos para ver lo que puedes hacer. Realiza algunos cambios y haz clic en",
   about_run_action_ui: "ejecutar.",
   about_links_privacy_prefix_ui: "Consulta la ",
   about_links_privacy_label_ui: "política de privacidad",

--- a/locale/fr.js
+++ b/locale/fr.js
@@ -303,7 +303,9 @@ export default {
 
   // Custom block translations - Transform blocks
   move_by_xyz: "changer la position de %1 de x: %2 y: %3 z: %4",
+  move_by_xyz_single: "changer la position de %1 de %2 %3",
   move_to_xyz: "définir la position de %1 à x: %2 y: %3 z: %4 y ? %5",
+  move_to_xyz_single: "définir la position de %1 à %2 %3",
   move_to: "définir la position de %1 à %2 y ? %3",
   scale: "échelle %1 x: %2 y: %3 z: %4\norigine x: %5 y: %6 z: %7",
   resize: "redimensionner %1 x: %2 y: %3 z: %4\norigine x: %5 y: %6 z: %7",
@@ -585,8 +587,12 @@ export default {
   // Tooltip translations - Transform blocks
   move_by_xyz_tooltip:
     "Déplace un maillage d'une certaine valeur selon X, Y et Z.\nMot-clé: move",
+  move_by_xyz_single_tooltip:
+    "Déplacer un maillage d’un montant donné sur l’axe x, y ou z.\nMot-clé: move",
   move_to_xyz_tooltip:
     "Téléporte le maillage aux coordonnées données. Utilise l’axe Y en option.\nMot-clé: moveby",
+  move_to_xyz_single_tooltip:
+    "Téléporter le maillage vers la coordonnée unique indiquée.\nMot-clé: moveby",
   move_to_tooltip:
     "Téléporte le premier maillage à l’emplacement du second.\nMot-clé: moveto",
   scale_tooltip:
@@ -893,8 +899,9 @@ export default {
   Dance2_option: "Danse2",
   Dance3_option: "Danse3",
   Dance4_option: "Danse4",
-  Jump_Idle_option: "Saut stationnaire",
-  Jump_Land_option: "Atterrissage",
+  JumpUp_option: "Sauter vers le haut",
+  JumpIdle_option: "Saut stationnaire",
+  JumpLand_option: "Atterrissage",
   Punch_option: "Coup de poing",
   HitReact_option: "Réaction au coup",
   Idle_Hold_option: "Attente immobile",
@@ -908,6 +915,7 @@ export default {
   Stand_Up_option: "Se lever",
   Wobble_option: "Osciller",
   Clap_option: "Applaudir",
+  Climb_rope_option: "Grimper à la corde",
 
   // HTML translations
   loading_ui: "Chargement de Flock XR...",
@@ -938,6 +946,9 @@ export default {
   tent_lights_ui: "⛺ Tente de festival",
   my_place_ui: "🏠 Mon endroit",
   microbit_monkey_ui: "🐵 Singe micro:bit",
+  tree_jump_ui: "🌳 Saut d’arbre",
+  shape_push_ui: "🔶 Pousser la forme",
+  alien_planet_ui: "👽 Planète alien",
   character_designer_ui: "👚 Créateur de personnages",
 
   sit_down_ui: "🪑 Assieds-toi",
@@ -950,6 +961,7 @@ export default {
   project_save_ui: "Enregistrer",
   language_submenu_ui: "Langue",
   about_submenu_ui: "À propos",
+  hub_submenu_ui: "Hub",
 
   theme_submenu_ui: "Thème",
   light_theme_ui: "Clair",
@@ -991,7 +1003,7 @@ export default {
   about_description_disclaimer_ui:
     " Veuillez l’essayer, mais sachez que certaines choses peuvent changer et que certaines fonctionnalités ne sont pas encore terminées. Nous cherchons actuellement du soutien pour développer Flock afin que vous puissiez compter sur lui.",
   about_run_intro_ui:
-    "Regardez les démos ci-dessus pour voir ce que vous pouvez faire. Apportez quelques modifications, puis cliquez sur",
+    "Regardez les démos ci-dessus pour voir ce que vous pouvez faire. Faites quelques modifications et cliquez sur",
   about_run_action_ui: " exécuter.",
   about_links_privacy_prefix_ui: "Consultez la ",
   about_links_privacy_label_ui: "politique de confidentialité",

--- a/locale/it.js
+++ b/locale/it.js
@@ -306,7 +306,9 @@ export default {
 
   // Custom block translations - Transform blocks
   move_by_xyz: "cambia posizione di %1 di x: %2 y: %3 z: %4",
+  move_by_xyz_single: "cambia la posizione di %1 di %2 %3",
   move_to_xyz: "imposta la posizione di %1 su x: %2 y: %3 z: %4 y? %5",
+  move_to_xyz_single: "imposta la posizione di %1 a %2 %3",
   move_to: "imposta la posizione di %1 su %2 y? %3",
   scale: "scala %1 x: %2 y: %3 z: %4\norigine x: %5 y: %6 z: %7",
   resize: "ridimensiona %1 x: %2 y: %3 z: %4\norigine x: %5 y: %6 z: %7",
@@ -582,8 +584,12 @@ export default {
   // Tooltip translations - Transform blocks
   move_by_xyz_tooltip:
     "Muove una mesh di una certa quantità in x, y e z.\nParola chiave: move",
+  move_by_xyz_single_tooltip:
+    "Sposta una mesh di una determinata quantità nella direzione x, y o z.\nParola chiave: move",
   move_to_xyz_tooltip:
     "Teletrasporta la mesh alle coordinate. Facoltativamente usa l’asse Y.\nParola chiave: moveby",
+  move_to_xyz_single_tooltip:
+    "Teletrasporta la mesh alla coordinata singola specificata.\nParola chiave: moveby",
   move_to_tooltip:
     "Teletrasporta la prima mesh alla posizione della seconda mesh.\nParola chiave: moveto",
   scale_tooltip:
@@ -890,8 +896,9 @@ export default {
   Dance2_option: "Danza2",
   Dance3_option: "Danza3",
   Dance4_option: "Danza4",
-  Jump_Idle_option: "Salto fermo",
-  Jump_Land_option: "Atterra",
+  JumpUp_option: "Salto in alto",
+  JumpIdle_option: "Salto fermo",
+  JumpLand_option: "Atterra",
   Punch_option: "Pugno",
   HitReact_option: "Reazione colpo",
   Idle_Hold_option: "Fermo con oggetto",
@@ -905,6 +912,7 @@ export default {
   Stand_Up_option: "Alzati",
   Wobble_option: "Dondola",
   Clap_option: "Applaudi",
+  Climb_rope_option: "Arrampicati sulla corda",
 
   // HTML translations
   loading_ui: "Caricamento di Flock XR...",
@@ -937,6 +945,9 @@ export default {
   tent_lights_ui: "⛺ Tenda festival",
   my_place_ui: "🏠 Il mio posto",
   microbit_monkey_ui: "🐵 micro:bit scimmia",
+  tree_jump_ui: "🌳 Salto dall'albero",
+  shape_push_ui: "🔶 Spinta forma",
+  alien_planet_ui: "👽 Pianeta alieno",
 
   main_menu_ui: "Menu principale",
   menu_button_sr_label_ui: "Menu",
@@ -946,6 +957,7 @@ export default {
   project_save_ui: "Salva",
   language_submenu_ui: "Lingua",
   about_submenu_ui: "Informazioni",
+  hub_submenu_ui: "Hub",
 
   theme_submenu_ui: "Tema",
   light_theme_ui: "Chiaro",
@@ -986,7 +998,7 @@ export default {
   about_description_disclaimer_ui:
     " Provalo pure, ma tieni presente che le cose possono cambiare e alcune funzionalità non sono ancora complete. Stiamo cercando supporto per sviluppare Flock in modo che tu possa farci affidamento.",
   about_run_intro_ui:
-    "Dai un’occhiata alle demo sopra per vedere cosa puoi fare. Fai qualche modifica e clicca",
+    "Guarda le demo sopra per vedere cosa puoi fare. Fai qualche modifica e clicca su",
   about_run_action_ui: "esegui.",
   about_links_privacy_prefix_ui: "Consulta la ",
   about_links_privacy_label_ui: "privacy policy",

--- a/locale/pl.js
+++ b/locale/pl.js
@@ -303,7 +303,9 @@ export default {
 
   // Custom block translations - Transform blocks
   move_by_xyz: "zmień pozycję %1 o x: %2, y: %3, z: %4",
+  move_by_xyz_single: "zmień położenie %1 o %2 %3",
   move_to_xyz: "ustaw pozycję %1 na x: %2, y: %3, z: %4 y? %5",
+  move_to_xyz_single: "ustaw położenie %1 na %2 %3",
   move_to: "ustaw pozycję %1 na %2 y? %3",
   scale: "skaluj %1 x: %2, y: %3, z: %4\npunkt odniesienia x: %5, y: %6, z: %7",
   resize:
@@ -579,8 +581,12 @@ export default {
   // Tooltip translations - Transform blocks
   move_by_xyz_tooltip:
     "Przesuń siatkę o określoną wartość w osiach x, y i z.\nSłowo kluczowe: move",
+  move_by_xyz_single_tooltip:
+    "Przesuń siatkę o podaną wartość w osi x, y lub z.\nSłowo kluczowe: move",
   move_to_xyz_tooltip:
     "Teleportuj siatkę do koordynatów. Opcjonalnie: użyj osi Y.\nSłowo kluczowe: moveby",
+  move_to_xyz_single_tooltip:
+    "Teleportuj siatkę do podanej pojedynczej współrzędnej.\nSłowo kluczowe: moveby",
   move_to_tooltip:
     "Teleportuj pierwszą siatkę do pozycji drugiej.\nSłowo kluczowe: moveto",
   scale_tooltip:
@@ -882,13 +888,15 @@ export default {
   Jump_option: "Skok",
   Flip_option: "Salto",
 
+  JumpUp_option: "Skok w górę",
+
   Dance1_option: "Taniec 1",
   Dance2_option: "Taniec 2",
   Dance3_option: "Taniec 3",
   Dance4_option: "Taniec 4",
 
-  Jump_Idle_option: "Skok – bezczynność",
-  Jump_Land_option: "Lądowanie",
+  JumpIdle_option: "Skok – bezczynność",
+  JumpLand_option: "Lądowanie",
   Punch_option: "Cios",
   HitReact_option: "Reakcja na uderzenie",
 
@@ -905,6 +913,7 @@ export default {
   Stand_Up_option: "Wstawanie",
   Wobble_option: "Chwianie",
   Clap_option: "Klaśnięcie",
+  Climb_rope_option: "Wspinaj się po linie",
 
   // HTML translations
   loading_ui: "Ładowanie Flock XR…",
@@ -935,6 +944,9 @@ export default {
   tent_lights_ui: "⛺ Światełka namiotu",
   my_place_ui: "🏠 Moje miejsce",
   microbit_monkey_ui: "🐵 małpa micro:bit",
+  tree_jump_ui: "🌳 Skok z drzewa",
+  shape_push_ui: "🔶 Pchnięcie kształtu",
+  alien_planet_ui: "👽 Obca planeta",
   character_designer_ui: "👚 Kreator postaci",
   sit_down_ui: "🪑 Usiądź",
 
@@ -946,6 +958,7 @@ export default {
   project_save_ui: "Zapisz",
   language_submenu_ui: "Język",
   about_submenu_ui: "O programie",
+  hub_submenu_ui: "Hub",
 
   theme_submenu_ui: "Motyw",
   light_theme_ui: "Jasny",
@@ -985,7 +998,7 @@ export default {
   about_description_disclaimer_ui:
     " Wypróbuj go, ale miej na uwadze, że rzeczy mogą się zmieniać i niektóre funkcje nie są jeszcze ukończone. Aktualnie poszukujemy wsparcia, aby Flock XR mógł stać się stabilny.",
   about_run_intro_ui:
-    "Spójrz na powyższe dema, aby zobaczyć, co możesz zrobić. Wprowadź zmiany i kliknij",
+    "Zobacz powyższe dema, aby dowiedzieć się, co możesz zrobić. Wprowadź kilka zmian i kliknij",
   about_run_action_ui: "uruchom.",
   about_links_privacy_prefix_ui: "Zobacz ",
   about_links_privacy_label_ui: "politykę prywatności",

--- a/locale/pt.js
+++ b/locale/pt.js
@@ -301,7 +301,9 @@ export default {
 
   // Custom block translations - Transform blocks
   move_by_xyz: "alterar posição de %1 em x: %2 y: %3 z: %4",
+  move_by_xyz_single: "alterar posição de %1 em %2 %3",
   move_to_xyz: "definir posição de %1 para x: %2 y: %3 z: %4 y? %5",
+  move_to_xyz_single: "definir posição de %1 para %2 %3",
   move_to: "definir posição de %1 para %2 y? %3",
   scale: "escalar %1 x: %2 y: %3 z: %4\norigem x: %5 y: %6 z: %7",
   resize: "redimensionar %1 x: %2 y: %3 z: %4\norigem x: %5 y: %6 z: %7",
@@ -578,8 +580,12 @@ export default {
   // Tooltip translations - Transform blocks
   move_by_xyz_tooltip:
     "Move um mesh uma certa distância nas direções x, y e z.\nPalavra-chave: mover",
+  move_by_xyz_single_tooltip:
+    "Mover uma malha uma determinada quantidade na direção x, y ou z.\nPalavra-chave: mover",
   move_to_xyz_tooltip:
     "Teleporta o mesh para as coordenadas. Opcionalmente, use o eixo Y.\nPalavra-chave: moverpor",
+  move_to_xyz_single_tooltip:
+    "Teletransportar a malha para a coordenada única especificada.\nPalavra-chave: moverpor",
   move_to_tooltip:
     "Teleporta o primeiro mesh para a localização do segundo mesh.\nPalavra-chave: moverte",
   scale_tooltip:
@@ -885,8 +891,9 @@ export default {
   Dance2_option: "Dança2",
   Dance3_option: "Dança3",
   Dance4_option: "Dança4",
-  Jump_Idle_option: "Salto em Espera",
-  Jump_Land_option: "Aterrar",
+  JumpUp_option: "Saltar para cima",
+  JumpIdle_option: "Salto em Espera",
+  JumpLand_option: "Aterrar",
   Punch_option: "Soco",
   HitReact_option: "Reação ao Impacto",
   Idle_Hold_option: "Parado com Objeto",
@@ -900,6 +907,7 @@ export default {
   Stand_Up_option: "Levantar-se",
   Wobble_option: "Oscilar",
   Clap_option: "Bater Palmas",
+  Climb_rope_option: "Subir a corda",
 
   // HTML translations
   loading_ui: "A carregar o Flock XR...",
@@ -930,6 +938,9 @@ export default {
   tent_lights_ui: "⛺ Tenda de Festival",
   my_place_ui: "🏠 O Meu Espaço",
   microbit_monkey_ui: "🐵 Macaco micro:bit",
+  tree_jump_ui: "🌳 Salto da árvore",
+  shape_push_ui: "🔶 Empurrar forma",
+  alien_planet_ui: "👽 Planeta alienígena",
   character_designer_ui: "👚 Criador de personagens",
   sit_down_ui: "🪑 Senta-te",
 
@@ -941,6 +952,7 @@ export default {
   project_save_ui: "Guardar",
   language_submenu_ui: "Idioma",
   about_submenu_ui: "Sobre",
+  hub_submenu_ui: "Hub",
 
   theme_submenu_ui: "Tema",
   light_theme_ui: "Claro",
@@ -980,7 +992,7 @@ export default {
   about_description_disclaimer_ui:
     " Por favor, experimenta, mas tem em atenção que algumas funcionalidades podem ainda estar por terminar e que o projeto pode sofrer alterações. Estamos à procura de apoio para continuar a desenvolver o Flock de forma fiável.",
   about_run_intro_ui:
-    "Vê as demonstrações acima para veres o que podes fazer. Faz algumas alterações e clica em",
+    "Veja as demonstrações para perceber o que pode fazer. Faça algumas alterações e clique em",
   about_run_action_ui: "executar.",
   about_links_privacy_prefix_ui: "Consulta a ",
   about_links_privacy_label_ui: "política de privacidade",

--- a/locale/sv.js
+++ b/locale/sv.js
@@ -299,7 +299,9 @@ export default {
 
       // Custom block translations - Transform blocks
       move_by_xyz: "ändra positionen för %1 med x: %2 y: %3 z: %4",
+      move_by_xyz_single: "ändra positionen för %1 med %2 %3",
       move_to_xyz: "ställ in positionen för %1 till x: %2 y: %3 z: %4 y? %5",
+      move_to_xyz_single: "ställ in positionen för %1 till %2 %3",
       move_to: "ställ in positionen för %1 till %2 y? %3",
       scale: "skala %1 x: %2 y: %3 z: %4\nursprung x: %5 y: %6 z: %7",
       resize: "ändra storlek på %1 x: %2 y: %3 z: %4\nursprung x: %5 y: %6 z: %7",
@@ -578,8 +580,12 @@ export default {
       // Tooltip translations - Transform blocks
       move_by_xyz_tooltip:
             "Flytta ett mesh ett angivet värde i x-, y- och z-led.\nKeyword: move",
+      move_by_xyz_single_tooltip:
+            "Flytta ett mesh en viss mängd i x-, y- eller z-led.\nKeyword: move",
       move_to_xyz_tooltip:
             "Teleportera mesh-objektet till angivna koordinater. Du kan välja att använda Y-axeln.\nKeyword: moveby",
+      move_to_xyz_single_tooltip:
+            "Teleportera mesh:en till den angivna enskilda koordinaten.\nKeyword: moveby",
       move_to_tooltip:
             "Teleportera det första mesh-objektet till det andra mesh-objektets position.\nKeyword: moveto",
       scale_tooltip:
@@ -885,8 +891,9 @@ export default {
       Dance2_option: "Dans 2",
       Dance3_option: "Dans 3",
       Dance4_option: "Dans 4",
-      Jump_Idle_option: "Hoppa vila",
-      Jump_Land_option: "Hoppa landa",
+      JumpUp_option: "Hoppa upp",
+      JumpIdle_option: "Hoppa vila",
+      JumpLand_option: "Hoppa landa",
       Punch_option: "Slag",
       HitReact_option: "Reaktion vid träff",
       Idle_Hold_option: "Vila håll",
@@ -900,6 +907,7 @@ export default {
       Stand_Up_option: "Ställ dig upp",
       Wobble_option: "Vingla",
       Clap_option: "Applådera",
+      Climb_rope_option: "Klättra rep",
 
       // HTML translations
       loading_ui: "Laddar Flock XR...",
@@ -930,6 +938,9 @@ export default {
       tent_lights_ui: "⛺ Festivaltält",
       my_place_ui: "🏠 Mitt ställe",
       microbit_monkey_ui: "🐵 micro:bit-apa",
+      tree_jump_ui: "🌳 Träd-hopp",
+      shape_push_ui: "🔶 Skjuta form",
+      alien_planet_ui: "👽 Alienplanet",
       character_designer_ui: "👚 Karaktärsdesign",
       sit_down_ui: "🪑 Sätt dig",
 
@@ -941,6 +952,7 @@ export default {
       project_save_ui: "Spara",
       language_submenu_ui: "Språk",
       about_submenu_ui: "Om",
+      hub_submenu_ui: "Nav",
 
       theme_submenu_ui: "Tema",
       light_theme_ui: "Ljust",
@@ -980,7 +992,7 @@ export default {
       about_description_disclaimer_ui:
             " Testa gärna, men kom ihåg att saker kan ändras och vissa funktioner är ännu inte färdiga. Vi söker för närvarande stöd för att utveckla Flock så att du kan lita på det.",
       about_run_intro_ui:
-            "Titta på demona ovan för att se vad du kan göra. Gör några ändringar och klicka på",
+            "Titta på demoversionerna ovan för att se vad du kan göra. Gör några ändringar och klicka på",
       about_run_action_ui: "kör.",
       about_links_privacy_prefix_ui: "Se ",
       about_links_privacy_label_ui: "integritetspolicyn",


### PR DESCRIPTION
## Summary
- add missing animation, transform, and UI locale keys across non-English locale files
- provide translations for new options and update about page run intro strings
- include new menu and scene names to keep locales aligned with English

## Testing
- not run (localization change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943aef2aca08326ba35fb502ae69b03)