### PR TITLE
Gate preview mesh updates to value-input descendant changes

### DIFF
--- a/blocks/blocks.js
+++ b/blocks/blocks.js
@@ -261,7 +261,11 @@ export function handleParentLinkedUpdate(containerBlock, changeEvent) {
   for (const changed of changedBlocks) {
     const parent = findCreateBlock(changed);
 
-    if (parent === containerBlock && changed) {
+    if (
+      changed &&
+      parent === containerBlock &&
+      isValueInputDescendantOf(containerBlock, changed)
+    ) {
       if (!window.loadingCode) {
         updateOrCreateMeshFromBlock(containerBlock, changeEvent);
       }


### PR DESCRIPTION
### Motivation
- Prevent runtime/statement-chain changes (highlights, tints, DO/next chains) from driving live preview mesh updates by only trusting configuration/value-input subtrees. 
- Consolidate and reuse the value-input ancestry check to remove ad-hoc/special-case traversal logic (e.g. `create_map` MATERIAL) and reduce duplication. 
- Make parent-propagation logic in block change handling more precise so only provably relevant child changes update meshes.

### Description
- Add `isValueInputDescendantOf(containerBlock, changedBlock)` in `blocks/blocks.js` that returns `true` for self-updates or when every parent hop from `changedBlock` to `containerBlock` is through a `VALUE` input connection. 
- Replace scattered ad-hoc checks in `handleFieldOrChildChange` with the new helper while keeping direct owner-field updates intact. 
- Gate parent-propagation in `handleBlockChange` so `updateOrCreateMeshFromBlock` is only called when a resolvable `changedBlock` exists and `isValueInputDescendantOf(block, changedBlock)` is `true`, and add the inline comment: "Only configuration inputs (value-input subtree) affect preview mesh; runtime statement blocks do not." 
- `load_object` and other load/create blocks that delegate to `handleBlockChange` now automatically benefit from the stricter VALUE-input-descendant gating without per-block duplication.

### Testing
- Ran `npx eslint blocks/blocks.js blocks/models.js`, which reported existing repository-level lint errors unrelated to the new helper and change (the lint run failed). 
- No additional automated unit or integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996e4130cb083269faa423ff7e5d4df)