### PR TITLE
Add mesh exists translation strings

### DIFF
--- a/blocks/sensing.js
+++ b/blocks/sensing.js
@@ -237,7 +237,7 @@ export function defineSensingBlocks() {
                 init: function () {
                         this.jsonInit({
                                 type: "mesh_exists",
-                                message0: "%1 exists",
+                                message0: translate("mesh_exists"),
                                 args0: [
                                         {
                                                 type: "field_variable",
@@ -247,7 +247,7 @@ export function defineSensingBlocks() {
                                 ],
                                 output: "Boolean",
                                 colour: categoryColours["Sensing"],
-                                tooltip: "Returns true if the mesh with this name is present in the scene.",
+                                tooltip: getTooltip("mesh_exists"),
                         });
                         this.setHelpUrl(getHelpUrlFor(this.type));
                         this.setStyle("sensing_blocks");

--- a/locale/de.js
+++ b/locale/de.js
@@ -255,6 +255,7 @@ export default {
   time: "Zeit in s",
   distance_to: "Entfernung von %1 nach %2",
   touching_surface: "Berührt %1 eine Oberfläche",
+  mesh_exists: "existiert %1?",
   get_property: "Hole %1 von %2",
   canvas_controls: "Leinwandsteuerung %1",
   button_controls: "Buttonsteuerung %1 aktiviert %2 Farbe %3",
@@ -648,6 +649,8 @@ export default {
   distance_to_tooltip: "Berechnet den Abstand zwischen zwei Objekten.",
   touching_surface_tooltip:
     "Prüft, ob das Objekt eine Oberfläche berührt.\nSchlüsselwort: surface",
+  mesh_exists_tooltip:
+    "Gibt true zurück, wenn das Mesh mit diesem Namen in der Szene vorhanden ist.",
   get_property_tooltip:
     "Gibt den Wert der gewählten Eigenschaft eines Objekts zurück.\nSchlüsselwort: get",
   canvas_controls_tooltip:

--- a/locale/en.js
+++ b/locale/en.js
@@ -252,6 +252,7 @@ export default {
   time: "time in s",
   distance_to: "distance from %1 to %2",
   touching_surface: "is %1 touching surface",
+  mesh_exists: "does %1 exist?",
   get_property: "get %1 of %2",
   canvas_controls: "canvas controls %1",
   button_controls: "button controls %1 enabled: %2 color: %3",
@@ -513,6 +514,8 @@ export default {
   distance_to_tooltip: "Calculate the distance between two meshes.",
   touching_surface_tooltip:
     "Check if the mesh is touching a surface.\nKeyword: surface",
+  mesh_exists_tooltip:
+    "Return true if the mesh with this name is present in the scene.",
   get_property_tooltip:
     "Get the value of the selected property of a mesh.\nKeyword: get",
   canvas_controls_tooltip:

--- a/locale/fr.js
+++ b/locale/fr.js
@@ -250,6 +250,7 @@ export default {
   time: "temps en s",
   distance_to: "distance de %1 à %2",
   touching_surface: "%1 touche la surface",
+  mesh_exists: "%1 existe-t-il ?",
   get_property: "obtenir %1 de %2",
   canvas_controls: "contrôles de la toile %1",
   button_controls: "contrôles du bouton %1 activé %2 couleur %3",
@@ -526,6 +527,8 @@ export default {
   distance_to_tooltip: "Calcule la distance entre deux maillages.",
   touching_surface_tooltip:
     "Vérifie si le maillage touche une surface.\nMot-clé: surface",
+  mesh_exists_tooltip:
+    "Renvoie vrai si le maillage portant ce nom est présent dans la scène.",
   get_property_tooltip:
     "Obtient la valeur de la propriété sélectionnée d’un maillage.\nMot-clé: get",
   canvas_controls_tooltip:

--- a/locale/it.js
+++ b/locale/it.js
@@ -254,6 +254,7 @@ export default {
   time: "tempo in s",
   distance_to: "distanza da %1 a %2",
   touching_surface: "%1 tocca una superficie",
+  mesh_exists: "%1 esiste?",
   get_property: "ottieni %1 di %2",
   canvas_controls: "controlli canvas %1",
   button_controls: "controlli pulsante %1 abilitati %2 colore %3",
@@ -524,6 +525,8 @@ export default {
   distance_to_tooltip: "Calcola la distanza tra due mesh.",
   touching_surface_tooltip:
     "Controlla se la mesh tocca una superficie.\nParola chiave: surface",
+  mesh_exists_tooltip:
+    "Restituisce vero se la mesh con questo nome è presente nella scena.",
   get_property_tooltip:
     "Ottiene il valore della proprietà selezionata di una mesh.\nParola chiave: get",
   canvas_controls_tooltip:

--- a/locale/pl.js
+++ b/locale/pl.js
@@ -251,6 +251,7 @@ export default {
   time: "czas w s",
   distance_to: "odległość od %1 do %2",
   touching_surface: "czy %1 dotyka powierzchni?",
+  mesh_exists: "czy %1 istnieje?",
   get_property: "pobierz %1 z %2",
   canvas_controls: "kontrola płótna %1",
   button_controls: "kontrolki przycisku %1 włączone: %2 kolor: %3",
@@ -520,6 +521,8 @@ export default {
   distance_to_tooltip: "Oblicz odległość między siatkami %1 i %2.",
   touching_surface_tooltip:
     "Sprawdź, czy siatka %1 dotyka powierzchni.\nSłowo kluczowe: surface",
+  mesh_exists_tooltip:
+    "Zwraca true, jeśli siatka o tej nazwie znajduje się na scenie.",
   get_property_tooltip:
     "Pobierz wartość właściwości %1 z siatki %2.\nSłowo kluczowe: get",
   canvas_controls_tooltip:

--- a/locale/pt.js
+++ b/locale/pt.js
@@ -249,6 +249,7 @@ export default {
   time: "tempo em s",
   distance_to: "distância de %1 até %2",
   touching_surface: "%1 está tocando superfície",
+  mesh_exists: "o %1 existe?",
   get_property: "obter %1 de %2",
   canvas_controls: "controles de tela %1",
   button_controls: "controles de botão %1 ativado %2 cor %3",
@@ -516,6 +517,8 @@ export default {
   distance_to_tooltip: "Calcula a distância entre dois meshes.",
   touching_surface_tooltip:
     "Verifica se o mesh está tocando uma superfície.\nPalavra-chave: superfície",
+  mesh_exists_tooltip:
+    "Retorna verdadeiro se a malha com esse nome estiver presente na cena.",
   get_property_tooltip:
     "Obtém o valor da propriedade selecionada de um mesh.\nPalavra-chave: obter",
   canvas_controls_tooltip:

--- a/locale/sv.js
+++ b/locale/sv.js
@@ -249,6 +249,7 @@ export default {
       time: "tid i s",
       distance_to: "avstånd från %1 till %2",
       touching_surface: "är %1 i kontakt med yta",
+      mesh_exists: "finns %1?",
       get_property: "hämta %1 från %2",
       canvas_controls: "canvas kontroller %1",
       button_controls: "knappkontroller %1 aktiverad %2 färg %3",
@@ -515,6 +516,8 @@ export default {
       distance_to_tooltip: "Beräkna avståndet mellan två mesh-objekt.",
       touching_surface_tooltip:
             "Kontrollera om mesh-objektet rör vid en yta.\nKeyword: surface",
+      mesh_exists_tooltip:
+            "Returnerar sant om meshen med det här namnet finns i scenen.",
       get_property_tooltip:
             "Hämta värdet på den valda egenskapen för ett mesh.\nKeyword: get",
       canvas_controls_tooltip:


### PR DESCRIPTION
## Summary
- localize the mesh exists sensing block to use translation strings
- add mesh_exists message and tooltip entries across non-Spanish locales

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69457b4a042c8326b8df5b0fde7e66e0)