### PR TITLE
Preserve checkbox inline styles when exporting block PNG/SVG

### DIFF
--- a/main/export.js
+++ b/main/export.js
@@ -275,13 +275,18 @@ async function generateSVG(block) {
 	});
 
 
-	const uiTexts = svgBlock.querySelectorAll(
-		"text.blocklyCheckbox, text.blocklyText",
-	);
+	const uiTexts = svgBlock.querySelectorAll("text.blocklyText");
 	uiTexts.forEach((textElement) => {
-		textElement.setAttribute("style", "fill: #000000 !important;");
-		textElement.setAttribute("stroke", "none");
-		textElement.setAttribute("font-weight", "500");
+		const isCheckbox = textElement.classList.contains("blocklyCheckbox");
+
+		textElement.style.fill = "#000000";
+
+		if (isCheckbox) {
+			return;
+		}
+
+		textElement.style.stroke = "none";
+		textElement.style.fontWeight = "500";
 	});
 
 	const fontBase64 = await convertFontToBase64(w500);


### PR DESCRIPTION
### Motivation
- Export was replacing entire inline `style` attributes on text nodes which clobbered checkbox-specific display/visibility styles and caused exported images to misrepresent checked/unchecked boxes.
- The goal is to normalize text appearance for readability while preserving checkbox inline behavior and any pre-existing inline style properties that should not be overwritten.

### Description
- In `generateSVG(block)` (`main/export.js`) changed the selector to target `text.blocklyText` and switched from `setAttribute("style", ...)` to per-property updates via `textElement.style.fill`, `textElement.style.stroke`, and `textElement.style.fontWeight`.
- Detect `.blocklyCheckbox` on text nodes and skip applying readability overrides (`stroke` and `fontWeight`) to checkbox text nodes while still enforcing a normalized `fill` color.
- Kept existing embedding of fonts and the stylesheet injection intact so exported SVGs still use the project font and field rect background normalization.

### Testing
- Ran a production build with `npm run build` which completed successfully.
- Attempted an automated headless validation that exercised the block export and captured the generated SVG via Playwright, but the export callback environment did not expose the needed registry hooks in the headless run so checkbox-visibility confirmation was only partially validated (script ran but could not fully capture the export output).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9bc7a70f0832692b8a1ddfc8c6f02)