### PR TITLE
Focus selected toolbox category row when navigating search with Arrow keys

### DIFF
--- a/main/blocklyinit.js
+++ b/main/blocklyinit.js
@@ -1653,15 +1653,21 @@ export function overrideSearchPlugin(workspace) {
                                         const selected =
                                                 toolbox?.getSelectedItem?.();
                                         const resolveFocusElement = (item) =>
-                                                item?.getClickTarget?.() ||
-                                                item?.getDiv?.() ||
                                                 item?.rowDiv_ ||
+                                                item?.getDiv?.() ||
+                                                item?.getClickTarget?.() ||
                                                 item?.htmlDiv_ ||
                                                 item?.svgGroup_ ||
                                                 item?.element_ ||
                                                 null;
                                         const focusElement =
                                                 resolveFocusElement(selected);
+                                        const toolboxContents =
+                                                toolboxDiv?.querySelector?.(
+                                                        ".blocklyToolboxCategoryGroup",
+                                                ) || null;
+                                        const fallbackElement =
+                                                toolboxContents || toolboxDiv;
                                         Blockly.getFocusManager?.()?.focusTree?.(
                                                 toolbox || null,
                                         );
@@ -1707,24 +1713,26 @@ export function overrideSearchPlugin(workspace) {
                                                         );
                                                 }
                                         }
-                                        if (focusElement) {
+                                        const elementToFocus =
+                                                focusElement || fallbackElement;
+                                        if (elementToFocus) {
                                                 if (
-                                                        focusElement instanceof
+                                                        elementToFocus instanceof
                                                         HTMLElement
                                                 ) {
                                                         if (
-                                                                focusElement.tabIndex <
+                                                                elementToFocus.tabIndex <
                                                                 0
                                                         ) {
-                                                                focusElement.tabIndex =
+                                                                elementToFocus.tabIndex =
                                                                         0;
                                                         }
                                                 } else if (
-                                                        focusElement instanceof
+                                                        elementToFocus instanceof
                                                         SVGElement
                                                 ) {
                                                         const currentTabIndex =
-                                                                focusElement.getAttribute?.(
+                                                                elementToFocus.getAttribute?.(
                                                                         "tabindex",
                                                                 );
                                                         if (
@@ -1733,18 +1741,13 @@ export function overrideSearchPlugin(workspace) {
                                                                 currentTabIndex ===
                                                                         "-1"
                                                         ) {
-                                                                focusElement.setAttribute?.(
+                                                                elementToFocus.setAttribute?.(
                                                                         "tabindex",
                                                                         "0",
                                                                 );
                                                         }
                                                 }
-                                                focusElement.focus?.();
-                                        } else if (toolboxDiv) {
-                                                if (toolboxDiv.tabIndex < 0) {
-                                                        toolboxDiv.tabIndex = 0;
-                                                }
-                                                toolboxDiv.focus();
+                                                elementToFocus.focus?.();
                                         }
                                 }, 0);
                         });


### PR DESCRIPTION
### Motivation
- Improve keyboard navigation from the search field so ArrowDown/ArrowUp focuses the selected toolbox category row instead of the toolbox container. 
- Ensure ArrowRight can move into the flyout without requiring a mouse click by focusing the category row itself. 

### Description
- Stop calling `toolboxDiv.focus()` immediately and instead obtain the selected toolbox item via `toolbox?.getSelectedItem?.()` after `toolbox.selectNext?.()`/`selectPrevious?.()` and `toolbox.refreshSelection?.()`.
- Resolve a focusable DOM node on the selected item using `getDiv?.()`, `htmlDiv_`, `svgGroup_`, `rowDiv_`, or `element_`, set `tabindex="0"` on it if needed, and call `.focus()`.
- Manage a `data-flock-toolbox-row` attribute and ensure only the active row remains in the tab order by removing the attribute and setting `tabindex=-1` on previous targets, and fall back to focusing `toolboxDiv` when no row element is found.
- Preserve the call to `Blockly.getFocusManager?.()?.focusTree?.(toolbox || null)` after focus is adjusted.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e9986c4e48326921424700a7676c4)