### PR TITLE
Remove unnecessary CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,18 +50,6 @@
     <!-- Duplicate CSS to prevent flash of unstyled content on load, rest of styles in style.css -->
     <link rel="stylesheet" href="style.css" />
     <style>
-      .sr-only {
-        position: absolute;
-        width: 1px;
-        height: 1px;
-        padding: 0;
-        margin: -1px;
-        overflow: hidden;
-        clip: rect(0, 0, 0, 0);
-        white-space: nowrap;
-        border: 0;
-      }
-
       /* Critical loading styles - inline to prevent flash */
       #flockeditor {
         opacity: 0 !important;
@@ -335,6 +323,7 @@
                 <span class="sr-only" data-i18n="menu_button_sr_label"
                   >Menu</span
                 >
+                <!-- Inline CSS for 1.25em otherwise this could be .bigbutton .icon -->
                 <div
                   class="icon"
                   style="width: 1.25em; height: 1.25em"

--- a/style.css
+++ b/style.css
@@ -836,10 +836,6 @@ button {
     outline: 3px solid var(--color-focus);
   }
 
-  .resizer:hover {
-    /*width: 20px; Hover expansion */
-  }
-
   .resizer::before {
     height: 60px; /* Taller grip indicator */
     width: 6px; /* Thicker grip */


### PR DESCRIPTION
# Summary
- Remove screenreader class from critical loading styles in `index.html`
- Remove empty CSS declaration (prettier wasn't happy)

Claude Sonnet 4.6 was asked to identify any CSS that could be moved. Decisions made by a human. 

## Notes
I don't think that this should cause any problems with FOUC as the screen reader elements shouldn't be visible anyway when loading, but just checking that this is OK @tracygardner . I think it's better to have `.sr-only` defined in only one place. 