### PR TITLE
Group MODE field changes with disconnect events into single undo entry

### DIFF
--- a/blocks/control.js
+++ b/blocks/control.js
@@ -461,6 +461,10 @@ export function defineControlBlocks() {
       // True while Blockly is constructing/rehydrating the block graph.
       this._isRestoring = true;
 
+      // Tracks a group we opened in the MODE validator so we can close it
+      // once Blockly fires the corresponding BLOCK_CHANGE event.
+      this._modeChangeGroupId = null;
+
       this.appendDummyInput("HEAD").appendField(
         new Blockly.FieldDropdown(
           [
@@ -469,6 +473,14 @@ export function defineControlBlocks() {
             ["%{BKY_CONTROLS_IF_MSG_ELSE}", MODE.ELSE],
           ],
           (newValue) => {
+            // If there's no active event group, open one so that any
+            // BLOCK_MOVE events fired by validateAndDisconnectInvalidChain_
+            // land in the same undo entry as the BLOCK_CHANGE that Blockly
+            // fires for this field after the validator returns.
+            if (!Blockly.Events.getGroup() && !this._modeChangeGroupId) {
+              Blockly.Events.setGroup(true);
+              this._modeChangeGroupId = Blockly.Events.getGroup();
+            }
             this.updateShape_(newValue);
             return newValue;
           },
@@ -583,6 +595,22 @@ export function defineControlBlocks() {
     onchange: function (event) {
       if (!this.workspace || this._isRestoring || this.isDisposed()) {
         return;
+      }
+
+      // Close the event group we opened in the MODE validator once Blockly
+      // has fired the corresponding BLOCK_CHANGE, so that the field change
+      // and any prior disconnect events are a single undo entry.
+      if (
+        this._modeChangeGroupId &&
+        event.type === Blockly.Events.BLOCK_CHANGE &&
+        event.element === "field" &&
+        event.name === "MODE" &&
+        event.blockId === this.id
+      ) {
+        if (Blockly.Events.getGroup() === this._modeChangeGroupId) {
+          Blockly.Events.setGroup(false);
+        }
+        this._modeChangeGroupId = null;
       }
 
       const isRelevantEvent =


### PR DESCRIPTION
## Summary
This change ensures that when the MODE field is changed on a control block, any block disconnections triggered by validation are grouped together with the field change into a single undo entry, providing a better user experience.

## Key Changes
- Added `_modeChangeGroupId` property to track event groups opened during MODE field changes
- Modified the MODE field validator to open a new event group if one isn't already active, allowing subsequent disconnect events to be grouped together
- Added logic in the `onchange` handler to close the event group once Blockly fires the corresponding `BLOCK_CHANGE` event for the MODE field

## Implementation Details
The solution works by:
1. When the MODE field dropdown changes, the validator checks if an event group is already active
2. If no group exists, it creates one and stores its ID in `_modeChangeGroupId`
3. The `updateShape_` method then executes, potentially triggering `BLOCK_MOVE` events from `validateAndDisconnectInvalidChain_`
4. Once Blockly fires the `BLOCK_CHANGE` event for the field change, the `onchange` handler detects it and closes the event group
5. This ensures all related events (field change + disconnections) are treated as a single undo operation

This approach respects existing event groups and only creates new ones when necessary, avoiding interference with other event grouping logic.

https://claude.ai/code/session_013VxihhypLXT63EyPWiBk6j

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved undo/redo handling for the if_clause block MODE field. When users modify the MODE, related block adjustments are now grouped into a single undo action, allowing all connected changes to be reverted together in one step rather than multiple operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->