### PR TITLE
Add shared anchor transform helper scaffold for placement refactor

### DIFF
--- a/api/anchorTransform.js
+++ b/api/anchorTransform.js
@@ -1,0 +1,108 @@
+let flock;
+
+export function setFlockReference(ref) {
+  flock = ref;
+}
+
+function getDefaultPivotSettings() {
+  return { x: "CENTER", y: "MIN", z: "CENTER" };
+}
+
+function normalizePivotSetting(setting, fallback = "CENTER") {
+  if (typeof setting === "number" && Number.isFinite(setting)) return setting;
+  if (typeof setting !== "string") return fallback;
+
+  const upper = setting.toUpperCase();
+  if (upper === "MIN" || upper === "CENTER" || upper === "MAX") return upper;
+  return fallback;
+}
+
+function resolveAxisPivotLocal(mesh, axis, setting) {
+  if (typeof setting === "number" && Number.isFinite(setting)) {
+    return setting;
+  }
+
+  const bounds = mesh?.getBoundingInfo?.()?.boundingBox;
+  if (!bounds) return 0;
+
+  const ext = bounds.extendSize?.[axis];
+  const half = Number.isFinite(ext) ? ext : 0;
+
+  if (setting === "MIN") return -half;
+  if (setting === "MAX") return half;
+  return 0;
+}
+
+export const flockAnchorTransform = {
+  getPivotSettings(mesh, fallback = getDefaultPivotSettings()) {
+    const configured = mesh?.metadata?.pivotSettings || {};
+    return {
+      x: normalizePivotSetting(configured.x, fallback.x),
+      y: normalizePivotSetting(configured.y, fallback.y),
+      z: normalizePivotSetting(configured.z, fallback.z),
+    };
+  },
+
+  getLocalAnchorOffset(mesh, pivotSettings = null) {
+    if (!mesh) {
+      return new flock.BABYLON.Vector3(0, 0, 0);
+    }
+
+    const resolved = pivotSettings || this.getPivotSettings(mesh);
+
+    return new flock.BABYLON.Vector3(
+      resolveAxisPivotLocal(mesh, "x", normalizePivotSetting(resolved.x, "CENTER")),
+      resolveAxisPivotLocal(mesh, "y", normalizePivotSetting(resolved.y, "MIN")),
+      resolveAxisPivotLocal(mesh, "z", normalizePivotSetting(resolved.z, "CENTER")),
+    );
+  },
+
+  resolveWorldAnchor(mesh, pivotSettings = null) {
+    if (!mesh) return null;
+
+    if (!mesh.getBoundingInfo || !mesh.getBoundingInfo()) {
+      const p = mesh.position || flock.BABYLON.Vector3.Zero();
+      return { x: p.x, y: p.y, z: p.z };
+    }
+
+    mesh.computeWorldMatrix?.(true);
+
+    const localAnchor = this.getLocalAnchorOffset(mesh, pivotSettings);
+    const worldAnchor = flock.BABYLON.Vector3.TransformCoordinates(
+      localAnchor,
+      mesh.getWorldMatrix(),
+    );
+
+    return { x: worldAnchor.x, y: worldAnchor.y, z: worldAnchor.z };
+  },
+
+  setMeshByWorldAnchor(
+    mesh,
+    target,
+    { useX = true, useY = true, useZ = true, pivotSettings = null } = {},
+  ) {
+    if (!mesh) return;
+
+    const current = this.resolveWorldAnchor(mesh, pivotSettings);
+    if (!current) return;
+
+    const tx = useX ? target?.x : current.x;
+    const ty = useY ? target?.y : current.y;
+    const tz = useZ ? target?.z : current.z;
+
+    const dx = Number.isFinite(tx) ? tx - current.x : 0;
+    const dy = Number.isFinite(ty) ? ty - current.y : 0;
+    const dz = Number.isFinite(tz) ? tz - current.z : 0;
+
+    if (dx !== 0 || dy !== 0 || dz !== 0) {
+      mesh.position.addInPlace(new flock.BABYLON.Vector3(dx, dy, dz));
+      mesh.computeWorldMatrix?.(true);
+    }
+
+    return {
+      x: current.x + dx,
+      y: current.y + dy,
+      z: current.z + dz,
+    };
+  },
+};

--- a/flock.js
+++ b/flock.js
@@ -75,6 +75,10 @@ import { flockCamera, setFlockReference as setFlockCamera } from "./api/camera";
 import { flockEvents, setFlockReference as setFlockEvents } from "./api/events";
 import { flockMath, setFlockReference as setFlockMath } from "./api/math";
 import {
+        flockAnchorTransform,
+        setFlockReference as setFlockAnchorTransform,
+} from "./api/anchorTransform";
+import {
         flockSensing,
         setFlockReference as setFlockSensing,
 } from "./api/sensing";
@@ -162,6 +166,7 @@ export const flock = {
         ...flockEvents,
         ...flockSensing,
         ...flockMath,
+        ...flockAnchorTransform,
         // Enhanced error reporting with block context
         createEnhancedError(error, code) {
                 const lines = code.split("\n");
@@ -2000,6 +2005,7 @@ export const flock = {
                 setFlockControl(flock);
                 setFlockEvents(flock);
                 setFlockSensing(flock);
+                setFlockAnchorTransform(flock);
 
                 // Add highlight layer
                 flock.highlighter = new flock.BABYLON.HighlightLayer(


### PR DESCRIPTION
## Summary
- add a new `api/anchorTransform.js` module to centralize anchor/pivot coordinate math
- expose reusable helper methods:
  - `getPivotSettings(mesh)`
  - `getLocalAnchorOffset(mesh, pivotSettings)`
  - `resolveWorldAnchor(mesh, pivotSettings)`
  - `setMeshByWorldAnchor(mesh, target, options)`
- wire the module into `flock.js` so helpers are available on the shared flock object and receive the flock reference

## Why
This is the first incremental step of the single coherent refactor to move away from scattered manual offset calculations while preserving current behavior. It provides a canonical helper surface without changing existing transform callsites yet.

## Notes
- no behavior migration is included in this commit; this is a scaffold step only
- existing repo lint issues remain outside this change and are unchanged

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ac63f7afc8326ad67896203ba6367)