### PR TITLE
Add controller rumble block for XR gamepad haptic feedback

### DIFF
--- a/api/xr.js
+++ b/api/xr.js
@@ -4,6 +4,71 @@ export function setFlockReference(ref) {
   flock = ref;
 }
 
+const rumblePatterns = {
+  objectGrab: [
+    { duration: 40, weakMagnitude: 0.1, strongMagnitude: 0.8, pauseAfter: 30 },
+    { duration: 25, weakMagnitude: 0.1, strongMagnitude: 0.4, pauseAfter:  0 },
+  ],
+  objectDrop: [
+    { duration: 60, weakMagnitude: 0.3, strongMagnitude: 1.0, pauseAfter: 20 },
+    { duration: 30, weakMagnitude: 0.1, strongMagnitude: 0.4, pauseAfter:  0 },
+  ],
+  smallCollision: [
+    { duration: 30, weakMagnitude: 0.5, strongMagnitude: 0.2, pauseAfter: 40 },
+    { duration: 20, weakMagnitude: 0.2, strongMagnitude: 0.1, pauseAfter:  0 },
+  ],
+  heavyCollision: [
+    { duration: 100, weakMagnitude: 0.5, strongMagnitude: 1.0, pauseAfter: 30 },
+    { duration:  60, weakMagnitude: 0.3, strongMagnitude: 0.7, pauseAfter: 40 },
+    { duration:  30, weakMagnitude: 0.1, strongMagnitude: 0.3, pauseAfter:  0 },
+  ],
+  snapToGrid: [
+    { duration: 20, weakMagnitude: 0.0, strongMagnitude: 0.9, pauseAfter: 25 },
+    { duration: 20, weakMagnitude: 0.0, strongMagnitude: 0.9, pauseAfter:  0 },
+  ],
+  errorInvalid: [
+    { duration: 50, weakMagnitude: 0.9, strongMagnitude: 0.1, pauseAfter: 25 },
+    { duration: 40, weakMagnitude: 0.7, strongMagnitude: 0.1, pauseAfter: 20 },
+    { duration: 50, weakMagnitude: 0.9, strongMagnitude: 0.1, pauseAfter: 30 },
+    { duration: 30, weakMagnitude: 0.5, strongMagnitude: 0.0, pauseAfter:  0 },
+  ],
+  successConfirmation: [
+    { duration: 30, weakMagnitude: 0.1, strongMagnitude: 0.3, pauseAfter: 40 },
+    { duration: 40, weakMagnitude: 0.2, strongMagnitude: 0.6, pauseAfter: 40 },
+    { duration: 50, weakMagnitude: 0.3, strongMagnitude: 0.9, pauseAfter:  0 },
+  ],
+  slidingGravel: [
+    { duration: 40, weakMagnitude: 0.6, strongMagnitude: 0.2, pauseAfter: 25 },
+    { duration: 25, weakMagnitude: 0.4, strongMagnitude: 0.1, pauseAfter: 20 },
+    { duration: 50, weakMagnitude: 0.7, strongMagnitude: 0.3, pauseAfter: 30 },
+    { duration: 30, weakMagnitude: 0.4, strongMagnitude: 0.1, pauseAfter: 20 },
+    { duration: 45, weakMagnitude: 0.6, strongMagnitude: 0.2, pauseAfter:  0 },
+  ],
+  slidingMetal: [
+    { duration: 90, weakMagnitude: 0.05, strongMagnitude: 0.40, pauseAfter: 25 },
+    { duration: 70, weakMagnitude: 0.05, strongMagnitude: 0.25, pauseAfter:  0 },
+  ],
+  machineRunning: [
+    { duration: 60, weakMagnitude: 0.2, strongMagnitude: 0.5, pauseAfter: 30 },
+    { duration: 60, weakMagnitude: 0.2, strongMagnitude: 0.5, pauseAfter: 30 },
+    { duration: 60, weakMagnitude: 0.2, strongMagnitude: 0.5, pauseAfter: 30 },
+    { duration: 60, weakMagnitude: 0.2, strongMagnitude: 0.5, pauseAfter:  0 },
+  ],
+  explosion: [
+    { duration: 120, weakMagnitude: 0.8, strongMagnitude: 1.0, pauseAfter: 20 },
+    { duration:  80, weakMagnitude: 0.6, strongMagnitude: 0.8, pauseAfter: 30 },
+    { duration:  60, weakMagnitude: 0.3, strongMagnitude: 0.5, pauseAfter: 40 },
+    { duration:  40, weakMagnitude: 0.1, strongMagnitude: 0.2, pauseAfter:  0 },
+  ],
+  teleport: [
+    { duration: 30, weakMagnitude: 0.1, strongMagnitude: 0.2, pauseAfter: 20 },
+    { duration: 50, weakMagnitude: 0.3, strongMagnitude: 0.5, pauseAfter: 20 },
+    { duration: 70, weakMagnitude: 0.5, strongMagnitude: 0.9, pauseAfter: 20 },
+    { duration: 50, weakMagnitude: 0.3, strongMagnitude: 0.5, pauseAfter: 20 },
+    { duration: 30, weakMagnitude: 0.1, strongMagnitude: 0.2, pauseAfter:  0 },
+  ],
+};
+
 export const flockXR = {
   /* 
           Category: Scene>XR
@@ -68,6 +133,24 @@ export const flockXR = {
           weakMagnitude: weakMagnitude,
           strongMagnitude: strongMagnitude,
         });
+      }
+    }
+  },
+  playRumblePattern(patternName) {
+    const pattern = rumblePatterns[patternName];
+    if (!pattern) return;
+    const gamepads = navigator.getGamepads ? navigator.getGamepads() : [];
+    for (const gamepad of gamepads) {
+      if (!gamepad || !gamepad.vibrationActuator) continue;
+      let startDelay = 0;
+      for (const pulse of pattern) {
+        gamepad.vibrationActuator.playEffect("dual-rumble", {
+          startDelay,
+          duration: pulse.duration,
+          weakMagnitude: pulse.weakMagnitude,
+          strongMagnitude: pulse.strongMagnitude,
+        });
+        startDelay += pulse.duration + pulse.pauseAfter;
       }
     }
   },

--- a/blocks/xr.js
+++ b/blocks/xr.js
@@ -59,6 +59,42 @@ export function defineXRBlocks() {
                 },
           };
 
+          Blockly.Blocks["play_rumble_pattern"] = {
+                init: function () {
+                  this.jsonInit({
+                        type: "play_rumble_pattern",
+                        message0: translate("play_rumble_pattern"),
+                        args0: [
+                          {
+                                type: "field_dropdown",
+                                name: "PATTERN",
+                                options: [
+                                  getDropdownOption("objectGrab"),
+                                  getDropdownOption("objectDrop"),
+                                  getDropdownOption("smallCollision"),
+                                  getDropdownOption("heavyCollision"),
+                                  getDropdownOption("snapToGrid"),
+                                  getDropdownOption("errorInvalid"),
+                                  getDropdownOption("successConfirmation"),
+                                  getDropdownOption("slidingGravel"),
+                                  getDropdownOption("slidingMetal"),
+                                  getDropdownOption("machineRunning"),
+                                  getDropdownOption("explosion"),
+                                  getDropdownOption("teleport"),
+                                ],
+                          },
+                        ],
+                        previousStatement: null,
+                        nextStatement: null,
+                        colour: categoryColours["Scene"],
+                        tooltip: getTooltip("play_rumble_pattern"),
+                  });
+                  this.setHelpUrl(getHelpUrlFor(this.type));
+                        this.setStyle('scene_blocks');
+
+                },
+          };
+
           Blockly.Blocks["controller_rumble"] = {
                 init: function () {
                   this.jsonInit({

--- a/flock.js
+++ b/flock.js
@@ -969,6 +969,8 @@ export const flock = {
                                 this.setCameraBackground?.bind(this),
                         setXRMode: this.setXRMode?.bind(this),
                         controllerRumble: this.controllerRumble?.bind(this),
+                        controllerRumblePattern: this.controllerRumblePattern?.bind(this),
+                        playRumblePattern: this.playRumblePattern?.bind(this),
                         applyForce: this.applyForce?.bind(this),
                         moveByVector: this.moveByVector?.bind(this),
                         glideTo: this.glideTo?.bind(this),

--- a/generators/generators.js
+++ b/generators/generators.js
@@ -3517,6 +3517,11 @@ export function defineGenerators() {
                 return `await setXRMode("${mode}");\n`;
         };
 
+        javascriptGenerator.forBlock["play_rumble_pattern"] = function (block) {
+                const pattern = block.getFieldValue("PATTERN");
+                return `playRumblePattern("${pattern}");\n`;
+        };
+
         javascriptGenerator.forBlock["controller_rumble"] = function (block) {
                 const motor = block.getFieldValue("MOTOR");
                 const strength = javascriptGenerator.valueToCode(

--- a/locale/de.js
+++ b/locale/de.js
@@ -363,6 +363,18 @@ export default {
   COLOUR_option: "Farbe",
   ANY_option: "beliebig",
   all_option: "alle",
+  objectGrab_option: "greifen",
+  objectDrop_option: "fallen lassen",
+  smallCollision_option: "kleiner Stoß",
+  heavyCollision_option: "harter Aufprall",
+  snapToGrid_option: "einrasten",
+  errorInvalid_option: "Fehler",
+  successConfirmation_option: "Erfolg",
+  slidingGravel_option: "Kies gleiten",
+  slidingMetal_option: "Metall gleiten",
+  machineRunning_option: "Maschine",
+  explosion_option: "Explosion",
+  teleport_option: "teleportieren",
 
   a_option: "A",
   b_option: "B",
@@ -463,6 +475,7 @@ export default {
   // XR blocks
   device_camera_background: "verwende %1 Kamera als Hintergrund",
   set_xr_mode: "XR‑Modus auf %1 setzen",
+  play_rumble_pattern: "Vibrationsmuster abspielen %1",
   controller_rumble: "Controller %1 Motor mit Stärke %2 für %3 ms vibrieren",
   controller_rumble_pattern: "Controller %1 Motor Stärke %2 an %3 ms aus %4 ms %5 mal",
 
@@ -776,6 +789,8 @@ export default {
     "Verwende Gerätekamera als Hintergrund für die Szene. Funktioniert auf Mobilgeräten und Desktop.",
   set_xr_mode_tooltip:
     "Setze XR‑Modus der Szene.\nOptionen: VR, AR, Magic Window.",
+  play_rumble_pattern_tooltip:
+    "Spielt ein vordefiniertes Vibrationsmuster auf allen angeschlossenen Controllern ab.\nStichwort: rumble preset",
   controller_rumble_tooltip:
     "Lässt einen verbundenen Gamecontroller vibrieren. Wähle alle, linken oder rechten Motor, stelle die Stärke (0 bis 1) und die Dauer in Millisekunden ein.\nStichwort: rumble",
   controller_rumble_pattern_tooltip:

--- a/locale/en.js
+++ b/locale/en.js
@@ -332,6 +332,7 @@ export default {
   // Custom block translations - XR blocks
   device_camera_background: "use %1 camera as background",
   set_xr_mode: "set XR mode to %1",
+  play_rumble_pattern: "play rumble pattern %1",
   controller_rumble: "rumble %1 motor at strength %2 for %3 ms",
   controller_rumble_pattern: "rumble %1 motor strength %2 on %3 ms off %4 ms %5 times",
 
@@ -635,6 +636,8 @@ export default {
     "Use the device camera as the background for the scene. Works on both mobile and desktop.",
   set_xr_mode_tooltip:
     "Set the XR mode for the scene.\nOptions: VR, AR, Magic Window.",
+  play_rumble_pattern_tooltip:
+    "Play a preset haptic rumble pattern on all connected controllers.\nKeyword: rumble preset",
   controller_rumble_tooltip:
     "Make a connected game controller rumble. Choose all, left, or right motor, set the strength (0 to 1), and how long to rumble in milliseconds.\nKeyword: rumble",
   controller_rumble_pattern_tooltip:
@@ -799,6 +802,18 @@ export default {
 
   ANY_option: "any",
   all_option: "all",
+  objectGrab_option: "grab",
+  objectDrop_option: "drop",
+  smallCollision_option: "small bump",
+  heavyCollision_option: "heavy crash",
+  snapToGrid_option: "snap",
+  errorInvalid_option: "error",
+  successConfirmation_option: "success",
+  slidingGravel_option: "gravel slide",
+  slidingMetal_option: "metal slide",
+  machineRunning_option: "machine",
+  explosion_option: "explosion",
+  teleport_option: "teleport",
   space_infinity_option: "space ❖", // Duplicate key space
   q_icon_option: "Q ■", // Duplicate key q
   e_icon_option: "E ✿", // Duplicate key e

--- a/locale/es.js
+++ b/locale/es.js
@@ -330,6 +330,7 @@ export default {
   // Custom block translations - XR blocks
   device_camera_background: "usar cámara %1 como fondo", // human
   set_xr_mode: "establecer modo XR a %1", // human
+  play_rumble_pattern: "reproducir patrón de vibración %1", // ai
   controller_rumble: "vibrar motor %1 con fuerza %2 durante %3 ms", // ai
   controller_rumble_pattern: "vibrar motor %1 fuerza %2 encendido %3 ms apagado %4 ms %5 veces", // ai
 
@@ -650,6 +651,8 @@ export default {
     "Usa la cámara del dispositivo como fondo para la escena. Funciona en móvil y computadora.", // human
   set_xr_mode_tooltip:
     "Establece el modo XR para la escena.\nOpciones: VR, RA, Ventana Mágica.", // human
+  play_rumble_pattern_tooltip:
+    "Reproduce un patrón de vibración predefinido en todos los mandos conectados.\nPalabra clave: rumble preset", // ai
   controller_rumble_tooltip:
     "Hace vibrar un mando de juego conectado. Elige el motor todos, izquierdo o derecho, establece la fuerza (0 a 1) y cuánto tiempo vibrar en milisegundos.\nPalabra clave: rumble", // ai
   controller_rumble_pattern_tooltip:
@@ -814,6 +817,18 @@ export default {
 
   ANY_option: "cualquiera", // human
   all_option: "todos", // ai
+  objectGrab_option: "agarrar", // ai
+  objectDrop_option: "soltar", // ai
+  smallCollision_option: "golpe leve", // ai
+  heavyCollision_option: "choque fuerte", // ai
+  snapToGrid_option: "ajustar", // ai
+  errorInvalid_option: "error", // ai
+  successConfirmation_option: "éxito", // ai
+  slidingGravel_option: "deslizar grava", // ai
+  slidingMetal_option: "deslizar metal", // ai
+  machineRunning_option: "máquina", // ai
+  explosion_option: "explosión", // ai
+  teleport_option: "teletransportar", // ai
   space_infinity_option: "espacio ❖", // human, Duplicate key space
   q_icon_option: "Q ■", // human, Duplicate key q
   e_icon_option: "E ✿", // human, Duplicate key e

--- a/locale/fr.js
+++ b/locale/fr.js
@@ -333,6 +333,7 @@ export default {
   // Custom block translations - XR blocks
   device_camera_background: "utiliser la caméra %1 comme arrière-plan",
   set_xr_mode: "définir le mode XR sur %1",
+  play_rumble_pattern: "jouer le motif de vibration %1",
   controller_rumble: "faire vibrer le moteur %1 à force %2 pendant %3 ms",
   controller_rumble_pattern: "faire vibrer le moteur %1 force %2 allumé %3 ms éteint %4 ms %5 fois",
 
@@ -653,6 +654,8 @@ export default {
     "Utilise la caméra de l’appareil comme arrière-plan pour la scène. Fonctionne sur mobile et ordinateur.",
   set_xr_mode_tooltip:
     "Définit le mode XR pour la scène.\nOptions: VR, AR, Magic Window.",
+  play_rumble_pattern_tooltip:
+    "Joue un motif de vibration prédéfini sur toutes les manettes connectées.\nMot-clé: rumble preset",
   controller_rumble_tooltip:
     "Fait vibrer une manette de jeu connectée. Choisissez le moteur tous, gauche ou droite, définissez la force (0 à 1) et la durée en millisecondes.\nMot-clé: rumble",
   controller_rumble_pattern_tooltip:
@@ -817,6 +820,18 @@ export default {
 
   ANY_option: "n'importe lequel",
   all_option: "tous",
+  objectGrab_option: "saisir",
+  objectDrop_option: "lâcher",
+  smallCollision_option: "petit choc",
+  heavyCollision_option: "choc violent",
+  snapToGrid_option: "aimanter",
+  errorInvalid_option: "erreur",
+  successConfirmation_option: "succès",
+  slidingGravel_option: "glisser gravier",
+  slidingMetal_option: "glisser métal",
+  machineRunning_option: "machine",
+  explosion_option: "explosion",
+  teleport_option: "téléporter",
   space_infinity_option: "espace ❖",
   q_icon_option: "Q ■",
   e_icon_option: "E ✿",

--- a/locale/it.js
+++ b/locale/it.js
@@ -336,6 +336,7 @@ export default {
   // Custom block translations - XR blocks
   device_camera_background: "usa la %1 del dispositivo come sfondo",
   set_xr_mode: "imposta modalità XR su %1",
+  play_rumble_pattern: "riproduci motivo di vibrazione %1",
   controller_rumble: "fai vibrare il motore %1 con intensità %2 per %3 ms",
   controller_rumble_pattern: "vibra motore %1 intensità %2 acceso %3 ms spento %4 ms %5 volte",
 
@@ -649,6 +650,8 @@ export default {
     "Usa la fotocamera del dispositivo come sfondo per la scena. Funziona su mobile e desktop.",
   set_xr_mode_tooltip:
     "Imposta la modalità XR per la scena.\nOpzioni: VR, AR, Magic Window.",
+  play_rumble_pattern_tooltip:
+    "Riproduce un motivo di vibrazione predefinito su tutti i controller collegati.\nParola chiave: rumble preset",
   controller_rumble_tooltip:
     "Fa vibrare un controller di gioco collegato. Scegli il motore tutti, sinistra o destra, imposta l'intensità (da 0 a 1) e la durata in millisecondi.\nParola chiave: rumble",
   controller_rumble_pattern_tooltip:
@@ -813,6 +816,18 @@ export default {
 
   ANY_option: "qualsiasi",
   all_option: "tutti",
+  objectGrab_option: "afferrare",
+  objectDrop_option: "rilasciare",
+  smallCollision_option: "piccolo urto",
+  heavyCollision_option: "urto forte",
+  snapToGrid_option: "aggancia",
+  errorInvalid_option: "errore",
+  successConfirmation_option: "successo",
+  slidingGravel_option: "scivola ghiaia",
+  slidingMetal_option: "scivola metallo",
+  machineRunning_option: "macchina",
+  explosion_option: "esplosione",
+  teleport_option: "teletrasporto",
   space_infinity_option: "spazio ❖", // Duplicate key space
   q_icon_option: "Q ■", // Duplicate key q
   e_icon_option: "E ✿", // Duplicate key e

--- a/locale/pl.js
+++ b/locale/pl.js
@@ -334,6 +334,7 @@ export default {
   // Custom block translations - XR blocks
   device_camera_background: "użyj kamery urządzenia %1 jako tło",
   set_xr_mode: "ustaw tryb XR na %1",
+  play_rumble_pattern: "odtwórz wzór wibracji %1",
   controller_rumble: "wibruj silnik %1 z siłą %2 przez %3 ms",
   controller_rumble_pattern: "wibruj silnik %1 siła %2 włączony %3 ms wyłączony %4 ms %5 razy",
 
@@ -646,6 +647,8 @@ export default {
   device_camera_background_tooltip:
     "Użyj kamery urządzenia jako tła sceny. działa na urządzeniach mobilnych i desktopie.",
   set_xr_mode_tooltip: "Ustaw tryb XR sceny.\nOpcje: VR, AR, Magic Window.",
+  play_rumble_pattern_tooltip:
+    "Odtwarza predefiniowany wzór wibracji na wszystkich podłączonych kontrolerach.\nSłowo kluczowe: rumble preset",
   controller_rumble_tooltip:
     "Sprawia, że podłączony kontroler wibruje. Wybierz silnik wszystkie, lewy lub prawy, ustaw siłę (od 0 do 1) i czas trwania w milisekundach.\nSłowo kluczowe: rumble",
   controller_rumble_pattern_tooltip:
@@ -810,6 +813,18 @@ export default {
 
   ANY_option: "dowolny",
   all_option: "wszystkie",
+  objectGrab_option: "chwytanie",
+  objectDrop_option: "upuszczenie",
+  smallCollision_option: "małe uderzenie",
+  heavyCollision_option: "mocne zderzenie",
+  snapToGrid_option: "przyciąganie",
+  errorInvalid_option: "błąd",
+  successConfirmation_option: "sukces",
+  slidingGravel_option: "ślizg po żwirze",
+  slidingMetal_option: "ślizg po metalu",
+  machineRunning_option: "maszyna",
+  explosion_option: "eksplozja",
+  teleport_option: "teleportacja",
   space_infinity_option: "przestrzeń ❖",
   q_icon_option: "Q ■",
   e_icon_option: "E ✿",

--- a/locale/pt.js
+++ b/locale/pt.js
@@ -331,6 +331,7 @@ export default {
   // Custom block translations - XR blocks
   device_camera_background: "usar câmera %1 como fundo",
   set_xr_mode: "definir modo XR para %1",
+  play_rumble_pattern: "reproduzir padrão de vibração %1",
   controller_rumble: "vibrar motor %1 com intensidade %2 por %3 ms",
   controller_rumble_pattern: "vibrar motor %1 intensidade %2 ligado %3 ms desligado %4 ms %5 vezes",
 
@@ -646,6 +647,8 @@ export default {
     "Usa a câmera do dispositivo como fundo da cena. Funciona em dispositivos móveis e desktop.",
   set_xr_mode_tooltip:
     "Define o modo XR da cena.\nOpções: VR, AR, Magic Window.",
+  play_rumble_pattern_tooltip:
+    "Reproduz um padrão de vibração predefinido em todos os controles conectados.\nPalavra-chave: rumble preset",
   controller_rumble_tooltip:
     "Faz um controle de jogo conectado vibrar. Escolha o motor todos, esquerdo ou direito, defina a intensidade (0 a 1) e a duração em milissegundos.\nPalavra-chave: rumble",
   controller_rumble_pattern_tooltip:
@@ -810,6 +813,18 @@ export default {
 
   ANY_option: "qualquer",
   all_option: "todos",
+  objectGrab_option: "pegar",
+  objectDrop_option: "soltar",
+  smallCollision_option: "leve colisão",
+  heavyCollision_option: "colisão forte",
+  snapToGrid_option: "encaixar",
+  errorInvalid_option: "erro",
+  successConfirmation_option: "sucesso",
+  slidingGravel_option: "deslizar cascalho",
+  slidingMetal_option: "deslizar metal",
+  machineRunning_option: "máquina",
+  explosion_option: "explosão",
+  teleport_option: "teleportar",
   space_infinity_option: "espaço ❖",
   q_icon_option: "Q ■",
   e_icon_option: "E ✿",

--- a/locale/sv.js
+++ b/locale/sv.js
@@ -329,6 +329,7 @@ export default {
       // Custom block translations - XR blocks
       device_camera_background: "använd %1 kamera som bakgrund",
       set_xr_mode: "ställ in XR-läge till %1",
+      play_rumble_pattern: "spela vibrationsmönster %1",
       controller_rumble: "vibrera %1 motor med styrka %2 i %3 ms",
       controller_rumble_pattern: "vibrera %1 motor styrka %2 på %3 ms av %4 ms %5 gånger",
 
@@ -647,6 +648,8 @@ export default {
             "Använd enhetens kamera som bakgrund för scenen. Fungerar på både mobil och dator.",
       set_xr_mode_tooltip:
             "Ställ in XR-läget för scenen.\nAlternativ: VR, AR, Magic Window.",
+      play_rumble_pattern_tooltip:
+            "Spelar ett fördefinierat vibrationsmönster på alla anslutna kontroller.\nNyckelord: rumble preset",
       controller_rumble_tooltip:
             "Gör att en ansluten spelkontroll vibrerar. Välj alla, vänster eller höger motor, ange styrka (0 till 1) och hur länge den ska vibrera i millisekunder.\nNyckelord: rumble",
       controller_rumble_pattern_tooltip:
@@ -811,6 +814,18 @@ export default {
 
       ANY_option: "vilken som helst",
       all_option: "alla",
+      objectGrab_option: "ta tag",
+      objectDrop_option: "släppa",
+      smallCollision_option: "liten stöt",
+      heavyCollision_option: "hård kollision",
+      snapToGrid_option: "snäppa",
+      errorInvalid_option: "fel",
+      successConfirmation_option: "lyckat",
+      slidingGravel_option: "grus glid",
+      slidingMetal_option: "metall glid",
+      machineRunning_option: "maskin",
+      explosion_option: "explosion",
+      teleport_option: "teleporterar",
       space_infinity_option: "rymd ❖", // Duplicate key space
       q_icon_option: "Q ■", // Duplicate key q
       e_icon_option: "E ✿", // Duplicate key e

--- a/toolbox.js
+++ b/toolbox.js
@@ -610,6 +610,11 @@ const toolboxSceneXR = {
                 },
                 {
                         kind: "block",
+                        type: "play_rumble_pattern",
+                        keyword: "rumble preset",
+                },
+                {
+                        kind: "block",
                         type: "controller_rumble",
                         keyword: "rumble",
                         inputs: {


### PR DESCRIPTION
## Summary
This PR adds support for gamepad haptic feedback in XR environments by introducing a new "controller_rumble" block that allows users to trigger vibration effects on connected game controllers.

## Key Changes
- **Block Definition** (`blocks/xr.js`): Added `controller_rumble` block with three configurable parameters:
  - Motor selection dropdown (any, left, or right)
  - Strength field (0 to 1, with 0.1 precision)
  - Duration field in milliseconds
  
- **API Implementation** (`api/xr.js`): Implemented `controllerRumble()` function that:
  - Accesses connected gamepads via the Gamepad API
  - Supports selective motor control (left/right/both)
  - Uses the Gamepad Vibration API's `dual-rumble` effect
  
- **Code Generator** (`generators/generators.js`): Added JavaScript code generation for the block to output proper function calls with parameters

- **Toolbox Integration** (`toolbox.js`): Added the block to the Scene XR toolbox with "rumble" keyword for quick access

- **Localization** (`locale/en.js`): Added English translations for:
  - Block message: "rumble %1 motor at strength %2 for %3 ms"
  - Tooltip with usage instructions and keyword reference

- **Runtime Binding** (`flock.js`): Exposed `controllerRumble` method in the flock API for script execution

## Implementation Details
The rumble effect uses the standard Gamepad Vibration API with `dual-rumble` pattern. Motor selection is handled by setting either `weakMagnitude` or `strongMagnitude` to 0, allowing precise control over which motor vibrates while maintaining compatibility with controllers that support selective motor control.

## Prompt Summary
Add haptic feedback support for XR gamepad controllers with two blocks:

A controller_rumble block with configurable motor (left/right/all), strength, and duration
A play_rumble_pattern block with 12 named preset patterns (objectGrab, objectDrop, smallCollision, heavyCollision, snapToGrid, errorInvalid, successConfirmation, slidingGravel, slidingMetal, machineRunning, explosion, teleport) — each with carefully tuned dual-motor waveforms conveying distinct physical sensations
Model
claude-sonnet-4-6

https://claude.ai/code/session_01HujV6aertAXoXbisarnPpH