### PR TITLE
Ensure input placeholder text colours consistent in all themes

### DIFF
--- a/style.css
+++ b/style.css
@@ -232,6 +232,10 @@
   margin-right: 10px;
 } 
 
+::placeholder {
+  color: var(--color-text-primary) !important;
+}
+
 [data-theme="contrast"] #exampleSelect {
   color: #000000 !important;
 }


### PR DESCRIPTION
<img width="546" height="82" alt="image" src="https://github.com/user-attachments/assets/8f4be936-5fd2-49c1-9c85-af2f27a12258" />

<img width="536" height="70" alt="image" src="https://github.com/user-attachments/assets/582d907f-8f6f-423f-9115-957c47e40be4" />

<img width="541" height="72" alt="image" src="https://github.com/user-attachments/assets/39d90550-a378-45ee-9234-36b817134168" />

<img width="548" height="84" alt="image" src="https://github.com/user-attachments/assets/482ae6b9-5b38-4603-bed1-3069bf3cb783" />
