### PR TITLE
Fix text in main menu when hovering not being easily legible in high-contrast theme

### DIFF
--- a/style.css
+++ b/style.css
@@ -1103,6 +1103,10 @@ details summary:focus,
   color: black;
 }
 
+[data-theme="contrast"] #main-menu a:hover {
+  color: black;
+}
+
 [data-theme="contrast"] .menu-item:hover .menu-icon svg {
   fill: black;
 }


### PR DESCRIPTION
<img width="383" height="275" alt="contrastmenutextfixes" src="https://github.com/user-attachments/assets/54f346ae-e439-41e2-b96e-7785f4958d1f" />
