### PR TITLE
Add `rumbleController` API and Blockly block for gamepad haptics

### DIFF
--- a/API.md
+++ b/API.md
@@ -492,6 +492,22 @@ Broadcasts a custom event.
 #### `onTrigger(meshName, callback)`
 Sets up collision/trigger detection for a mesh.
 
+#### `rumbleController(controller = "ANY", strength = 1, durationMs = 200)`
+Triggers rumble/haptic feedback on supported gamepads and controllers.
+
+**Parameters:**
+- `controller` (string): `"ANY"`, `"LEFT"`, or `"RIGHT"`.
+- `strength` (number): Intensity from `0` to `1`.
+- `durationMs` (number): Rumble duration in milliseconds.
+
+**Returns:**
+- `Promise<boolean>`: `true` when a rumble command was sent, otherwise `false` (for unsupported devices/browsers).
+
+**Example:**
+```javascript
+await rumbleController("ANY", 0.8, 250);
+```
+
 ## Examples
 
 For a complete working example, see [example.html](example.html) in the repository, which demonstrates a full Flock XR application with character movement, physics, and camera controls.

--- a/api/xr.js
+++ b/api/xr.js
@@ -49,6 +49,74 @@ export const flockXR = {
       color: "white",
     });
   },
+  async rumbleController(controller = "ANY", strength = 1, durationMs = 200) {
+    const normalizedController = String(controller || "ANY").toUpperCase();
+    const normalizedStrength = Math.min(
+      1,
+      Math.max(0, Number.isFinite(strength) ? strength : 1),
+    );
+    const normalizedDuration = Math.max(
+      0,
+      Math.floor(Number.isFinite(durationMs) ? durationMs : 200),
+    );
+
+    if (typeof navigator === "undefined" || !navigator.getGamepads) {
+      return false;
+    }
+
+    const gamepads = Array.from(navigator.getGamepads() || []).filter(Boolean);
+    if (!gamepads.length) {
+      return false;
+    }
+
+    const matchesController = (gamepad) => {
+      if (normalizedController === "ANY") {
+        return true;
+      }
+
+      const hand = String(gamepad.hand || "").toLowerCase();
+      const id = String(gamepad.id || "").toLowerCase();
+      if (normalizedController === "LEFT") {
+        return hand === "left" || id.includes("left");
+      }
+      if (normalizedController === "RIGHT") {
+        return hand === "right" || id.includes("right");
+      }
+      return true;
+    };
+
+    const targetPad = gamepads.find(matchesController);
+    if (!targetPad) {
+      return false;
+    }
+
+    const actuator =
+      targetPad.vibrationActuator || targetPad.hapticActuators?.[0] || null;
+    if (!actuator) {
+      return false;
+    }
+
+    try {
+      if (typeof actuator.playEffect === "function") {
+        await actuator.playEffect("dual-rumble", {
+          startDelay: 0,
+          duration: normalizedDuration,
+          weakMagnitude: normalizedStrength,
+          strongMagnitude: normalizedStrength,
+        });
+        return true;
+      }
+
+      if (typeof actuator.pulse === "function") {
+        await actuator.pulse(normalizedStrength, normalizedDuration);
+        return true;
+      }
+    } catch {
+      return false;
+    }
+
+    return false;
+  },
   exportMesh(meshName, format) {
     //meshName = "scene";
 

--- a/blocks/xr.js
+++ b/blocks/xr.js
@@ -58,5 +58,41 @@ export function defineXRBlocks() {
 
                 },
           };
-}
 
+          Blockly.Blocks["rumble_controller"] = {
+                init: function () {
+                  this.jsonInit({
+                        type: "rumble_controller",
+                        message0: translate("rumble_controller"),
+                        args0: [
+                          {
+                                type: "field_dropdown",
+                                name: "CONTROLLER",
+                                options: [
+                                  getDropdownOption("ANY"),
+                                  getDropdownOption("LEFT"),
+                                  getDropdownOption("RIGHT"),
+                                ],
+                          },
+                          {
+                                type: "input_value",
+                                name: "STRENGTH",
+                                check: "Number",
+                          },
+                          {
+                                type: "input_value",
+                                name: "DURATION_MS",
+                                check: "Number",
+                          },
+                        ],
+                        previousStatement: null,
+                        nextStatement: null,
+                        colour: categoryColours["Scene"],
+                        tooltip: getTooltip("rumble_controller"),
+                  });
+                  this.setHelpUrl(getHelpUrlFor(this.type));
+                        this.setStyle('scene_blocks');
+
+                },
+          };
+}

--- a/flock.js
+++ b/flock.js
@@ -968,6 +968,7 @@ export const flock = {
                         setCameraBackground:
                                 this.setCameraBackground?.bind(this),
                         setXRMode: this.setXRMode?.bind(this),
+                        rumbleController: this.rumbleController?.bind(this),
                         applyForce: this.applyForce?.bind(this),
                         moveByVector: this.moveByVector?.bind(this),
                         glideTo: this.glideTo?.bind(this),
@@ -1083,6 +1084,7 @@ export const flock = {
                         "setSky",
                         "setFog",
                         "setCameraBackground",
+                        "rumbleController",
                         "lightIntensity",
                         "lightColor",
                         "create3DText",

--- a/generators/generators.js
+++ b/generators/generators.js
@@ -3517,6 +3517,24 @@ export function defineGenerators() {
                 return `await setXRMode("${mode}");\n`;
         };
 
+        javascriptGenerator.forBlock["rumble_controller"] = function (block) {
+                const controller = block.getFieldValue("CONTROLLER");
+                const strength =
+                        javascriptGenerator.valueToCode(
+                                block,
+                                "STRENGTH",
+                                javascriptGenerator.ORDER_NONE,
+                        ) || "1";
+                const durationMs =
+                        javascriptGenerator.valueToCode(
+                                block,
+                                "DURATION_MS",
+                                javascriptGenerator.ORDER_NONE,
+                        ) || "200";
+
+                return `await rumbleController("${controller}", ${strength}, ${durationMs});\n`;
+        };
+
         javascriptGenerator.forBlock["camera_control"] = function (block) {
                 const key = block.getFieldValue("KEY");
                 const action = block.getFieldValue("ACTION");

--- a/locale/en.js
+++ b/locale/en.js
@@ -332,6 +332,7 @@ export default {
   // Custom block translations - XR blocks
   device_camera_background: "use %1 camera as background",
   set_xr_mode: "set XR mode to %1",
+  rumble_controller: "rumble %1 strength %2 for %3 ms",
 
   // Blockly message overrides for English
   LISTS_CREATE_WITH_INPUT_WITH: "list",
@@ -633,6 +634,8 @@ export default {
     "Use the device camera as the background for the scene. Works on both mobile and desktop.",
   set_xr_mode_tooltip:
     "Set the XR mode for the scene.\nOptions: VR, AR, Magic Window.",
+  rumble_controller_tooltip:
+    "Trigger controller rumble on supported gamepads using strength from 0 to 1 and duration in milliseconds.",
 
   // Dropdown option translations
   AWAIT_option: "await",

--- a/toolbox.js
+++ b/toolbox.js
@@ -605,6 +605,29 @@ const toolboxSceneXR = {
                 },
                 {
                         kind: "block",
+                        type: "rumble_controller",
+                        keyword: "rumble",
+                        inputs: {
+                                STRENGTH: {
+                                        shadow: {
+                                                type: "math_number",
+                                                fields: {
+                                                        NUM: 1,
+                                                },
+                                        },
+                                },
+                                DURATION_MS: {
+                                        shadow: {
+                                                type: "math_number",
+                                                fields: {
+                                                        NUM: 200,
+                                                },
+                                        },
+                                },
+                        },
+                },
+                {
+                        kind: "block",
                         type: "export_mesh",
                         keyword: "export",
                 },


### PR DESCRIPTION
### Motivation
- Provide a simple cross-platform API to trigger controller vibration/haptics from scripts and Blockly, enabling richer tactile feedback in experiences.

### Description
- Add `rumbleController(controller = "ANY", strength = 1, durationMs = 200)` implementation in `api/xr.js` that normalizes inputs, locates a matching gamepad, and uses `vibrationActuator` or `hapticActuators` to play effects or pulse, returning `Promise<boolean>`.
- Expose `rumbleController` in the public `flock` API and include it in the side-effect API list in `flock.js`.
- Add a Blockly block definition in `blocks/xr.js`, a JS code generator in `generators/generators.js`, a toolbox entry in `toolbox.js`, and English localization/tooltip in `locale/en.js`.
- Document the new function in `API.md` with parameters, return value, and an example.

### Testing
- Ran the project build (`npm run build`) and the test suite (`npm test`) after changes, and both completed successfully.
- Linting (`npm run lint`) was executed and showed no new errors related to these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab1bbe6a6883268e0a4b1ef9a18808)