### PR TITLE
Normalize hex color outputs to lowercase

### DIFF
--- a/api/material.js
+++ b/api/material.js
@@ -147,7 +147,7 @@ export const flockMaterial = {
     }
     if (flock.materialsDebug)
       console.log(`  Generated the random colour ${colour}`);
-    return colour;
+    return colour.toLowerCase();
   },
   rgbToHex(rgb) {
     const matches = rgb.match(/\d+/g);
@@ -185,7 +185,7 @@ export const flockMaterial = {
     // if (flock.materialsDebug) console.log(` Getting a colour from ${colourString}`);
 
     if (/^#([0-9A-F]{3}){1,2}$/i.test(colourString)) {
-      return colourString;
+      return colourString.toLowerCase();
     }
 
     try {
@@ -204,7 +204,7 @@ export const flockMaterial = {
       const g = parseInt(matches[1]);
       const b = parseInt(matches[2]);
       const result = flock.rgbToHex(r, g, b);
-      return result;
+      return result.toLowerCase();
     } catch (e) {
       return "#000000";
     }

--- a/api/sensing.js
+++ b/api/sensing.js
@@ -186,9 +186,9 @@ export const flockSensing = {
         colors = materialNodes
           .map((node) => {
             if (node.material.diffuseColor) {
-              return node.material.diffuseColor.toHexString();
+              return node.material.diffuseColor.toHexString().toLowerCase();
             } else if (node.material.albedoColor) {
-              return node.material.albedoColor.toHexString();
+              return node.material.albedoColor.toHexString().toLowerCase();
             }
             return null;
           })


### PR DESCRIPTION
### Motivation
- Ensure consistent hex color formatting across the codebase by normalizing generated and derived hex color strings to lowercase to avoid mismatches and improve string comparisons.

### Description
- `randomColour()` now returns a lowercase hex string via `return colour.toLowerCase()`.
- `getColorFromString()` normalizes direct `#...` inputs and computed color results by returning lowercase hex via `.toLowerCase()`.
- Color extraction in sensing for the `COLOUR` property now calls `.toLowerCase()` on `toHexString()` results for both `diffuseColor` and `albedoColor`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a746e403048326a5da31d27e48c22b)