### PR TITLE
Use Vite BASE_URL to resolve Blockly media assets

### DIFF
--- a/blocks/blocks.js
+++ b/blocks/blocks.js
@@ -1006,9 +1006,13 @@ export class CustomZelosRenderer extends Blockly.zelos.Renderer {
   }
 }
 
-const mediaPath = window.location.pathname.includes("/flock")
-  ? "/flock/blockly/media/" // For GitHub Pages
-  : "/blockly/media/"; // For local dev
+function getBlocklyMediaPath() {
+  let baseUrl = import.meta.env.BASE_URL || "/";
+  if (!baseUrl.endsWith("/")) baseUrl += "/";
+  return `${baseUrl}blockly/media/`;
+}
+
+const mediaPath = getBlocklyMediaPath();
 
 export const options = {
   //theme: FlockTheme,


### PR DESCRIPTION
### Motivation
- Remove fragile `window.location.pathname.includes("/flock")` branching used to choose Blockly media paths. 
- Use the Vite-provided `import.meta.env.BASE_URL` so media resolution works the same for local dev (`/`) and production sites served from a subpath (`/<repo>/`).
- Align `blocks/blocks.js` behavior with the existing `getBlocklyMediaPath` approach in `main/themes.js` for consistency.

### Description
- Added a `getBlocklyMediaPath()` helper to `blocks/blocks.js` that reads `import.meta.env.BASE_URL`, ensures it ends with `/`, and returns `${baseUrl}blockly/media/`.
- Replaced the `window.location.pathname.includes("/flock")` branch with `const mediaPath = getBlocklyMediaPath();`.
- Wired Blockly `options.media` to the computed `mediaPath` so asset paths are resolved from the Vite base URL.

### Testing
- Ran `npm run build`, which completed successfully (production build emitted with standard warnings about chunk sizes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a85ea6535c8326996bb00808770a6e)