### PR TITLE
Handle missing rotation quaternion during rotations

### DIFF
--- a/api/transform.js
+++ b/api/transform.js
@@ -363,6 +363,19 @@ export const flockTransform = {
         flock.BABYLON.Tools.ToRadians(x),
         flock.BABYLON.Tools.ToRadians(z),
       );
+
+      if (!mesh.rotationQuaternion) {
+        const {
+          x: currentX = 0,
+          y: currentY = 0,
+          z: currentZ = 0,
+        } = mesh.rotation || {};
+        mesh.rotationQuaternion = flock.BABYLON.Quaternion.FromEulerAngles(
+          currentX,
+          currentY,
+          currentZ,
+        );
+      }
       mesh.rotationQuaternion.multiplyInPlace(incrementalRotation).normalize();
 
       if (mesh.physics) {


### PR DESCRIPTION
## Summary
- ensure meshes gain a rotation quaternion before applying incremental rotations
- prevent rotation calls from throwing when models such as 3D text lack an existing quaternion

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69497fa4778c83269ad040b35b9c1184)