### PR TITLE
Fix inspector icons being purple on grey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ playwright-report/
 logs/
 *.log
 reports/
+.claude/settings.json
+.claude/settings.local.json

--- a/style.css
+++ b/style.css
@@ -556,6 +556,18 @@ button {
 .bigbutton svg {
   filter: none; /* light mode: normal */
 }
+/* Only apply to flock icons, not Babylon.js icons */
+[data-theme="dark"] #flockeditor .icon path {
+  fill: #bababa !important;
+}
+
+[data-theme="dark-contrast"] #flockeditor .icon path {
+  fill: #cdcdcd !important;
+}
+
+[data-theme="contrast"] #flockeditor .icon path {
+  fill: #ffffff !important;
+}
 
 [data-theme="contrast"] .gizmo-button img {
   color: #ffffff !important;
@@ -1140,7 +1152,8 @@ body.color-picker-open #renderCanvas {
   height: 1.5em;
 }
 
-.bigbutton .icon svg {
+/* Make this specific to flock editor buttons, not Babylon.js */
+#flockeditor .bigbutton .icon svg {
   width: 100%;
   height: 100%;
   display: block;
@@ -1193,13 +1206,6 @@ body.color-picker-open #renderCanvas {
   min-width: 100px;
   flex-grow: 1;
   margin-right: 10px;
-}
-
-#projectName {
-  flex-shrink: 1;
-  width: 100%;
-  min-width: 10px;
-  max-width: 80px;
 }
 
 .menu-item,

--- a/style.css
+++ b/style.css
@@ -238,7 +238,7 @@
 }
 
 ::placeholder {
-  color: var(--color-text-primary) !important;
+  color: var(--color-text-primary);
 }
 
 [data-theme="contrast"] #exampleSelect {
@@ -1142,6 +1142,11 @@ body.color-picker-open #renderCanvas {
 /* Add an icon colour, so that svgs don't have a hardcoded fill colour */
 .icon {
   color: var(--color-text-brand);
+}
+
+/* Override Flock UI colours so that Babylon.js can use its own */
+#sceneExplorer .icon {
+  color: unset;
 }
 
 .bigbutton .icon {


### PR DESCRIPTION
# Summary
- Allow Babylon.js to set its own colour for icons in the inspector panel
- Fix the placeholder text within the inspector filter (previously forced as black on grey)

Claude Sonnet 4.6 provided advice and located CSS items to change. 

## Caveats
I don't think that this causes problems anywhere else with placeholder text, but I have removed the !important specificity on the `::placeholder` rule so it's possible that there is a side effect somewhere that I haven't noticed. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved placeholder text styling with consistent color handling.
  * Enhanced icon appearance and color accuracy in dark theme modes.
  * Refined button and layout styling for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->