### PR TITLE
Set colour for block placeholder in Dark and Contrast theme

### DIFF
--- a/style/blockly.css
+++ b/style/blockly.css
@@ -38,11 +38,11 @@
 }
 
 [data-theme="dark-contrast"] .blocklyInsertionMarker path {
-  fill: blue !important;
+  fill: grey !important;
 }
 
 [data-theme="contrast"] .blocklyInsertionMarker path {
-  fill: blue !important;
+  fill: grey !important;
 }
 
 /* Only target text inputs with cursor: text */


### PR DESCRIPTION
<img width="366" height="173" alt="new_block_placeholder_colour" src="https://github.com/user-attachments/assets/6f2a4445-2287-48bb-ae51-2b9ef84e1df7" />
