### PR TITLE
Fix physics updates for scaled meshes

### DIFF
--- a/api/transform.js
+++ b/api/transform.js
@@ -618,11 +618,15 @@ export const flockTransform = {
         mesh.refreshBoundingInfo(true);
         mesh.computeWorldMatrix(true);
         let physicsTarget = mesh;
-        while (physicsTarget.parent) {
+        while (physicsTarget.parent && !physicsTarget.physics) {
           physicsTarget = physicsTarget.parent;
         }
 
-        flock.updatePhysics(physicsTarget);
+        if (physicsTarget.physics && physicsTarget !== mesh) {
+          flock.updatePhysics(mesh, physicsTarget);
+        } else {
+          flock.updatePhysics(mesh);
+        }
         resolve();
       });
     });


### PR DESCRIPTION
### Motivation
- Scaling a mesh did not always update the correct physics body because the updater walked to the topmost parent instead of the nearest ancestor that actually had a physics body.

### Description
- Update the `scale` implementation to walk up the parent chain until a parent with `physics` is found and call `flock.updatePhysics(mesh, physicsTarget)` when such a parent exists, otherwise fall back to `flock.updatePhysics(mesh)` so physics shapes are recreated against the correct target.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69860361d49c8326b204c295ddfb5233)