### PR TITLE
Fix shader material tiling on maps

### DIFF
--- a/api/scene.js
+++ b/api/scene.js
@@ -237,6 +237,12 @@ export const flockScene = {
       setTextureTiling(tex);
 
       if (mat instanceof flock.BABYLON.ShaderMaterial) {
+        const shaderTex =
+          mat.getTextureByName?.("textureSampler") ||
+          mat.getTexture?.("textureSampler") ||
+          null;
+        setTextureTiling(shaderTex);
+
         mat.setFloat("uScale", repeat);
         mat.setFloat("vScale", repeat);
       }


### PR DESCRIPTION
## Summary
- ensure map materials using shader-based textures respect tiling repeat values
- propagate u/v scale uniforms to shader materials for consistent map scaling

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69470057bac48326b4fe149583b03b42)