### PR TITLE
Fix duplicate variable renames on repeated block copy

### DIFF
--- a/blocks/blocks.js
+++ b/blocks/blocks.js
@@ -429,11 +429,18 @@ function isVariableUsedElsewhere(
   varId,
   excludingBlockId,
   BlocklyNS,
+  excludeBlockIds = null,
 ) {
   if (!varId) return false;
+  const excludeSet = Array.isArray(excludeBlockIds)
+    ? new Set(excludeBlockIds)
+    : excludeBlockIds instanceof Set
+      ? excludeBlockIds
+      : null;
   const blocks = workspace.getAllBlocks(false);
   for (const b of blocks) {
     if (b.id === excludingBlockId) continue;
+    if (excludeSet && excludeSet.has(b.id)) continue;
     const fields = getVariableFieldsOnBlock(b, BlocklyNS);
     for (const f of fields) {
       if (f.getValue && f.getValue() === varId) return true;
@@ -703,7 +710,8 @@ export function ensureFreshVarOnDuplicate(
   if (!oldVarId) return false;
 
   // Duplicate/copy/duplicate-parent case?
-  if (!isVariableUsedElsewhere(ws, oldVarId, block.id, BlocklyNS))
+  const createdIds = Array.isArray(changeEvent.ids) ? changeEvent.ids : null;
+  if (!isVariableUsedElsewhere(ws, oldVarId, block.id, BlocklyNS, createdIds))
     return false;
 
   const varType = getFieldVariableType(block, fieldName, BlocklyNS);


### PR DESCRIPTION
### Motivation
- Prevent variable rename logic from treating newly-created blocks in the same duplication event as existing uses, which caused multiple blocks in a copied subtree to be renamed incorrectly.
- Ensure that when duplicating/copying blocks, only pre-existing uses outside the created group are considered for splitting variables.

### Description
- Add an optional `excludeBlockIds` parameter to `isVariableUsedElsewhere` and normalize it to a `Set` for efficient checks in `blocks/blocks.js`.
- Skip blocks whose ids are in the provided exclude set when scanning for uses of a variable inside `isVariableUsedElsewhere`.
- Pass `changeEvent.ids` (when present) into `ensureFreshVarOnDuplicate` so newly created blocks from the same `BLOCK_CREATE` event are ignored during the reuse check.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698733aaff748326ab63e518ffa6f3db)