### PR TITLE
Prevent material/color changes from affecting speech text planes

### DIFF
--- a/api/material.js
+++ b/api/material.js
@@ -616,6 +616,9 @@ export const flockMaterial = {
     };
 
     const isCharacterLike = isCharacterMesh(mesh) || isCharacterLikeMesh(mesh);
+    const isTextPlaneMesh = (part) =>
+      part?.name === "textPlane" || part?.metadata?.isTextPlane;
+
     if (isCharacterLike) {
       const root = getRootMesh(mesh);
       flock.ensureStandardMaterial(root);
@@ -655,6 +658,8 @@ export const flockMaterial = {
     const materialToColorMap = new Map();
 
     function applyColorInOrder(part) {
+      if (isTextPlaneMesh(part)) return;
+
       if (part.material) {
         // Check if the material is already processed
         if (!materialToColorMap.has(part.material)) {
@@ -695,6 +700,7 @@ export const flockMaterial = {
       // Process the submeshes (children) of the current mesh, sorted alphabetically
       const sortedChildMeshes = part
         .getChildMeshes()
+        .filter((child) => !isTextPlaneMesh(child))
         .sort((a, b) => a.name.localeCompare(b.name));
       sortedChildMeshes.forEach((child) => applyColorInOrder(child));
     }
@@ -924,8 +930,13 @@ export const flockMaterial = {
     material.alpha = alpha;
     material.backFaceCulling = false;
 
+    const isTextPlaneMesh = (part) =>
+      part?.name === "textPlane" || part?.metadata?.isTextPlane;
+
     // Assign the material to the mesh and its descendants
-    const allMeshes = [mesh].concat(mesh.getDescendants());
+    const allMeshes = [mesh]
+      .concat(mesh.getDescendants())
+      .filter((part) => !isTextPlaneMesh(part));
     allMeshes.forEach((part) => {
       part.material = material;
       flock.adjustMaterialTilingToMesh(part, material);
@@ -1485,10 +1496,16 @@ export const flockMaterial = {
     const applyColor = opts.applyColor ?? true;
     if (!applyColor || !rootMesh || !colorInput) return rootMesh;
 
+    const isTextPlaneMesh = (part) =>
+      part?.name === "textPlane" || part?.metadata?.isTextPlane;
+
     const geometryMeshes = rootMesh
       .getDescendants(false)
       .filter(
-        (n) => n instanceof flock.BABYLON.Mesh && n.getTotalVertices() > 0,
+        (n) =>
+          n instanceof flock.BABYLON.Mesh &&
+          n.getTotalVertices() > 0 &&
+          !isTextPlaneMesh(n),
       )
       .sort((a, b) =>
         a.name.localeCompare(b.name, undefined, {

--- a/api/ui.js
+++ b/api/ui.js
@@ -637,6 +637,10 @@ export const flockUI = {
           );
           plane.name = "textPlane";
           plane.parent = targetMesh;
+          plane.metadata = {
+            ...(plane.metadata || {}),
+            isTextPlane: true,
+          };
           plane.checkCollisions = false;
           plane.isPickable = false;
           plane.billboardMode = flock.BABYLON.Mesh.BILLBOARDMODE_ALL;


### PR DESCRIPTION
## Summary
- mark generated `say` overlay planes with `metadata.isTextPlane` in `api/ui.js`
- exclude `textPlane`/`isTextPlane` meshes from color and material traversal paths in `api/material.js`
  - `changeColorMesh` recursion
  - `changeMaterialMesh` descendant assignment
  - `applyMaterialToHierarchy` target discovery

## Why
Meshes with speech bubbles (`say`) create a child plane used for UI text. Material/color operations on the parent mesh were also touching this helper plane, unintentionally changing the speech bubble background.

## Result
Changing a mesh color/material now leaves its speech text plane unchanged while still applying updates to real geometry descendants.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fe2d59d6883269c07537a9b9c905b)