### PR TITLE
Remove inline styles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,9 @@ Before starting, we suggest you [get in touch](https://flipcomputing.com/contact
 
 ### Deploying your fork to GitHub Pages
 1. **Push your fork to GitHub**:
+   ```bash
+   git push origin main
+   ```
 
 2. **Set up GitHub Actions** 
    - Go to your fork on GitHub at https://github.com/YOUR_USERNAME/flock/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,9 +65,7 @@ Before starting, we suggest you [get in touch](https://flipcomputing.com/contact
 
 ### Deploying your fork to GitHub Pages
 1. **Push your fork to GitHub**:
-   ```bash
-   git push origin
-   ```
+
 2. **Set up GitHub Actions** 
    - Go to your fork on GitHub at https://github.com/YOUR_USERNAME/flock/
    - Click Settings > Pages

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,34 @@ Before starting, we suggest you [get in touch](https://flipcomputing.com/contact
    ```
 6. **Create a Pull Request** on GitHub
 
+### Deploying your fork to GitHub Pages
+1. **Push your fork to GitHub**:
+   ```bash
+   git push origin
+   ```
+2. **Set up GitHub Actions** 
+   - Go to your fork on GitHub at https://github.com/YOUR_USERNAME/flock/
+   - Click Settings > Pages
+   - In the 'Source' dropdown, select 'GitHub Actions'
+
+3. **Create the Flock environment**:
+   - Still in settings, click 'Environments'
+   - Click 'New Environment'
+   - Name it `flock` (all lowercase, do not change this)
+   - Click 'Configure environment' but do not make any changes 
+
+4. **Trigger the deployment**
+   - Go back to your fork at https://github.com/YOUR_USERNAME/flock/ 
+   - Click the 'Actions' tab
+   - Click 'I understand my workflows, go ahead and enable them'
+   - Click on the new option 'Vite Github Pages Deploy' 
+   - Click 'Run workflow' dropdown, then select 'Run workflow' to deploy manually
+
+5. **Visit your deployment**
+   - Once the site has deployed you will see it at https://YOUR_USERNAME.github.io/flock/
+   - GitHub pages should redeploy automatically when you push to main
+
+
 For more specific developer-facing documentation, please see [dev-docs.md](dev-docs/dev-docs.md).
 
 ## 📁 Project Structure

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ Before starting, we suggest you [get in touch](https://flipcomputing.com/contact
    - Go back to your fork at https://github.com/YOUR_USERNAME/flock/ 
    - Click the 'Actions' tab
    - Click 'I understand my workflows, go ahead and enable them'
-   - Click on the new option 'Vite Github Pages Deploy' 
+   - Click on the new option 'Vite GitHub Pages Deploy' 
    - Click 'Run workflow' dropdown, then select 'Run workflow' to deploy manually
 
 5. **Visit your deployment**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,35 +63,6 @@ Before starting, we suggest you [get in touch](https://flipcomputing.com/contact
    ```
 6. **Create a Pull Request** on GitHub
 
-### Deploying your fork to GitHub Pages
-1. **Push your fork to GitHub**:
-   ```bash
-   git push origin main
-   ```
-
-2. **Set up GitHub Actions** 
-   - Go to your fork on GitHub at https://github.com/YOUR_USERNAME/flock/
-   - Click Settings > Pages
-   - In the 'Source' dropdown, select 'GitHub Actions'
-
-3. **Create the Flock environment**:
-   - Still in settings, click 'Environments'
-   - Click 'New Environment'
-   - Name it `flock` (all lowercase, do not change this)
-   - Click 'Configure environment' but do not make any changes 
-
-4. **Trigger the deployment**
-   - Go back to your fork at https://github.com/YOUR_USERNAME/flock/ 
-   - Click the 'Actions' tab
-   - Click 'I understand my workflows, go ahead and enable them'
-   - Click on the new option 'Vite GitHub Pages Deploy' 
-   - Click 'Run workflow' dropdown, then select 'Run workflow' to deploy manually
-
-5. **Visit your deployment**
-   - Once the site has deployed you will see it at https://YOUR_USERNAME.github.io/flock/
-   - GitHub pages should redeploy automatically when you push to main
-
-
 For more specific developer-facing documentation, please see [dev-docs.md](dev-docs/dev-docs.md).
 
 ## 📁 Project Structure

--- a/index.html
+++ b/index.html
@@ -238,7 +238,7 @@
                   data-i18n-attrs="title,aria-label"
               >
                   <span class="sr-only" data-i18n="menu_button_sr_label">Menu</span>
-                  <div class="icon" style="width: 1.25em; height: 1.25em" aria-hidden="true">
+                  <div class="icon icon--sm" aria-hidden="true">
                       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" fill="#511D91">
                           <path fill="#511D91" d="M0 96C0 78.3 14.3 64 32 64h384c17.7 0 32 14.3 32 32s-14.3 32-32 32H32C14.3 128 0 113.7 0 96zm0 160c0-17.7 14.3-32 32-32h384c17.7 0 32 14.3 32 32s-14.3 32-32 32H32c-17.7 0-32-14.3-32-32zm448 160c0 17.7-14.3 32-32 32H32c-17.7 0-32-14.3-32-32s14.3-32 32-32h384c17.7 0 32-14.3 32 32z"/>
                       </svg>
@@ -291,8 +291,7 @@
                       <span class="menu-icon">
                           <svg
                               xmlns="http://www.w3.org/2000/svg"
-                              viewBox="0 0 512 512"
-                              style="width: 1.2em; height: 1.2em;"
+                              viewBox="0 0 512 512"                             
                               aria-hidden="true"
                           >
                               <path d="M352 256c0 22.2-1.2 43.6-3.3 64l-185.3 0c-2.2-20.4-3.3-41.8-3.3-64s1.2-43.6 3.3-64l185.3 0c2.2 20.4 3.3 41.8 3.3 64zm28.8-64l123.1 0c5.3 20.5 8.1 41.9 8.1 64s-2.8 43.5-8.1 64l-123.1 0c2.1-20.6 3.2-42 3.2-64s-1.1-43.4-3.2-64zm112.6-32l-116.7 0c-10-63.9-29.8-117.4-55.3-151.6c78.3 20.7 142 77.5 171.9 151.6zm-149.1 0l-176.6 0c6.1-36.4 15.5-68.6 27-94.7c10.5-23.6 22.2-40.7 33.5-51.5C239.4 3.2 248.7 0 256 0s16.6 3.2 27.8 13.8c11.3 10.8 23 27.9 33.5 51.5c11.6 26 20.9 58.2 27 94.7zm-209 0L18.6 160C48.6 85.9 112.2 29.1 190.6 8.4C165.1 42.6 145.3 96.1 135.3 160zM8.1 192l123.1 0c-2.1 20.6-3.2 42-3.2 64s1.1 43.4 3.2 64L8.1 320C2.8 299.5 0 278.1 0 256s2.8-43.5 8.1-64zM194.7 446.6c-11.6-26-20.9-58.2-27-94.6l176.6 0c-6.1 36.4-15.5 68.6-27 94.6c-10.5 23.6-22.2 40.7-33.5 51.5C272.6 508.8 263.3 512 256 512s-16.6-3.2-27.8-13.8c-11.3-10.8-23-27.9-33.5-51.5zM135.3 352c10 63.9 29.8 117.4 55.3 151.6C112.2 482.9 48.6 426.1 18.6 352l116.7 0zm358.1 0c-30 74.1-93.6 130.9-171.9 151.6c25.5-34.2 45.2-87.7 55.3-151.6l116.7 0z"/>
@@ -363,7 +362,7 @@
                       tabindex="-1"
                   >
                       <span class="menu-icon">
-                          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" style="width: 1.2em; height: 1.2em;" aria-hidden="true">
+                          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" aria-hidden="true">
                               <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336l24 0 0-64-24 0c-13.3 0-24-10.7-24-24s10.7-24 24-24l48 0c13.3 0 24 10.7 24 24l0 88 8 0c13.3 0 24 10.7 24 24s-10.7 24-24 24l-80 0c-13.3 0-24-10.7-24-24s10.7-24 24-24zm40-208a32 32 0 1 1 0 64 32 32 0 1 1 0-64z"/>
                           </svg>
                       </span>
@@ -374,7 +373,7 @@
           <div id="infoModal" class="modal hidden" role="dialog" aria-labelledby="modal-title" aria-modal="true">
             <div class="modal-content" tabindex="-1">
               <span class="close-button" id="closeInfoModal" aria-label="Close information modal">&times;</span>
-              <h2 id="modal-title" data-i18n="about_heading" style="margin-top: 0;">About Flock XR</h2>
+              <h2 id="modal-title" data-i18n="about_heading">About Flock XR</h2>
 
               <div id="model-panel-content">
               <p>
@@ -390,18 +389,8 @@
                 <span data-i18n="about_description_disclaimer"></span>
               </p>
               <div class="about-run">
-                <span data-i18n="about_run_intro"></span>
-                <div
-                  style="
-                    display: inline-block;
-                    margin-left: 2px;
-                    margin-right: 2px;
-                  "
-                >
-                  <div
-                    class="icon"
-                    style="height: 1em; width: 1em; padding: 0px"
-                  >
+                <span data-i18n="about_run_intro"></span>               
+                  <div class="icon icon--inline" aria-hidden="true">
                     <svg
                       xmlns="http://www.w3.org/2000/svg"
                       viewBox="0 0 512 512"
@@ -411,8 +400,7 @@
                         d="M0 256a256 256 0 1 1 512 0A256 256 0 1 1 0 256zM188.3 147.1c-7.6 4.2-12.3 12.3-12.3 20.9l0 176c0 8.7 4.7 16.7 12.3 20.9s16.8 4.1 24.3-.5l144-88c7.1-4.4 11.5-12.1 11.5-20.5s-4.4-16.1-11.5-20.5l-144-88c-7.4-4.5-16.7-4.7-24.3-.5z"
                       />
                     </svg>
-                  </div>
-                </div>
+                  </div>            
                 <span data-i18n="about_run_action"></span>
               </div>
               <p>      
@@ -835,7 +823,7 @@
           >
             <label for="fileInput" class="sr-only" data-i18n="open_file_input_label">Select project file to open</label>
             <input type="file" id="fileInput" style="display: none" disabled />
-            <div class="icon" style="width: 1.25em; height: 1.25em" aria-hidden="true">
+            <div class="icon icon--sm" aria-hidden="true">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--!Font Awesome Free v6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.--><path fill="#511D91" d="M288 109.3L288 352c0 17.7-14.3 32-32 32s-32-14.3-32-32l0-242.7-73.4 73.4c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3l128-128c12.5-12.5 32.8-12.5 45.3 0l128 128c12.5 12.5 12.5 32.8 0 45.3s-32.8 12.5-45.3 0L288 109.3zM64 352l128 0c0 35.3 28.7 64 64 64s64-28.7 64-64l128 0c35.3 0 64 28.7 64 64l0 32c0 35.3-28.7 64-64 64L64 512c-35.3 0-64-28.7-64-64l0-32c0-35.3 28.7-64 64-64zM432 456a24 24 0 1 0 0-48 24 24 0 1 0 0 48z"/></svg>
             </div>
           </button>
@@ -862,7 +850,7 @@
             aria-label="Save this project to a file on your computer"
             aria-describedby="export-desc"
           >
-            <div class="icon" style="width: 1.25em; height: 1.25em" aria-hidden="true">
+            <div class="icon icon--sm" aria-hidden="true">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
                 <!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->
                 <path
@@ -878,12 +866,11 @@
             class="bigbutton"
             data-i18n="example_select"
             title="Choose an example project to load."
-            style="font-size: 14px"
             disabled
             aria-label="Choose an example project to load"
             aria-describedby="demo-desc"
           >
-            <option value="" data-i18n="demo" style="color: #511d91">Demo</option>
+            <option value="" data-i18n="demo">Demo</option>
             <option id="new" data-i18n="new" value="examples/new.flock">New</option>
             <option data-i18n="starter" value="examples/starter.flock">👋🏽 Starter</option>
             <option data-i18n="snow_globe" value="examples/snow_globe.flock">❄️ Snow globe</option>
@@ -935,7 +922,7 @@
           </button>
           <div id="design-desc" class="sr-only">Toggle design mode to visually create and modify 3D objects in your scene</div>
           <button class="bigbutton" id="togglePlay" data-i18n="toggle_play" title="Use your project" aria-label="Switch to play mode" aria-describedby="play-desc" aria-pressed="false">
-            <div class="icon" style="width: 2em" aria-hidden="true">
+            <div class="icon" aria-hidden="true">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512">
                 <!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->
                 <path
@@ -980,8 +967,7 @@
               <button
                 class="gizmo-button"
                 id="showShapesButton"
-                data-i18n="show_shapes_button"
-                style="margin-left: 5px"
+                data-i18n="show_shapes_button"                
                 disabled
                 aria-label="Add shapes and models"
                 title="Add shapes and models"
@@ -1278,16 +1264,16 @@
                   id="info-panel-link"
                   data-i18n="info_panel_link"
                   
-                  aria-label="Visit Flock XR website (opens in new tab)"
-                  title="Visit Flock XR website"
+                  aria-label="Visit Flock XR website (opens in new tab)"
+                  title="Visit Flock XR website"
                 >
                   <img
                     src="./images/inline-flock-xr.svg"
-                    alt="Flock XR logo"
+                    alt="Flock XR logo"
                     id="flocklogo"
                   >
                   <span class="sr-only">
-                    Visit Flock XR website in a new tab
+                    Visit Flock XR website in a new tab
                   </span>
                 </a>
               </div>

--- a/style.css
+++ b/style.css
@@ -1155,7 +1155,13 @@ body.color-picker-open #renderCanvas {
   margin-right: 2px;
   height: 1em; 
   width: 1em; 
-  padding: 0px
+  padding: 0;
+}
+
+.icon--inline svg {
+  width: 100%;
+  height: 100%;
+  display: block;
 }
 
 /* Make the gamepad icon wider */

--- a/style.css
+++ b/style.css
@@ -91,10 +91,10 @@
   --color-spinner-border-top:        var(--color-primary);
 
   /* Dropdown & menus */
-  --color-dropdown-text:        var(--color-text);
-  --color-menu-item-text:       var(--color-text);
-  --color-dropdown-menu-bg:     var(--color-bg);
-  --color-dropdown-menu-hover:  rgba(0, 0, 0, 0.05);
+  --color-dropdown-text: var(--color-text);
+  --color-menu-item-text: var(--color-text);
+  --color-dropdown-menu-bg: var(--color-bg);
+  --color-dropdown-menu-hover: rgba(0, 0, 0, 0.05);
   --color-dropdown-menu-border: var(--color-dropdown-menu-border, 1px solid rgba(0,0,0,0.1));
 
   --color-dropdown-bg:               #333333;
@@ -150,10 +150,10 @@
   --color-spinner-border-top:        var(--color-primary);
 
   /* Dropdown & menus */
-  --color-dropdown-text:        var(--color-text);
-  --color-menu-item-text:       var(--color-text);
-  --color-dropdown-menu-bg:     var(--color-bg);
-  --color-dropdown-menu-hover:  rgba(0, 0, 0, 0.05);
+  --color-dropdown-text: var(--color-text);
+  --color-menu-item-text: var(--color-text);
+  --color-dropdown-menu-bg: var(--color-bg);
+  --color-dropdown-menu-hover: rgba(0, 0, 0, 0.05);
   --color-dropdown-menu-border: var(--color-dropdown-menu-border, 1px solid rgba(0,0,0,0.1));
 
   --color-dropdown-bg:               #333333;
@@ -399,6 +399,11 @@ button {
   color: var(--color-text-primary);
 }
 
+/* Font size for examples menu */
+#exampleSelect {
+  font-size: 14px;
+}
+
 /* Canvas Styles */
 #renderCanvas {
   width: 100%;
@@ -571,6 +576,7 @@ button {
   position: relative;
   display: inline-block;
   z-index: 80;
+  margin-left: 5px;
 }
 
 #shapes-dropdown {
@@ -978,6 +984,10 @@ button {
   overflow-y: auto;
 }
 
+.modal-content h2 {
+  margin-top: 0;
+}
+
 .hidden {
   display: none;
 }
@@ -1129,6 +1139,26 @@ body.color-picker-open #renderCanvas {
   height: 100%;
   display: block;
   fill: var(--color-text-brand);
+}
+
+/* Make some of the icons smaller for better fit in buttons */
+.bigbutton .icon--sm {
+  height: 1.25em;
+  width: 1.25em;
+}
+
+/* Style inline icon (e.g. run button) */
+.icon--inline {
+  display: inline-block;
+  margin-left: 2px;
+  margin-right: 2px;
+  height: 1em; 
+  width: 1em; 
+  padding: 0px
+}
+
+#togglePlay .icon {
+  width: 2em;
 }
 
 .menu-icon svg {

--- a/style.css
+++ b/style.css
@@ -984,6 +984,7 @@ button {
   overflow-y: auto;
 }
 
+/* Always skip the top margin for h2s in modals */
 .modal-content h2 {
   margin-top: 0;
 }
@@ -1157,6 +1158,7 @@ body.color-picker-open #renderCanvas {
   padding: 0px
 }
 
+/* Make the gamepad icon wider */
 #togglePlay .icon {
   width: 2em;
 }


### PR DESCRIPTION
# Summary
Remove (almost) all inline styles from index.html and put them in `style.css` instead. 
Claude Sonnet 4.6 was asked to list inline styles and then each was modified by hand, sometimes with AI advice. 

# Changes
- Add new icon--sm class for icons which need to be smaller
- Remove some redundant styles
- Always skip the top margin on H2 in a modal
- Add icon--inline class for icons inline within text
- Add togglePlay specific width increase style
- Remove some nbsp characters
- Add exampleSelect specific font size for examples menu
- Display the shape menu with a 5px margin to the left 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Consolidated inline icon and control styling into standardized classes; added consistent sizing and spacing for icons and controls.
  * Normalized CSS variables and set explicit font-size for example select controls.

* **Refactor**
  * Simplified markup by removing redundant wrappers and relying on class-based styling.

* **Accessibility**
  * Standardized alt text and adjusted accessibility attributes for links and logos.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->