### PR TITLE
Fix sky vertical UV orientation and add per-sky `flipV` option

### DIFF
--- a/api/scene.js
+++ b/api/scene.js
@@ -26,7 +26,7 @@ export const flockScene = {
 
     if (!color) return;
 
-    const { clear = false } = options;
+    const { clear = false, flipV = true } = options;
 
     if (flock.sky) {
       flock.disposeMesh(flock.sky);
@@ -66,17 +66,17 @@ export const flockScene = {
         color.diffuseTexture || color.albedoTexture || color.baseTexture;
 
       if (tex || isShader) {
-        
         const scaleValue = 10;
+        const verticalScale = flipV ? -scaleValue : scaleValue;
 
         if (tex) {
           tex.uScale = scaleValue;
-          tex.vScale = scaleValue;
+          tex.vScale = verticalScale;
         }
 
         if (isShader) {
           color.setFloat("uScale", scaleValue);
-          color.setFloat("vScale", scaleValue);
+          color.setFloat("vScale", verticalScale);
         }
       }
 


### PR DESCRIPTION
### Motivation
- Sky textures and shader materials were using the same positive scaling for both U and V, but the vertical orientation for sky should be inverted while keeping `uScale` positive. 
- Provide a way to opt out when inversion causes mirrored appearances by exposing a per-sky toggle rather than changing global material behavior.

### Description
- In `api/scene.js` (`flockScene.setSky`) added an `options.flipV` parameter defaulting to `true` and kept `clear` behavior unchanged. 
- Compute `verticalScale = flipV ? -scaleValue : scaleValue` and apply it only in the sky-material branch. 
- For standard textures set `tex.uScale = scaleValue` and `tex.vScale = verticalScale`, and for shader materials call `color.setFloat("uScale", scaleValue)` and `color.setFloat("vScale", verticalScale)`. 
- No global material creation logic was modified; changes are scoped to sky setup only in `setSky`.

### Testing
- `node --check api/scene.js` completed successfully. 
- `npm -s run test:api` failed in this environment because Playwright browser binaries are not installed (error: missing Chromium executable). 
- `npm -s run lint` reported pre-existing unrelated lint issues in `flock.js` and did not pass in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9c97f66ec8326aa95f88af4d83935)