### PR TITLE
Use ESLint as a workflow, and lint (almost) everything 

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,0 +1,16 @@
+name: ESLint
+
+on:
+  pull_request:
+
+jobs:
+  eslint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npx eslint .
+        continue-on-error: true # Remove to block PRs that fail the check

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,7 @@ import pluginJs from "@eslint/js";
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [
+  { ignores: ["node_modules/", "dev-dist/", "dist/", "examples/"] },
   { languageOptions: { globals: globals.browser } },
   pluginJs.configs.recommended,
 ];

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "node --max-old-space-size=4096 node_modules/vite/bin/vite.js build",
     "serve": "vite preview",
-    "lint": "eslint flock.js && npm run check:link-security",
+    "lint": "eslint . && npm run check:link-security",
     "check:link-security": "node scripts/check-link-security.mjs",
     "test:api": "node scripts/run-api-tests.mjs",
     "test:api:watch": "node scripts/run-api-tests.mjs --watch",


### PR DESCRIPTION
# Summary
- Add an ESLint workflow which raises linting issues on PRs (but doesn't block them)
- The `npm run lint` command lints everything not just `flock.js`
- Various directories are spared from this wider lint-fest

Claude Sonnet 4.6 advised on which files to change, decisions were made by a human. 

Addresses #415 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced pull request validation with automated code quality checks
  * Expanded code linting to cover the entire project
  * Configured linting as non-blocking feedback for pull requests
  * Optimized linting to exclude build and dependency directories

<!-- end of auto-generated comment: release notes by coderabbit.ai -->