### PR TITLE
Toolbox keyboard: ArrowRight focuses flyout; Enter/Space toggle categories

### DIFF
--- a/main/blocklyinit.js
+++ b/main/blocklyinit.js
@@ -530,6 +530,67 @@ export function createBlocklyWorkspace() {
             return false;
         };
 
+        (function wireToolboxKeyboardOverrides() {
+                if (!toolbox) return;
+                const toolboxDiv =
+                        toolbox.HtmlDiv ||
+                        document.querySelector(".blocklyToolboxDiv");
+                if (!toolboxDiv) return;
+
+                toolboxDiv.addEventListener(
+                        "keydown",
+                        (e) => {
+                                const target = e.target;
+                                if (
+                                        target &&
+                                        (target.tagName === "INPUT" ||
+                                                target.tagName === "TEXTAREA" ||
+                                                target.isContentEditable)
+                                ) {
+                                        return;
+                                }
+
+                                const flyout = toolbox.getFlyout?.();
+                                const flyoutVisible =
+                                        !!flyout && !!flyout.isVisible?.();
+
+                                if (e.key === "ArrowRight" && flyoutVisible) {
+                                        e.preventDefault();
+                                        e.stopPropagation();
+                                        e.stopImmediatePropagation();
+                                        const flyoutWorkspace =
+                                                flyout.getWorkspace?.();
+                                        if (flyoutWorkspace) {
+                                                Blockly.getFocusManager().focusTree(
+                                                        flyoutWorkspace,
+                                                );
+                                        }
+                                        return;
+                                }
+
+                                if (
+                                        e.key === "Enter" ||
+                                        e.key === " " ||
+                                        e.key === "Spacebar"
+                                ) {
+                                        const selectedItem =
+                                                toolbox.getSelectedItem?.();
+                                        if (
+                                                selectedItem &&
+                                                typeof selectedItem.toggleExpanded ===
+                                                        "function"
+                                        ) {
+                                                e.preventDefault();
+                                                e.stopPropagation();
+                                                e.stopImmediatePropagation();
+                                                selectedItem.toggleExpanded();
+                                        }
+                                }
+                        },
+                        true,
+                );
+        })();
+
         initializeIfClauseConnectionChecker(workspace);
 
         (function wireToolboxSearchArrowDown() {


### PR DESCRIPTION
### Motivation
- Improve keyboard navigation so pressing `ArrowRight` on a toolbox category always moves focus into the flyout when the flyout is open.  
- Make `Enter`/`Space` open and close collapsible toolbox categories instead of using lateral arrow keys for that action.

### Description
- Updated `main/blocklyinit.js` to add a `wireToolboxKeyboardOverrides` IIFE that installs a `keydown` listener on the toolbox DOM (`toolbox.HtmlDiv` or `.blocklyToolboxDiv`).
- The listener ignores text inputs and content-editable elements and intercepts `ArrowRight` to focus the flyout workspace when `flyout.isVisible()` is true using `Blockly.getFocusManager().focusTree(flyoutWorkspace)`.
- The listener also maps `Enter` / `Space` / `Spacebar` to toggle expandable toolbox categories by calling `selectedItem.toggleExpanded()` when available.
- Existing monkey-patch that no-ops `toolbox.onKeyDown_` remains to defer core handling to the keyboard-navigation plugin.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f66ec4b8483268ba5e944991ae665)