### PR TITLE
Add report to track the age of automated tests for the API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1678,33 +1678,33 @@
       }
     },
     "node_modules/@babylonjs/addons": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@babylonjs/addons/-/addons-8.56.1.tgz",
-      "integrity": "sha512-2LUFP+Vn0sp8wtkIYpViDNZXnrDYt2aZWj8bt+u0XFmFdtpJSsUXAm9dabkDp9XEz+07iuK+1EqmpF71GaWViw==",
+      "version": "8.56.2",
+      "resolved": "https://registry.npmjs.org/@babylonjs/addons/-/addons-8.56.2.tgz",
+      "integrity": "sha512-CiWyleGcNG0EB8ZqUkIbDMyOAbBum0QP81ACNEPZJBJGKKYl4FNiUdC5BMyJbsWb9K4lcxsH7acpsPQR54bACA==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@babylonjs/core": "^8.0.0"
       }
     },
     "node_modules/@babylonjs/core": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-8.56.1.tgz",
-      "integrity": "sha512-oy/wnZifTdNnE4zMIyo8AKF7sYX/HpQjCbAuU18vDqwV4vyD73p0BKEfxsCR17G/p1zGAyaJgsw23gYvY1empg==",
+      "version": "8.56.2",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-8.56.2.tgz",
+      "integrity": "sha512-UShs1pt8tSTLYOoITWclXPNrUZUpuHvB2Ur2L1D+uM8c9qaAYOi9gjkurOkQwIlbPGqwQHWImGEyiyix0mQ1dg==",
       "license": "Apache-2.0"
     },
     "node_modules/@babylonjs/gui": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@babylonjs/gui/-/gui-8.56.1.tgz",
-      "integrity": "sha512-BbzErM1JjOlTdLONiCNFDIRL3o2fKhtzyCPuQuKu4H1Hmko4OBRwXfvP4UUg+O8+i4gSZIrVip3uJ3olM0MVWQ==",
+      "version": "8.56.2",
+      "resolved": "https://registry.npmjs.org/@babylonjs/gui/-/gui-8.56.2.tgz",
+      "integrity": "sha512-p1zGvZpxnM6aQbWXWf94Q4TrOZ2VQoMUqeNBTgaGWZ4PhxYyqFU7AN3CaqDjhfn7YTAm/Rjx0E0B5EQMDPsQBA==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@babylonjs/core": "^8.0.0"
       }
     },
     "node_modules/@babylonjs/gui-editor": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@babylonjs/gui-editor/-/gui-editor-8.56.1.tgz",
-      "integrity": "sha512-nzCQ10x0xr0s2iyndAECTcUN6qHwIK1Iv40fjl3qRaGnZxKlje1esefoP88YZKfPCl9JAYSuVbQm3yOKdAf4OQ==",
+      "version": "8.56.2",
+      "resolved": "https://registry.npmjs.org/@babylonjs/gui-editor/-/gui-editor-8.56.2.tgz",
+      "integrity": "sha512-PBBaTJAJ7SAM16YSAcBf7h0WTSvXoqDWi7gELO4rLD44CJlFFMAXY+g0ZYMxvWZeRPNu7eNuf4fuxFKncOZDPQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@babylonjs/core": "^8.0.0",
@@ -1746,9 +1746,9 @@
       }
     },
     "node_modules/@babylonjs/loaders": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-8.56.1.tgz",
-      "integrity": "sha512-10zdyCjg02XXOK2bNLjpNbT/I1mgaV9sw20cyb1CojEdUEji8SqqUY2Xw1VIlb8fud/0WYQceVNCK8zk9SKT4g==",
+      "version": "8.56.2",
+      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-8.56.2.tgz",
+      "integrity": "sha512-I2klIhTl4HLVVQEMsBpEh5YqbCCi1hA1oajRVCUcy+9Vfh0owzHEGau0GsVRlAOeYEBDNUrfOj0N6nFGTjNQ6g==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@babylonjs/core": "^8.0.0",
@@ -1756,18 +1756,18 @@
       }
     },
     "node_modules/@babylonjs/materials": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@babylonjs/materials/-/materials-8.56.1.tgz",
-      "integrity": "sha512-WJIF7E1PhCvAhDQsSutaso8z/r++uMzQylyMYt5vcrZA/Ppefn5PUMIKbpc5vgwTbWswsQvsc2VqEqYX4ql1Mw==",
+      "version": "8.56.2",
+      "resolved": "https://registry.npmjs.org/@babylonjs/materials/-/materials-8.56.2.tgz",
+      "integrity": "sha512-uBcw0fT3NdQlm/2dG7vmaDyK3yl/MrKWEJVAW64O1oU3KPPvprHAA7r1yhDidHPEFKYmwO9fCazDqW9NN8Z6gQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@babylonjs/core": "^8.6.0"
       }
     },
     "node_modules/@babylonjs/serializers": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@babylonjs/serializers/-/serializers-8.56.1.tgz",
-      "integrity": "sha512-cQNcPmfcQdqq9GMsr06OANUd761CfyZpt5DT7g37/vI2k2dzDP3QZTBbxL1wMsKJuw+qdrL4D6+voAdOwz9rBg==",
+      "version": "8.56.2",
+      "resolved": "https://registry.npmjs.org/@babylonjs/serializers/-/serializers-8.56.2.tgz",
+      "integrity": "sha512-bpc3dSNPFFim2/8tUZnbBQYS3+HM4nJKFH2jPQt08f5tlkud7y0erfKeKjEnTZM8qsE4f+NhoXmCx8lHOdAqmw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@babylonjs/core": "^8.0.0",
@@ -3501,9 +3501,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/pluginutils/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3514,9 +3514,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
-      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.0.tgz",
+      "integrity": "sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==",
       "cpu": [
         "arm"
       ],
@@ -3528,9 +3528,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
-      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.0.tgz",
+      "integrity": "sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==",
       "cpu": [
         "arm64"
       ],
@@ -3542,9 +3542,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
-      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.0.tgz",
+      "integrity": "sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==",
       "cpu": [
         "arm64"
       ],
@@ -3556,9 +3556,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
-      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.0.tgz",
+      "integrity": "sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==",
       "cpu": [
         "x64"
       ],
@@ -3570,9 +3570,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
-      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.0.tgz",
+      "integrity": "sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==",
       "cpu": [
         "arm64"
       ],
@@ -3584,9 +3584,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
-      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.0.tgz",
+      "integrity": "sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==",
       "cpu": [
         "x64"
       ],
@@ -3598,9 +3598,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
-      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.0.tgz",
+      "integrity": "sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==",
       "cpu": [
         "arm"
       ],
@@ -3612,9 +3612,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
-      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.0.tgz",
+      "integrity": "sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==",
       "cpu": [
         "arm"
       ],
@@ -3626,9 +3626,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
-      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.0.tgz",
+      "integrity": "sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==",
       "cpu": [
         "arm64"
       ],
@@ -3640,9 +3640,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
-      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.0.tgz",
+      "integrity": "sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==",
       "cpu": [
         "arm64"
       ],
@@ -3654,9 +3654,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
-      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.0.tgz",
+      "integrity": "sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==",
       "cpu": [
         "loong64"
       ],
@@ -3668,9 +3668,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
-      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.0.tgz",
+      "integrity": "sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==",
       "cpu": [
         "loong64"
       ],
@@ -3682,9 +3682,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
-      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.0.tgz",
+      "integrity": "sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==",
       "cpu": [
         "ppc64"
       ],
@@ -3696,9 +3696,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
-      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.0.tgz",
+      "integrity": "sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==",
       "cpu": [
         "ppc64"
       ],
@@ -3710,9 +3710,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
-      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.0.tgz",
+      "integrity": "sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==",
       "cpu": [
         "riscv64"
       ],
@@ -3724,9 +3724,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
-      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.0.tgz",
+      "integrity": "sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==",
       "cpu": [
         "riscv64"
       ],
@@ -3738,9 +3738,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
-      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.0.tgz",
+      "integrity": "sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==",
       "cpu": [
         "s390x"
       ],
@@ -3752,9 +3752,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.0.tgz",
+      "integrity": "sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==",
       "cpu": [
         "x64"
       ],
@@ -3766,9 +3766,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
-      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.0.tgz",
+      "integrity": "sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==",
       "cpu": [
         "x64"
       ],
@@ -3780,9 +3780,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
-      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.0.tgz",
+      "integrity": "sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==",
       "cpu": [
         "x64"
       ],
@@ -3794,9 +3794,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
-      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.0.tgz",
+      "integrity": "sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==",
       "cpu": [
         "arm64"
       ],
@@ -3808,9 +3808,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
-      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.0.tgz",
+      "integrity": "sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==",
       "cpu": [
         "arm64"
       ],
@@ -3822,9 +3822,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
-      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.0.tgz",
+      "integrity": "sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==",
       "cpu": [
         "ia32"
       ],
@@ -3836,9 +3836,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.0.tgz",
+      "integrity": "sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==",
       "cpu": [
         "x64"
       ],
@@ -3850,9 +3850,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
-      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.0.tgz",
+      "integrity": "sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==",
       "cpu": [
         "x64"
       ],
@@ -4037,9 +4037,9 @@
       }
     },
     "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4191,35 +4191,35 @@
       }
     },
     "node_modules/babylonjs": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-8.56.1.tgz",
-      "integrity": "sha512-ggaIUCn9yY/B4IIEHtI3ZzlHHRJ5PJQsB9cSMvdYvLpy/toIyVFrdB0B9uSw3XZRlecMNNjxHAmtkMuDzRHYnA==",
+      "version": "8.56.2",
+      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-8.56.2.tgz",
+      "integrity": "sha512-fQdVZfjccdlbQqrRH0nZMJuLnFtIW2wUVIjRaUqXSNLSlq/OgFKG+dDODHGpZqmJHO6WIOJB/mWxIUCKQrjV8Q==",
       "hasInstallScript": true,
       "license": "Apache-2.0"
     },
     "node_modules/babylonjs-gltf2interface": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-8.56.1.tgz",
-      "integrity": "sha512-ZWgSyJYsoxvwIlJvnEjuh1gso5uFkmvFrS9e6pTuETubxezlrbcn7XYu/JPqpyaGA3SJqH9+xd0vvdBMrL0XOg==",
+      "version": "8.56.2",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-8.56.2.tgz",
+      "integrity": "sha512-c2k14C9mPR0pnfksjBdC4uXEos3t2IAYxcMgn5tI1OSC3aDfr6JAq4kADM4gfN9cUo2qIiDdSg6geUVeU8vi6w==",
       "license": "Apache-2.0"
     },
     "node_modules/babylonjs-gui": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-8.56.1.tgz",
-      "integrity": "sha512-jgYxkPbfRvTy0SIrcgnE6q3cpWWMO2GGJkxSuxdeqXiAPgmHFPnXwfSF8ehuUgxVmCH244qJ0Qo0f1RO2Mev8w==",
+      "version": "8.56.2",
+      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-8.56.2.tgz",
+      "integrity": "sha512-LEm6Os7oms1QFMVryhiJ3wiD5GKcCo+PplwMXs0Tf+PBMN3eUTTyGBpqB1LWpv0/SGpUwx0P6u/09T3LE+1F0w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "babylonjs": "8.56.1"
+        "babylonjs": "8.56.2"
       }
     },
     "node_modules/babylonjs-serializers": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-serializers/-/babylonjs-serializers-8.56.1.tgz",
-      "integrity": "sha512-76TQqvhwTeMk6BtRdz8DaUX70G616VoaMusk6slt7+Cq9l0FoUD/NB5G3bucW+yH8DzmbhE3dkhYERDwtrdYZQ==",
+      "version": "8.56.2",
+      "resolved": "https://registry.npmjs.org/babylonjs-serializers/-/babylonjs-serializers-8.56.2.tgz",
+      "integrity": "sha512-Jq5LldFPKKav/IHaMZaJDZd4Cd0FqBnQnq9+COIVbDw0NwZhI6NLhIKRMQMp7HhdGmTBfrlaM4UglRRPI2orbQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "babylonjs": "8.56.1",
-        "babylonjs-gltf2interface": "8.56.1"
+        "babylonjs": "8.56.2",
+        "babylonjs-gltf2interface": "8.56.2"
       }
     },
     "node_modules/balanced-match": {
@@ -4233,9 +4233,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.9",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.9.tgz",
-      "integrity": "sha512-OZd0e2mU11ClX8+IdXe3r0dbqMEznRiT4TfbhYIbcRPZkqJ7Qwer8ij3GZAmLsRKa+II9V1v5czCkvmHH3XZBg==",
+      "version": "2.10.10",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.10.tgz",
+      "integrity": "sha512-sUoJ3IMxx4AyRqO4MLeHlnGDkyXRoUG0/AI9fjK+vS72ekpV0yWVY7O0BVjmBcRtkNcsAO2QDZ4tdKKGoI6YaQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4259,9 +4259,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.3.1.tgz",
-      "integrity": "sha512-BbWUcpqroY241XgSxTuAiEMHeIZ6u3+oD2zOATf3Fi+0NMWJ/MdMtuSkOcDCSk6Nc7WR3z5n9GHKqz2L+3kQOQ==",
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+      "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
       "license": "Apache-2.0",
       "dependencies": {
         "jsdom": "26.1.0"
@@ -4271,9 +4271,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4408,9 +4408,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001780",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001780.tgz",
-      "integrity": "sha512-llngX0E7nQci5BPJDqoZSbuZ5Bcs9F5db7EtgfwBerX9XGtkkiO4NwfDDIRzHTTwcYC8vC7bmeUEPGrKlR/TkQ==",
+      "version": "1.0.30001781",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001781.tgz",
+      "integrity": "sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==",
       "dev": true,
       "funding": [
         {
@@ -4888,9 +4888,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.321",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.321.tgz",
-      "integrity": "sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==",
+      "version": "1.5.325",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.325.tgz",
+      "integrity": "sha512-PwfIw7WQSt3xX7yOf5OE/unLzsK9CaN2f/FvV3WjPR1Knoc1T9vePRVV4W1EM301JzzysK51K7FNKcusCr0zYA==",
       "dev": true,
       "license": "ISC"
     },
@@ -5115,16 +5115,16 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.3.tgz",
-      "integrity": "sha512-COV33RzXZkqhG9P2rZCFl9ZmJ7WL+gQSCRzE7RhkbclbQPtLAWReL7ysA0Sh4c8Im2U9ynybdR56PV0XcKvqaQ==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.1.0.tgz",
+      "integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.3",
-        "@eslint/config-helpers": "^0.5.2",
+        "@eslint/config-helpers": "^0.5.3",
         "@eslint/core": "^1.1.1",
         "@eslint/plugin-kit": "^0.6.1",
         "@humanfs/node": "^0.16.6",
@@ -5137,7 +5137,7 @@
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^9.1.2",
         "eslint-visitor-keys": "^5.0.1",
-        "espree": "^11.1.1",
+        "espree": "^11.2.0",
         "esquery": "^1.7.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -5334,6 +5334,41 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.5.9",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.9.tgz",
+      "integrity": "sha512-jldvxr1MC6rtiZKgrFnDSvT8xuH+eJqxqOBThUVjYrxssYTo1avZLGql5l0a0BAERR01CadYzZ83kVEkbyDg+g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.2"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -6799,9 +6834,9 @@
       }
     },
     "node_modules/manifold-3d": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/manifold-3d/-/manifold-3d-3.4.0.tgz",
-      "integrity": "sha512-GD5PrrJRG8YTfELvxWl00YYHdlpk+qUEkJ7weYrGUKwoUHQ7CfXSz0aWM4Obw6iIh7PnQIz6+QCMXmEX9n6Uhg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/manifold-3d/-/manifold-3d-3.4.1.tgz",
+      "integrity": "sha512-qb20ldFMUBu3w0dBZ61Hmi3FKCqGxST92wC+wH3iOTyT+5qCyKPvi9xDAFDfhPtkw0YfJQ5XsQfUIvFClyRFOw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@gltf-transform/core": "^4.2.0",
@@ -6812,6 +6847,7 @@
         "@jscadui/3mf-export": "^0.5.0",
         "commander": "^13.1.0",
         "convert-source-map": "^2.0.0",
+        "fast-xml-parser": "^5.4.2",
         "fflate": "^0.8.0",
         "magic-string": "^0.30.21"
       },
@@ -7204,6 +7240,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
+      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -7246,9 +7297,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7369,9 +7420,9 @@
       }
     },
     "node_modules/property-graph": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/property-graph/-/property-graph-4.0.0.tgz",
-      "integrity": "sha512-I0hojAJfTbSCZy3y6xyK29eayxo14v1bj1VPiDkHjTdz33SV6RdfMz2AHnf4ai62Vng2mN5GkaKahkooBIo9gA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/property-graph/-/property-graph-4.1.0.tgz",
+      "integrity": "sha512-AvPcP7XECNWy4LGmFQ77k7un4lSKM4eS29PTvW4ck95uYeLxXPWJM7hLuBqK91FaHqCcgJvIUCuNJjjxKE7VKQ==",
       "license": "MIT"
     },
     "node_modules/punycode": {
@@ -7551,9 +7602,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
-      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
+      "integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7567,31 +7618,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.59.0",
-        "@rollup/rollup-android-arm64": "4.59.0",
-        "@rollup/rollup-darwin-arm64": "4.59.0",
-        "@rollup/rollup-darwin-x64": "4.59.0",
-        "@rollup/rollup-freebsd-arm64": "4.59.0",
-        "@rollup/rollup-freebsd-x64": "4.59.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
-        "@rollup/rollup-linux-arm64-musl": "4.59.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
-        "@rollup/rollup-linux-loong64-musl": "4.59.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
-        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
-        "@rollup/rollup-linux-x64-gnu": "4.59.0",
-        "@rollup/rollup-linux-x64-musl": "4.59.0",
-        "@rollup/rollup-openbsd-x64": "4.59.0",
-        "@rollup/rollup-openharmony-arm64": "4.59.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
-        "@rollup/rollup-win32-x64-gnu": "4.59.0",
-        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "@rollup/rollup-android-arm-eabi": "4.60.0",
+        "@rollup/rollup-android-arm64": "4.60.0",
+        "@rollup/rollup-darwin-arm64": "4.60.0",
+        "@rollup/rollup-darwin-x64": "4.60.0",
+        "@rollup/rollup-freebsd-arm64": "4.60.0",
+        "@rollup/rollup-freebsd-x64": "4.60.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.0",
+        "@rollup/rollup-linux-arm64-musl": "4.60.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.0",
+        "@rollup/rollup-linux-loong64-musl": "4.60.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.0",
+        "@rollup/rollup-linux-x64-gnu": "4.60.0",
+        "@rollup/rollup-linux-x64-musl": "4.60.0",
+        "@rollup/rollup-openbsd-x64": "4.60.0",
+        "@rollup/rollup-openharmony-arm64": "4.60.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.0",
+        "@rollup/rollup-win32-x64-gnu": "4.60.0",
+        "@rollup/rollup-win32-x64-msvc": "4.60.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -8274,6 +8325,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
+      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -8813,9 +8876,9 @@
       }
     },
     "node_modules/vite-plugin-static-copy": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-3.3.0.tgz",
-      "integrity": "sha512-XiAtZcev7nppxNFgKoD55rfL+ukVp/RtrnTJONRwRuzv/B2FK2h2ZRCYjvxhwBV/Oarse83SiyXBSxMTfeEM0Q==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-3.4.0.tgz",
+      "integrity": "sha512-ekryzCw0ouAOE8tw4RvVL/dfqguXzumsV3FBKoKso4MQ1MUUrUXtl5RI4KpJQUNGqFEsg9kxl4EvDl02YtA9VQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8874,9 +8937,9 @@
       }
     },
     "node_modules/vite-plugin-static-copy/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9509,9 +9572,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/scripts/run-api-tests.mjs
+++ b/scripts/run-api-tests.mjs
@@ -423,8 +423,12 @@ async function runTests(suiteId = "all") {
   console.log("🌐 Launching headless browser...");
 
   browser = await chromium.launch({
-    headless: true,
-    args: ["--no-sandbox", "--disable-setuid-sandbox"],
+    headless: false, // must be false to use --headless=old
+    args: [
+      "--no-sandbox",
+      "--disable-setuid-sandbox",
+      "--headless=old", // old headless mode retains WebGL support (new headless shell drops it)
+    ],
   });
 
   const context = await browser.newContext({

--- a/scripts/test-coverage-matrix.mjs
+++ b/scripts/test-coverage-matrix.mjs
@@ -1,0 +1,412 @@
+#!/usr/bin/env node
+
+/**
+ * Test Coverage Matrix Script
+ *
+ * Generates a matrix showing the relationship between API files and their test files,
+ * including test counts and staleness tracking (API changes since tests were updated).
+ *
+ * Usage: npm run docs:matrix
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import { countTestsInFile } from './utils/test-analyzer.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '..');
+
+/**
+ * Get the last modification date of a file from git
+ * @param {string} filePath - Path to the file (relative to project root)
+ * @returns {string|null} ISO date string or null if not in git
+ */
+function getGitLastModified(filePath) {
+  try {
+    const result = execSync(
+      `git log -1 --format="%ai" -- "${filePath}"`,
+      { cwd: projectRoot, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+    ).trim();
+    return result ? result.split(' ')[0] : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Count the number of commits to a file since a given date
+ * @param {string} filePath - Path to the file (relative to project root)
+ * @param {string} sinceDate - ISO date string
+ * @returns {number} Number of commits
+ */
+function getCommitsSince(filePath, sinceDate) {
+  if (!sinceDate) return 0;
+  try {
+    const result = execSync(
+      `git log --oneline --after="${sinceDate}" -- "${filePath}"`,
+      { cwd: projectRoot, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+    ).trim();
+    return result ? result.split('\n').length : 0;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Find test files that correspond to an API file
+ * @param {string} apiFileName - Name of the API file (e.g., 'animate.js')
+ * @param {string[]} testFiles - Array of all test file names
+ * @returns {string[]} Matching test file names
+ */
+function findMatchingTestFiles(apiFileName, testFiles) {
+  const baseName = apiFileName.replace('.js', '');
+  const matches = [];
+
+  for (const testFile of testFiles) {
+    // Match patterns like:
+    // - animate.test.js (exact match)
+    // - transform.rotate.test.js (prefix match for transform.js)
+    // - materials.test.js (plural form of material.js)
+    // - uitextbutton.test.js (contains 'ui')
+    const testBaseName = testFile.replace('.test.js', '');
+
+    if (testBaseName === baseName) {
+      matches.push(testFile);
+    } else if (testBaseName.startsWith(baseName + '.')) {
+      // e.g., transform.rotate.test.js for transform.js
+      matches.push(testFile);
+    } else if (testBaseName === baseName + 's') {
+      // e.g., materials.test.js for material.js
+      matches.push(testFile);
+    } else if (baseName === 'sound' && testFile.startsWith('sound')) {
+      // Special case: sound has multiple test files
+      matches.push(testFile);
+    } else if (baseName === 'ui' && testFile.includes('ui')) {
+      // Special case: ui has uitextbutton.test.js
+      matches.push(testFile);
+    }
+  }
+
+  return matches;
+}
+
+/**
+ * Get staleness status indicator
+ * @param {number} commitsBehind - Number of commits behind
+ * @returns {string} Status indicator with emoji
+ */
+function getStalenessIndicator(commitsBehind) {
+  if (commitsBehind === 0) return '✅';
+  if (commitsBehind <= 5) return '🟡';
+  if (commitsBehind <= 15) return '🟠';
+  return '🔴';
+}
+
+/**
+ * Main function to generate the test coverage matrix
+ */
+function generateTestCoverageMatrix() {
+  console.log('\n╔════════════════════════════════════════════════════════════════════════════════╗');
+  console.log('║                    API File to Test File Coverage Matrix                       ║');
+  console.log('╚════════════════════════════════════════════════════════════════════════════════╝\n');
+
+  const apiDir = path.join(projectRoot, 'api');
+  const testsDir = path.join(projectRoot, 'tests');
+
+  // Get all API files
+  const apiFiles = fs.readdirSync(apiDir)
+    .filter(f => f.endsWith('.js'))
+    .sort();
+
+  // Get all test files
+  const testFiles = fs.readdirSync(testsDir)
+    .filter(f => f.endsWith('.test.js'))
+    .sort();
+
+  // Build the matrix data
+  const matrixData = [];
+  let totalTests = 0;
+  let filesWithTests = 0;
+  let filesWithStaleTests = 0;
+  let filesWithNoTests = 0;
+
+  for (const apiFile of apiFiles) {
+    const apiPath = `api/${apiFile}`;
+    const apiLastModified = getGitLastModified(apiPath);
+
+    // Find matching test files
+    const matchingTests = findMatchingTestFiles(apiFile, testFiles);
+
+    let testCount = 0;
+    let testLastModified = null;
+    let commitsBehind = 0;
+    const testFileDetails = [];
+
+    if (matchingTests.length > 0) {
+      filesWithTests++;
+
+      for (const testFile of matchingTests) {
+        const testPath = path.join(testsDir, testFile);
+        const stats = countTestsInFile(testPath);
+        testCount += stats.tests;
+
+        const testModDate = getGitLastModified(`tests/${testFile}`);
+        if (!testLastModified || (testModDate && testModDate > testLastModified)) {
+          testLastModified = testModDate;
+        }
+
+        testFileDetails.push({
+          name: testFile,
+          tests: stats.tests,
+          lastModified: testModDate
+        });
+      }
+
+      // Calculate staleness
+      if (testLastModified && apiLastModified) {
+        commitsBehind = getCommitsSince(apiPath, testLastModified);
+        if (commitsBehind > 0) {
+          filesWithStaleTests++;
+        }
+      }
+    } else {
+      filesWithNoTests++;
+    }
+
+    totalTests += testCount;
+
+    matrixData.push({
+      apiFile,
+      apiLastModified,
+      testFiles: testFileDetails,
+      testCount,
+      testLastModified,
+      commitsBehind,
+      hasTests: matchingTests.length > 0
+    });
+  }
+
+  // Print summary statistics
+  console.log('┌─────────────────────────────────────────┐');
+  console.log('│           Summary Statistics            │');
+  console.log('└─────────────────────────────────────────┘\n');
+
+  console.log(`  Total API Files:         ${apiFiles.length}`);
+  console.log(`  Files with Tests:        ${filesWithTests} (${Math.round(filesWithTests / apiFiles.length * 100)}%)`);
+  console.log(`  Files without Tests:     ${filesWithNoTests} (${Math.round(filesWithNoTests / apiFiles.length * 100)}%)`);
+  console.log(`  Files with Stale Tests:  ${filesWithStaleTests}`);
+  console.log(`  Total Test Cases:        ${totalTests}`);
+  console.log('');
+
+  // Print the matrix table
+  console.log('┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐');
+  console.log('│                                        API File to Test Mapping                                            │');
+  console.log('└─────────────────────────────────────────────────────────────────────────────────────────────────────────────┘\n');
+
+  // Table header
+  const header = [
+    'API File'.padEnd(16),
+    'Last Modified'.padEnd(12),
+    'Test File(s)'.padEnd(38),
+    'Tests'.padStart(5),
+    'Test Modified'.padEnd(12),
+    'Stale'.padStart(5),
+    'Status'
+  ].join(' │ ');
+
+  console.log('  ' + header);
+  console.log('  ' + '─'.repeat(header.length));
+
+  // Table rows
+  for (const row of matrixData) {
+    const testFileStr = row.testFiles.length > 0
+      ? row.testFiles.map(t => t.name).join(', ').substring(0, 36)
+      : '(none)';
+
+    const stalenessStr = row.hasTests
+      ? (row.commitsBehind > 0 ? row.commitsBehind.toString() : '0')
+      : '-';
+
+    const statusIndicator = row.hasTests
+      ? getStalenessIndicator(row.commitsBehind)
+      : '❌';
+
+    const rowStr = [
+      row.apiFile.padEnd(16),
+      (row.apiLastModified || '-').padEnd(12),
+      testFileStr.padEnd(38),
+      row.testCount.toString().padStart(5),
+      (row.testLastModified || '-').padEnd(12),
+      stalenessStr.padStart(5),
+      statusIndicator
+    ].join(' │ ');
+
+    console.log('  ' + rowStr);
+  }
+
+  console.log('');
+
+  // Print staleness legend
+  console.log('  Staleness Legend:');
+  console.log('    ✅ = Up to date (0 commits behind)');
+  console.log('    🟡 = Slightly stale (1-5 commits behind)');
+  console.log('    🟠 = Moderately stale (6-15 commits behind)');
+  console.log('    🔴 = Very stale (>15 commits behind)');
+  console.log('    ❌ = No tests');
+  console.log('');
+
+  // Print files needing attention
+  const staleFiles = matrixData
+    .filter(r => r.hasTests && r.commitsBehind > 0)
+    .sort((a, b) => b.commitsBehind - a.commitsBehind);
+
+  if (staleFiles.length > 0) {
+    console.log('┌─────────────────────────────────────────┐');
+    console.log('│     Files Needing Test Updates          │');
+    console.log('└─────────────────────────────────────────┘\n');
+
+    for (const file of staleFiles) {
+      console.log(`  ${getStalenessIndicator(file.commitsBehind)} ${file.apiFile.padEnd(16)} - ${file.commitsBehind} commit(s) since tests updated`);
+    }
+    console.log('');
+  }
+
+  // Print files without tests
+  const noTestFiles = matrixData.filter(r => !r.hasTests);
+  if (noTestFiles.length > 0) {
+    console.log('┌─────────────────────────────────────────┐');
+    console.log('│       Files Without Direct Tests        │');
+    console.log('└─────────────────────────────────────────┘\n');
+
+    for (const file of noTestFiles) {
+      console.log(`  ❌ ${file.apiFile}`);
+    }
+    console.log('');
+  }
+
+  // Generate and save markdown report
+  const reportsDir = path.join(projectRoot, 'reports');
+  if (!fs.existsSync(reportsDir)) {
+    fs.mkdirSync(reportsDir, { recursive: true });
+  }
+
+  const markdownReport = generateMarkdownReport(matrixData, {
+    totalApiFiles: apiFiles.length,
+    filesWithTests,
+    filesWithNoTests,
+    filesWithStaleTests,
+    totalTests
+  });
+
+  const reportPath = path.join(reportsDir, 'test-coverage-matrix.md');
+  fs.writeFileSync(reportPath, markdownReport);
+  console.log(`📄 Detailed report saved to: ${reportPath}\n`);
+
+  // Return exit code based on coverage
+  const coveragePercent = Math.round(filesWithTests / apiFiles.length * 100);
+  if (coveragePercent < 50) {
+    console.log(`⚠️  Warning: Only ${coveragePercent}% of API files have direct tests\n`);
+  }
+}
+
+/**
+ * Generate markdown report
+ * @param {Array} matrixData - The matrix data
+ * @param {Object} stats - Summary statistics
+ * @returns {string} Markdown content
+ */
+function generateMarkdownReport(matrixData, stats) {
+  const now = new Date().toISOString();
+
+  let md = '# Test Coverage Matrix Report\n\n';
+  md += `**Generated:** ${now}\n\n`;
+
+  md += '## Summary\n\n';
+  md += `- **Total API Files:** ${stats.totalApiFiles}\n`;
+  md += `- **Files with Tests:** ${stats.filesWithTests} (${Math.round(stats.filesWithTests / stats.totalApiFiles * 100)}%)\n`;
+  md += `- **Files without Tests:** ${stats.filesWithNoTests}\n`;
+  md += `- **Files with Stale Tests:** ${stats.filesWithStaleTests}\n`;
+  md += `- **Total Test Cases:** ${stats.totalTests}\n\n`;
+
+  md += '## Coverage Matrix\n\n';
+  md += '| API File | Last Modified | Test File(s) | Tests | Test Modified | Commits Behind | Status |\n';
+  md += '|----------|---------------|--------------|------:|---------------|---------------:|--------|\n';
+
+  for (const row of matrixData) {
+    const testFileStr = row.testFiles.length > 0
+      ? row.testFiles.map(t => `\`${t.name}\``).join(', ')
+      : '(none)';
+
+    const stalenessStr = row.hasTests
+      ? row.commitsBehind.toString()
+      : '-';
+
+    const statusIndicator = row.hasTests
+      ? getStalenessIndicator(row.commitsBehind)
+      : '❌';
+
+    md += `| ${row.apiFile} | ${row.apiLastModified || '-'} | ${testFileStr} | ${row.testCount} | ${row.testLastModified || '-'} | ${stalenessStr} | ${statusIndicator} |\n`;
+  }
+
+  md += '\n## Staleness Legend\n\n';
+  md += '- ✅ = Up to date (0 commits behind)\n';
+  md += '- 🟡 = Slightly stale (1-5 commits behind)\n';
+  md += '- 🟠 = Moderately stale (6-15 commits behind)\n';
+  md += '- 🔴 = Very stale (>15 commits behind)\n';
+  md += '- ❌ = No tests\n\n';
+
+  // Files needing attention
+  const staleFiles = matrixData
+    .filter(r => r.hasTests && r.commitsBehind > 0)
+    .sort((a, b) => b.commitsBehind - a.commitsBehind);
+
+  if (staleFiles.length > 0) {
+    md += '## Files Needing Test Updates\n\n';
+    md += 'These API files have been modified since their tests were last updated:\n\n';
+
+    for (const file of staleFiles) {
+      md += `- **${file.apiFile}** - ${file.commitsBehind} commit(s) behind ${getStalenessIndicator(file.commitsBehind)}\n`;
+    }
+    md += '\n';
+  }
+
+  // Files without tests
+  const noTestFiles = matrixData.filter(r => !r.hasTests);
+  if (noTestFiles.length > 0) {
+    md += '## Files Without Direct Tests\n\n';
+    md += 'These API files do not have dedicated test files:\n\n';
+
+    for (const file of noTestFiles) {
+      md += `- [ ] \`${file.apiFile}\`\n`;
+    }
+    md += '\n';
+  }
+
+  // Detailed test file breakdown
+  md += '## Test File Details\n\n';
+
+  for (const row of matrixData) {
+    if (row.testFiles.length > 0) {
+      md += `### ${row.apiFile}\n\n`;
+      md += `| Test File | Tests | Last Modified |\n`;
+      md += `|-----------|------:|---------------|\n`;
+
+      for (const testFile of row.testFiles) {
+        md += `| ${testFile.name} | ${testFile.tests} | ${testFile.lastModified || '-'} |\n`;
+      }
+      md += '\n';
+    }
+  }
+
+  return md;
+}
+
+// Run if called directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  generateTestCoverageMatrix();
+}
+
+export { generateTestCoverageMatrix, findMatchingTestFiles, getGitLastModified, getCommitsSince };

--- a/scripts/test-coverage-matrix.mjs
+++ b/scripts/test-coverage-matrix.mjs
@@ -11,7 +11,7 @@
 
 import fs from 'fs';
 import path from 'path';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { countTestsInFile } from './utils/test-analyzer.mjs';
 
@@ -26,11 +26,12 @@ const projectRoot = path.resolve(__dirname, '..');
  */
 function getGitLastModified(filePath) {
   try {
-    const result = execSync(
-      `git log -1 --format="%ai" -- "${filePath}"`,
+    const result = execFileSync(
+      'git',
+      ['log', '-1', '--format=%cI', '--', filePath],
       { cwd: projectRoot, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
     ).trim();
-    return result ? result.split(' ')[0] : null;
+    return result || null;
   } catch {
     return null;
   }
@@ -45,8 +46,9 @@ function getGitLastModified(filePath) {
 function getCommitsSince(filePath, sinceDate) {
   if (!sinceDate) return 0;
   try {
-    const result = execSync(
-      `git log --oneline --after="${sinceDate}" -- "${filePath}"`,
+    const result = execFileSync(
+      'git',
+      ['log', '--oneline', `--after=${sinceDate}`, '--', filePath],
       { cwd: projectRoot, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
     ).trim();
     return result ? result.split('\n').length : 0;
@@ -405,7 +407,7 @@ function generateMarkdownReport(matrixData, stats) {
 }
 
 // Run if called directly
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (process.argv[1] && __filename === path.resolve(process.argv[1])) {
   generateTestCoverageMatrix();
 }
 

--- a/scripts/test-coverage-matrix.mjs
+++ b/scripts/test-coverage-matrix.mjs
@@ -197,8 +197,8 @@ function generateTestCoverageMatrix() {
   console.log('└─────────────────────────────────────────┘\n');
 
   console.log(`  Total API Files:         ${apiFiles.length}`);
-  console.log(`  Files with Tests:        ${filesWithTests} (${Math.round(filesWithTests / apiFiles.length * 100)}%)`);
-  console.log(`  Files without Tests:     ${filesWithNoTests} (${Math.round(filesWithNoTests / apiFiles.length * 100)}%)`);
+  console.log(`  Files with Tests:        ${filesWithTests} (${apiFiles.length ? Math.round(filesWithTests / apiFiles.length * 100) : 0}%)`);
+  console.log(`  Files without Tests:     ${filesWithNoTests} (${apiFiles.length ? Math.round(filesWithNoTests / apiFiles.length * 100) : 0}%)`);
   console.log(`  Files with Stale Tests:  ${filesWithStaleTests}`);
   console.log(`  Total Test Cases:        ${totalTests}`);
   console.log('');
@@ -328,7 +328,7 @@ function generateMarkdownReport(matrixData, stats) {
 
   md += '## Summary\n\n';
   md += `- **Total API Files:** ${stats.totalApiFiles}\n`;
-  md += `- **Files with Tests:** ${stats.filesWithTests} (${Math.round(stats.filesWithTests / stats.totalApiFiles * 100)}%)\n`;
+  md += `- **Files with Tests:** ${stats.filesWithTests} (${stats.totalApiFiles ? Math.round(stats.filesWithTests / stats.totalApiFiles * 100) : 0}%)\n`;
   md += `- **Files without Tests:** ${stats.filesWithNoTests}\n`;
   md += `- **Files with Stale Tests:** ${stats.filesWithStaleTests}\n`;
   md += `- **Total Test Cases:** ${stats.totalTests}\n\n`;

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -75,11 +75,12 @@
       tabindex="0"
     ></canvas>
 
-    <script
-      type="module"
-      src="https://unpkg.com/mocha@10.2.0/mocha.js"
-    ></script>
-    <script type="module" src="https://unpkg.com/chai@4.3.7/chai.js"></script>
+    <link rel="stylesheet" href="/node_modules/mocha/mocha.css" />
+    <script src="/node_modules/mocha/mocha.js"></script>
+    <script type="module">
+      import * as chai from "/node_modules/chai/index.js";
+      window.chai = chai;
+    </script>
 
     <!-- Test selection interface -->
     <div style="margin: 20px 0">


### PR DESCRIPTION
This adds a new report to assess whether various API tests lag updates to the respective APIs. Currently this report is run using a CLI command `npm run docs:matrix`. The output appears in console output and is also written to `./reports/test-coverage-matrix.md`.

Please let me know whether this report is useful and, if so, what'd improve its utility. I'll update the test documentation once I know the report is worthwhile. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated test‑coverage matrix with Markdown reporting of per‑API test mappings, staleness indicators, and summary metrics.

* **Chores**
  * Updated test runner/browser launch to enable legacy headless mode for local interactive runs (preserves WebGL).
  * Switched test framework assets from CDN to local distribution for more reliable test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->