### PR TITLE
Enable direct canvas painting while color picker is open

### DIFF
--- a/style.css
+++ b/style.css
@@ -1053,6 +1053,11 @@ details summary:focus,
   background-color: var(--color-button-bg-hover);
 }
 
+/* Show crosshair on canvas whenever colour picker is open */
+body.color-picker-open #renderCanvas {
+  cursor: crosshair;
+}
+
       /* Focus management for modal */
       .modal:focus-within .modal-content {
         outline: 2px solid var(--color-focus-ring);

--- a/ui/colourpicker.js
+++ b/ui/colourpicker.js
@@ -86,6 +86,7 @@ class CustomColorPicker {
     this.onColorChange = options.onColorChange || (() => {});
     this.onClose = options.onClose || (() => {});
     this.targetElement = options.target || document.body;
+    this.excludeFromClose = options.excludeFromClose || null;
 
     this.isOpen = false;
 
@@ -647,6 +648,7 @@ class CustomColorPicker {
     // Click outside to close (guarded during eyedropper)
     this.outsideClickHandler = (e) => {
       if (this._eyedropperActive) return; // don't close while eyedropper overlay is up
+      if (this.excludeFromClose && this.excludeFromClose(e.target)) return; // e.g. canvas click
       if (this.isOpen && !this.container.contains(e.target)) {
         this.close();
       }
@@ -1829,12 +1831,13 @@ class CustomColorPicker {
 
   open(color = this.currentColor) {
     disableGizmos();
-    
+
     // Show first so layout has real sizes
     this.container.style.display = "block";
     this.container.style.opacity = "1";
     this.container.style.pointerEvents = "auto";
     this.isOpen = true;
+    document.body.classList.add("color-picker-open");
 
     // --- Positioning (unchanged) ---
     const colorButton = document.getElementById("colorPickerButton");
@@ -2020,6 +2023,7 @@ class CustomColorPicker {
   close() {
     this.container.style.display = "none";
     this.isOpen = false;
+    document.body.classList.remove("color-picker-open");
     document.removeEventListener("click", this.outsideClickHandler, true);
   }
 

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -95,10 +95,31 @@ document.addEventListener("DOMContentLoaded", function () {
         // After color picker closes, start mesh selection
         pickMeshFromCanvas();
       },
+      excludeFromClose: (target) => {
+        // Don't close picker when clicking on the 3D canvas — we handle it directly
+        const canvas = document.getElementById("renderCanvas");
+        return canvas && (canvas === target || canvas.contains(target));
+      },
       target: document.body,
     });
     // Make accessible globally for translation updates
     window.flockColorPicker = colorPicker;
+
+    // Direct painting: clicking/tapping the canvas while picker is open applies colour
+    const renderCanvas = document.getElementById("renderCanvas");
+    if (renderCanvas) {
+      renderCanvas.addEventListener("click", (event) => {
+        if (!colorPicker?.isOpen) return;
+        // Use picker's live colour (not yet confirmed via "Use")
+        window.selectedColor = colorPicker.currentColor || window.selectedColor;
+        const canvasRect = renderCanvas.getBoundingClientRect();
+        const [canvasX, canvasY] = getCanvasXAndCanvasYValues(
+          event,
+          canvasRect,
+        );
+        applyColorAtPosition(canvasX, canvasY);
+      });
+    }
   }
 
   // Attach click event to open custom color picker


### PR DESCRIPTION
## Summary
This PR adds the ability to directly paint on the canvas by clicking/tapping while the color picker is open, without requiring users to confirm the color selection first. It also improves UX by showing a crosshair cursor on the canvas when the picker is active.

## Key Changes
- **Direct painting on canvas**: Added click event listener to the render canvas that applies the color picker's current color directly to the canvas when clicked, even while the picker remains open
- **Exclude canvas from close logic**: Implemented `excludeFromClose` callback in the color picker to prevent the picker from closing when clicking on the canvas itself
- **Visual feedback**: Added `color-picker-open` class to `body` when picker opens/closes, enabling a crosshair cursor on the canvas via CSS
- **State tracking**: Color picker now tracks `isOpen` state more reliably by adding/removing the body class in `open()` and `close()` methods

## Implementation Details
- The canvas click handler uses the picker's `currentColor` (live color) rather than waiting for confirmation via the "Use" button
- Canvas coordinates are properly calculated using `getCanvasXAndCanvasYValues()` before applying color
- The `excludeFromClose` option allows the color picker to remain open after canvas interactions, improving workflow efficiency
- CSS cursor change provides clear visual indication that the canvas is interactive while the picker is open

https://claude.ai/code/session_01DAYassUFrMjCRWJQyiyQgG