### PR TITLE
Update physics bounds after scaling

### DIFF
--- a/api/physics.js
+++ b/api/physics.js
@@ -152,6 +152,8 @@ export const flockPhysics = {
   },
   updatePhysics(mesh, parent = null) {
     if (!parent) parent = mesh;
+    mesh.computeWorldMatrix(true);
+    mesh.refreshBoundingInfo(true);
     // If the mesh has a physics body, update its shape
     if (parent.physics) {
       // Preserve the disablePreStep setting if it exists

--- a/api/transform.js
+++ b/api/transform.js
@@ -580,7 +580,7 @@ export const flockTransform = {
 
         mesh.scaling = new flock.BABYLON.Vector3(x, y, z);
 
-        mesh.refreshBoundingInfo();
+        mesh.refreshBoundingInfo(true);
         mesh.computeWorldMatrix(true);
 
         const newBoundingInfo = mesh.getBoundingInfo();
@@ -615,7 +615,7 @@ export const flockTransform = {
           mesh.position.z -= diffZ;
         }
 
-        mesh.refreshBoundingInfo();
+        mesh.refreshBoundingInfo(true);
         mesh.computeWorldMatrix(true);
         let physicsTarget = mesh;
         while (physicsTarget.parent) {


### PR DESCRIPTION
### Motivation
- Scaling models was not updating their world matrices and bounding info before rebuilding physics shapes, causing colliders to be the wrong size and objects to fall through the ground.
- Ensure physics shape updates use up-to-date bounding information so collider sizes/origins remain correct after `scale`/`resize` operations.

### Description
- In `api/transform.js` improved `scale` by calling `mesh.refreshBoundingInfo(true)` (instead of the previous call) in the `scale` method so bounding info is refreshed for children when computing origin offsets.
- In `api/physics.js` added `mesh.computeWorldMatrix(true)` and `mesh.refreshBoundingInfo(true)` at the start of `updatePhysics` so physics shape rebuilding uses current world transforms and bounding boxes.
- These changes ensure box/mesh/capsule shapes are recreated from accurate bounds after scaling and preserve prior `disablePreStep` and motion settings when reassigning shapes.

### Testing
- No automated tests were executed for this change.
- The change was validated by static inspection and local code edits and committed as "Update physics bounds after scaling".

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985f4d716f08326be8c846d3a84b6ee)