### PR TITLE
Add translations for untranslated blocks

### DIFF
--- a/blocks/blocks.js
+++ b/blocks/blocks.js
@@ -2,7 +2,7 @@ import * as Blockly from "blockly";
 //import "@blockly/block-plus-minus";
 import * as BlockDynamicConnection from "@blockly/block-dynamic-connection";
 import { toolbox } from "../toolbox.js";
-import { getOption, translate } from "../main/translation.js";
+import { getOption, translate, getTooltip } from "../main/translation.js";
 import { flock } from "../flock.js";
 
 import {
@@ -1064,7 +1064,7 @@ export function defineBlocks() {
     init: function () {
       this.jsonInit({
         type: "rotate_camera",
-        message0: "rotate camera by %1 degrees",
+        message0: translate("rotate_camera"),
         args0: [
           {
             type: "input_value",
@@ -1076,8 +1076,7 @@ export function defineBlocks() {
         previousStatement: null,
         nextStatement: null,
         colour: categoryColours["Transform"],
-        tooltip:
-          "Rotate the camera left or right by the given degrees.\nKeyword: rotate",
+        tooltip: getTooltip("rotate_camera"),
       });
       this.setHelpUrl(getHelpUrlFor(this.type));
     },
@@ -1087,7 +1086,7 @@ export function defineBlocks() {
     init: function () {
       this.jsonInit({
         type: "up",
-        message0: "up %1 force %2",
+        message0: translate("up"),
         args0: [
           {
             type: "field_variable",
@@ -1103,7 +1102,7 @@ export function defineBlocks() {
         previousStatement: null,
         nextStatement: null,
         colour: categoryColours["Transform"],
-        tooltip: "Apply the specified upwards force.\nKeyword: up",
+        tooltip: getTooltip("up"),
       });
       this.setHelpUrl(getHelpUrlFor(this.type));
     },
@@ -1113,7 +1112,7 @@ export function defineBlocks() {
     init: function () {
       this.jsonInit({
         type: "random_seeded_int",
-        message0: "random integer from %1 to %2 seed: %3",
+        message0: translate("random_seeded_int"),
         args0: [
           {
             type: "input_value",
@@ -1137,7 +1136,7 @@ export function defineBlocks() {
         inputsInline: true,
         output: "Number",
         colour: 230,
-        tooltip: "Generate a random integer with a seed.\n Keyword: seed",
+        tooltip: getTooltip("random_seeded_int"),
       });
       this.setHelpUrl(getHelpUrlFor(this.type));
     },
@@ -1147,7 +1146,7 @@ export function defineBlocks() {
     init: function () {
       this.jsonInit({
         type: "to_number",
-        message0: "convert %1 to %2",
+        message0: translate("to_number"),
         args0: [
           {
             type: "input_value",
@@ -1166,7 +1165,7 @@ export function defineBlocks() {
         inputsInline: true,
         output: "Number",
         colour: 230,
-        tooltip: "Convert a string to an integer or float.",
+        tooltip: getTooltip("to_number"),
       });
       this.setHelpUrl(getHelpUrlFor(this.type));
     },

--- a/locale/de.js
+++ b/locale/de.js
@@ -306,6 +306,10 @@ export default {
   create_3d_text:
     "Füge 3D‑Text hinzu %1: %2 Schrift: %3 Größe: %4 Farbe: %5\nTiefe: %6 x: %7 y: %8 z: %9",
 
+  // Math blocks
+  random_seeded_int: "zufällige Ganzzahl von %1 bis %2 Seed: %3",
+  to_number: "konvertiere %1 zu %2",
+
   // Transform blocks
   move_by_xyz: "Position von %1 ändern um x: %2 y: %3 z: %4",
   move_by_xyz_single: "Position von %1 ändern um %2 %3",
@@ -318,6 +322,8 @@ export default {
   rotate_to: "Rotiere %1 zu x: %2 y: %3 z: %4",
   look_at: "Lass %1 auf %2 sehen y? %3",
   move_forward: "Bewege %1 %2 Geschwindigkeit %3",
+  rotate_camera: "Kamera um %1 Grad drehen",
+  up: "nach oben %1 Kraft %2",
   set_pivot: "Setze Anker von %1\nx: %2 y: %3 z: %4",
   min_centre_max: "%1",
 
@@ -709,6 +715,12 @@ export default {
     "Stelle dem Benutzer eine Frage und warte auf die Eingabe. Ergebnis wird in einer Variable gespeichert.",
   create_3d_text_tooltip: "Erstelle 3D-Text in der Szene.",
 
+  // Tooltip translations - Math blocks
+  random_seeded_int_tooltip:
+    "Erzeuge eine zufällige Ganzzahl mit Seed.\nSchlüsselwort: seed",
+  to_number_tooltip:
+    "Konvertiere eine Zeichenkette in eine Ganzzahl oder Gleitkommazahl.",
+
   // Tooltip translations - Transform blocks
   move_by_xyz_tooltip:
     "Bewege ein Objekt um den angegebenen Wert in X-, Y- und Z-Richtung.\nSchlüsselwort: move",
@@ -732,6 +744,9 @@ export default {
     "Dreht das erste Objekt so, dass es auf die Position des zweiten zeigt.\nSchlüsselwort: look",
   move_forward_tooltip:
     "Bewegt das Objekt in die gewählte Richtung: 'Vorwärts' entlang Blickrichtung, 'Seitlich' relativ zur Kamera, 'Strafe' quer zur Kamerarichtung.\nSchlüsselwort: push",
+  rotate_camera_tooltip:
+    "Drehe die Kamera um die angegebenen Grad nach links oder rechts.\nSchlüsselwort: rotate",
+  up_tooltip: "Wende die angegebene Aufwärtskraft an.\nSchlüsselwort: up",
   set_pivot_tooltip:
     "Setze den Ankerpunkt eines Objekts in X-, Y- und Z-Richtung.\nSchlüsselwort: Anker",
   min_centre_max_tooltip:

--- a/locale/en.js
+++ b/locale/en.js
@@ -302,6 +302,10 @@ export default {
   create_3d_text:
     "add %1 3D text: %2 font: %3 size: %4 color: %5\ndepth: %6 x: %7 y: %8 z: %9 ",
 
+  // Custom block translations - Math blocks
+  random_seeded_int: "random integer from %1 to %2 seed: %3",
+  to_number: "convert %1 to %2",
+
   // Custom block translations - Transform blocks
   move_by_xyz: "change position of %1 by x: %2 y: %3 z: %4",
   move_by_xyz_single: "change position of %1 by %2 %3",
@@ -314,6 +318,8 @@ export default {
   rotate_to: "rotate %1 to x: %2 y: %3 z: %4",
   look_at: "look %1 at %2 y? %3",
   move_forward: "move %1 %2 speed: %3",
+  rotate_camera: "rotate camera by %1 degrees",
+  up: "up %1 force %2",
   set_pivot: "set anchor of %1\nx: %2 y: %3 z: %4",
   min_centre_max: "%1",
 
@@ -572,6 +578,11 @@ export default {
     "Ask the user a question and wait for input. Stores the result in a variable.",
   create_3d_text_tooltip: "Create 3D text in the scene.",
 
+  // Tooltip translations - Math blocks
+  random_seeded_int_tooltip:
+    "Generate a random integer with a seed.\nKeyword: seed",
+  to_number_tooltip: "Convert a string to an integer or float.",
+
   // Tooltip translations - Transform blocks
   move_by_xyz_tooltip:
     "Move a mesh a given amount in x y and z directions.\nKeyword: move",
@@ -595,6 +606,9 @@ export default {
     "Rotate the first mesh towards the position of the second mesh.\nKeyword: look",
   move_forward_tooltip:
     "Move the mesh in the specified direction. 'Forward' moves it in the direction it's pointing, 'sideways' moves it relative to the camera's direction, and 'strafe' moves it sideways relative to the camera's direction.\nKeyword: push",
+  rotate_camera_tooltip:
+    "Rotate the camera left or right by the given degrees.\nKeyword: rotate",
+  up_tooltip: "Apply the specified upwards force.\nKeyword: up",
   set_pivot_tooltip:
     "Set the anchor point for a mesh on the X, Y, and Z axes\nKeyword: anchor",
   min_centre_max_tooltip:

--- a/locale/fr.js
+++ b/locale/fr.js
@@ -302,6 +302,10 @@ export default {
   create_3d_text:
     "ajouter texte 3D %1: %2 police: %3 taille: %4 couleur: %5\nprofondeur: %6 x: %7 y: %8 z: %9",
 
+  // Custom block translations - Math blocks
+  random_seeded_int: "entier aléatoire de %1 à %2 graine : %3",
+  to_number: "convertir %1 en %2",
+
   // Custom block translations - Transform blocks
   move_by_xyz: "changer la position de %1 de x: %2 y: %3 z: %4",
   move_by_xyz_single: "changer la position de %1 de %2 %3",
@@ -314,6 +318,8 @@ export default {
   rotate_to: "pivoter %1 vers x: %2 y: %3 z: %4",
   look_at: "regarder %1 vers %2 y ? %3",
   move_forward: "avancer %1 %2 vitesse %3",
+  rotate_camera: "faire pivoter la caméra de %1 degrés",
+  up: "vers le haut %1 force %2",
   set_pivot: "définir l’ancre de %1\nx: %2 y: %3 z: %4",
   min_centre_max: "%1",
 
@@ -587,6 +593,12 @@ export default {
     "Pose une question à l’utilisateur et attend une réponse. Stocke le résultat dans une variable.",
   create_3d_text_tooltip: "Crée du texte 3D dans la scène.",
 
+  // Tooltip translations - Math blocks
+  random_seeded_int_tooltip:
+    "Génère un entier aléatoire avec une graine.\nMot-clé: seed",
+  to_number_tooltip:
+    "Convertit une chaîne en entier ou en nombre flottant.",
+
   // Tooltip translations - Transform blocks
   move_by_xyz_tooltip:
     "Déplace un maillage d'une certaine valeur selon X, Y et Z.\nMot-clé: move",
@@ -610,6 +622,9 @@ export default {
     "Fait pivoter le premier maillage pour regarder vers la position du second.\nMot-clé: look",
   move_forward_tooltip:
     "Déplace le maillage dans la direction spécifiée. 'Forward' le fait avancer, 'sideways' le fait se déplacer par rapport à la caméra, 'strafe' le fait se déplacer latéralement.\nMot-clé: push",
+  rotate_camera_tooltip:
+    "Fait pivoter la caméra vers la gauche ou la droite du nombre de degrés indiqué.\nMot-clé: rotate",
+  up_tooltip: "Applique la force vers le haut spécifiée.\nMot-clé: up",
   set_pivot_tooltip:
     "Définit le point d’ancrage d’un maillage selon les axes X, Y et Z\nMot-clé: ancre",
   min_centre_max_tooltip:

--- a/locale/it.js
+++ b/locale/it.js
@@ -305,6 +305,10 @@ export default {
   create_3d_text:
     "aggiungi %1 testo 3D: %2 font: %3 dimensione: %4 colore: %5\nprofondità: %6 x: %7 y: %8 z: %9 ",
 
+  // Custom block translations - Math blocks
+  random_seeded_int: "numero intero casuale da %1 a %2 seed: %3",
+  to_number: "converti %1 in %2",
+
   // Custom block translations - Transform blocks
   move_by_xyz: "cambia posizione di %1 di x: %2 y: %3 z: %4",
   move_by_xyz_single: "cambia la posizione di %1 di %2 %3",
@@ -317,6 +321,8 @@ export default {
   rotate_to: "ruota %1 a x: %2 y: %3 z: %4",
   look_at: "fai guardare %1 a %2 y? %3",
   move_forward: "muovi %1 %2 velocità %3",
+  rotate_camera: "ruota la camera di %1 gradi",
+  up: "su %1 forza %2",
   set_pivot: "imposta ancoraggio di %1\nx: %2 y: %3 z: %4",
   min_centre_max: "%1",
 
@@ -584,6 +590,11 @@ export default {
     "Chiede all’utente una risposta e attende l’input. Salva il risultato in una variabile.",
   create_3d_text_tooltip: "Crea testo 3D nella scena.",
 
+  // Tooltip translations - Math blocks
+  random_seeded_int_tooltip:
+    "Genera un numero intero casuale con un seed.\nParola chiave: seed",
+  to_number_tooltip: "Converte una stringa in intero o float.",
+
   // Tooltip translations - Transform blocks
   move_by_xyz_tooltip:
     "Muove una mesh di una certa quantità in x, y e z.\nParola chiave: move",
@@ -607,6 +618,9 @@ export default {
     "Ruota la prima mesh verso la posizione della seconda mesh.\nParola chiave: look",
   move_forward_tooltip:
     "Muove la mesh nella direzione specificata. 'Avanti' segue la direzione in cui punta; 'laterale' si muove rispetto alla camera; 'strafe' si muove di lato rispetto alla camera.\nParola chiave: push",
+  rotate_camera_tooltip:
+    "Ruota la camera a sinistra o destra dei gradi indicati.\nParola chiave: rotate",
+  up_tooltip: "Applica la forza verso l'alto indicata.\nParola chiave: up",
   set_pivot_tooltip:
     "Imposta il punto di ancoraggio di una mesh sugli assi X, Y e Z\nParola chiave: ancora",
   min_centre_max_tooltip:

--- a/locale/pl.js
+++ b/locale/pl.js
@@ -302,6 +302,10 @@ export default {
   create_3d_text:
     "dodaj tekst 3D %1: %2 czcionka: %3 rozmiar: %4 kolor: %5\ngłębokość: %6 x: %7 y: %8 z: %9",
 
+  // Custom block translations - Math blocks
+  random_seeded_int: "losowa liczba całkowita od %1 do %2 z ziarnem: %3",
+  to_number: "konwertuj %1 na %2",
+
   // Custom block translations - Transform blocks
   move_by_xyz: "zmień pozycję %1 o x: %2, y: %3, z: %4",
   move_by_xyz_single: "zmień położenie %1 o %2 %3",
@@ -315,6 +319,8 @@ export default {
   rotate_to: "obróć %1 do x: %2, y: %3, z: %4",
   look_at: "spójrz %1 na %2 y? %3",
   move_forward: "przesuń %1 %2 prędkość: %3",
+  rotate_camera: "obróć kamerę o %1 stopni",
+  up: "w górę %1 siła %2",
   set_pivot: "ustaw punkt kotwiczenia %1\nx: %2, y: %3, z: %4",
   min_centre_max: "%1",
 
@@ -581,6 +587,12 @@ export default {
     "Zadaj użytkownikowi pytanie i poczekaj na odpowiedź. Wynik zapisany w zmiennej.",
   create_3d_text_tooltip: "Stwórz tekst 3D w scenie.",
 
+  // Tooltip translations - Math blocks
+  random_seeded_int_tooltip:
+    "Wygeneruj losową liczbę całkowitą z ziarnem.\nSłowo kluczowe: seed",
+  to_number_tooltip:
+    "Konwertuje ciąg na liczbę całkowitą lub zmiennoprzecinkową.",
+
   // Tooltip translations - Transform blocks
   move_by_xyz_tooltip:
     "Przesuń siatkę o określoną wartość w osiach x, y i z.\nSłowo kluczowe: move",
@@ -604,6 +616,9 @@ export default {
     "Obróć pierwszą siatkę w stronę pozycji drugiej.\nSłowo kluczowe: look",
   move_forward_tooltip:
     "Przesuń siatkę: 'forward' = w kierunku, 'sideways' = względem kamery, 'strafe' = bocznie.\nSłowo kluczowe: push",
+  rotate_camera_tooltip:
+    "Obraca kamerę w lewo lub w prawo o podaną liczbę stopni.\nSłowo kluczowe: rotate",
+  up_tooltip: "Zastosuj określoną siłę w górę.\nSłowo kluczowe: up",
   set_pivot_tooltip:
     "Ustaw punkt kotwiczenia siatki na osiach X, Y i Z.\nSłowo kluczowe: kotwica",
   min_centre_max_tooltip:

--- a/locale/pt.js
+++ b/locale/pt.js
@@ -300,6 +300,10 @@ export default {
   create_3d_text:
     "adicionar texto 3D %1: %2 fonte: %3 tamanho: %4 cor: %5\nprofundidade: %6 x: %7 y: %8 z: %9",
 
+  // Custom block translations - Math blocks
+  random_seeded_int: "inteiro aleatório de %1 a %2 semente: %3",
+  to_number: "converter %1 para %2",
+
   // Custom block translations - Transform blocks
   move_by_xyz: "alterar posição de %1 em x: %2 y: %3 z: %4",
   move_by_xyz_single: "alterar posição de %1 em %2 %3",
@@ -312,6 +316,8 @@ export default {
   rotate_to: "girar %1 para x: %2 y: %3 z: %4",
   look_at: "fazer %1 olhar para %2 y? %3",
   move_forward: "mover %1 %2 velocidade %3",
+  rotate_camera: "girar câmera em %1 graus",
+  up: "para cima %1 força %2",
   set_pivot: "definir âncora de %1\nx: %2 y: %3 z: %4",
   min_centre_max: "%1",
 
@@ -580,6 +586,12 @@ export default {
     "Faz uma pergunta ao usuário e aguarda a resposta. Armazena o resultado em uma variável.",
   create_3d_text_tooltip: "Cria um texto 3D na cena.",
 
+  // Tooltip translations - Math blocks
+  random_seeded_int_tooltip:
+    "Gera um inteiro aleatório com uma semente.\nPalavra-chave: seed",
+  to_number_tooltip:
+    "Converte uma string em número inteiro ou decimal.",
+
   // Tooltip translations - Transform blocks
   move_by_xyz_tooltip:
     "Move um mesh uma certa distância nas direções x, y e z.\nPalavra-chave: mover",
@@ -603,6 +615,9 @@ export default {
     "Gira o primeiro mesh para olhar para a posição do segundo mesh.\nPalavra-chave: olhar",
   move_forward_tooltip:
     "Move o mesh na direção especificada. 'Frente' o move na direção que está apontando, 'lateral' move em relação à câmera e 'deslocamento' move lateralmente em relação à câmera.\nPalavra-chave: empurrar",
+  rotate_camera_tooltip:
+    "Gira a câmera para a esquerda ou direita pelos graus indicados.\nPalavra-chave: rotate",
+  up_tooltip: "Aplica a força para cima especificada.\nPalavra-chave: up",
   set_pivot_tooltip:
     "Define o ponto de âncora de um mesh nos eixos X, Y e Z.\nPalavra-chave: âncora",
   min_centre_max_tooltip:

--- a/locale/sv.js
+++ b/locale/sv.js
@@ -298,6 +298,10 @@ export default {
       create_3d_text:
             "lägg till %1 3D text: %2 font: %3 storlek: %4 färg: %5\ndjup: %6 x: %7 y: %8 z: %9 ",
 
+      // Custom block translations - Math blocks
+      random_seeded_int: "slumpmässigt heltal från %1 till %2 frö: %3",
+      to_number: "konvertera %1 till %2",
+
       // Custom block translations - Transform blocks
       move_by_xyz: "ändra positionen för %1 med x: %2 y: %3 z: %4",
       move_by_xyz_single: "ändra positionen för %1 med %2 %3",
@@ -310,6 +314,8 @@ export default {
       rotate_to: "rotera %1 till x: %2 y: %3 z: %4",
       look_at: "titta %1 på %2 y? %3",
       move_forward: "flytta %1 %2 hastighet %3",
+      rotate_camera: "rotera kamera med %1 grader",
+      up: "upp %1 kraft %2",
       set_pivot: "ställ in ankare för %1\nx: %2 y: %3 z: %4",
       min_centre_max: "%1",
 
@@ -580,6 +586,12 @@ export default {
             "Ställ en fråga till användaren och vänta på svar. Sparar resultatet i en variabel.",
       create_3d_text_tooltip: "Skapa 3D-text i scenen.",
 
+      // Tooltip translations - Math blocks
+      random_seeded_int_tooltip:
+            "Genererar ett slumpmässigt heltal med frö.\nKeyword: seed",
+      to_number_tooltip:
+            "Konverterar en sträng till ett heltal eller flyttal.",
+
       // Tooltip translations - Transform blocks
       move_by_xyz_tooltip:
             "Flytta ett mesh ett angivet värde i x-, y- och z-led.\nKeyword: move",
@@ -603,6 +615,10 @@ export default {
             "Rotera det första mesh-objektet mot det andra objektets position.\nKeyword: look",
       move_forward_tooltip:
             "Flytta mesh-objektet i angiven riktning. 'Framåt' flyttar det i riktningen det pekar, 'sida' i kamerans riktning och 'strafe' i sidled relativt kameran.\nKeyword: push",
+      rotate_camera_tooltip:
+            "Roterar kameran åt vänster eller höger med angivet antal grader.\nKeyword: rotate",
+      up_tooltip:
+            "Applicerar den angivna uppåtriktade kraften.\nKeyword: up",
       set_pivot_tooltip:
             "Ställ in ankarpunkten för ett mesh längs X-, Y- och Z-axeln\nKeyword: ankare",
       min_centre_max_tooltip:


### PR DESCRIPTION
## Summary
- localize block messages for rotate camera, up, random seeded integer, and converting to number
- add matching tooltip translations across supported locales except Spanish

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69457c7be6f48326a922974ea84c81a2)