### PR TITLE
Add PS4/PS5 touchpad click support via synthetic pointer events

### DIFF
--- a/flock.js
+++ b/flock.js
@@ -1458,7 +1458,7 @@ export const flock = {
                 let lastTouchpadPressed = false;
 
                 // Track last pointer position so the touchpad click fires at
-                // the current mouse cursor location rather than a fixed point.
+                // the current pointer location.
                 let lastPointerClientX = flock.canvas.getBoundingClientRect().left + flock.canvas.getBoundingClientRect().width / 2;
                 let lastPointerClientY = flock.canvas.getBoundingClientRect().top + flock.canvas.getBoundingClientRect().height / 2;
 


### PR DESCRIPTION
## Summary
Added support for PS4/PS5 controller touchpad clicks (button 17) by dispatching synthetic pointer events to the canvas, enabling the existing Babylon.js pick-trigger pipeline to handle touchpad interactions naturally.

## Key Changes
- Track touchpad button state (button 17) to detect press/release transitions
- Implement `fireTouchpadPointerEvent()` function that dispatches synthetic `PointerEvent` objects to the canvas center when the touchpad is clicked
- Integrate touchpad event detection into the existing gamepad observer loop
- Synthetic pointer events use standard properties (pointerId, pointerType, clientX/Y, button state) compatible with Babylon.js picking system

## Implementation Details
- Touchpad clicks are mapped to the canvas center coordinates (`rect.left + rect.width / 2`, `rect.top + rect.height / 2`)
- State tracking via `lastTouchpadPressed` variable prevents duplicate events on consecutive frames
- Pointer events are dispatched with `bubbles: true` and `cancelable: true` for proper event propagation
- The solution leverages the existing `normalizeButtonState()` utility for consistent button state handling

https://claude.ai/code/session_01MCV6VJ7Bx6GhxKxvnBjiPB