### PR TITLE
Update physics shape after scaling root mesh

### DIFF
--- a/api/transform.js
+++ b/api/transform.js
@@ -617,7 +617,12 @@ export const flockTransform = {
 
         mesh.refreshBoundingInfo();
         mesh.computeWorldMatrix(true);
-        flock.updatePhysics(mesh);
+        let physicsTarget = mesh;
+        while (physicsTarget.parent) {
+          physicsTarget = physicsTarget.parent;
+        }
+
+        flock.updatePhysics(physicsTarget);
         resolve();
       });
     });


### PR DESCRIPTION
### Motivation
- Scaling a mesh via the transform APIs did not reliably update the physics collider for the model hierarchy, leaving physics shapes out of sync with the visual scale; the change ensures the physics body is refreshed for the root mesh after scaling.

### Description
- Replace the direct `flock.updatePhysics(mesh)` call in `api/transform.js` with logic that finds the top-most parent (`while (physicsTarget.parent) physicsTarget = physicsTarget.parent`) and calls `flock.updatePhysics(physicsTarget)`, so the physics shape is recreated on the root of the mesh hierarchy after scaling.

### Testing
- No automated tests were run for this change (no test invocation was requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985b7d3e8ec83269622499899b652ca)