### PR TITLE
Add OverlayMetricsManager to avoid workspace shift when flyout is open

### DIFF
--- a/main/blocklyinit.js
+++ b/main/blocklyinit.js
@@ -606,6 +606,55 @@ export function initializeWorkspace() {
 }
 
 export function createBlocklyWorkspace() {
+  class OverlayMetricsManager extends Blockly.MetricsManager {
+    getAbsoluteMetrics() {
+      const absolute = super.getAbsoluteMetrics();
+      const flyout = this.workspace_.getFlyout?.();
+      if (!flyout || flyout.autoClose) return absolute;
+
+      const flyoutMetrics = this.getFlyoutMetrics();
+      const toolboxPosition = this.getToolboxMetrics().position;
+      const Position = Blockly.utils.toolbox.Position;
+
+      const adjusted = { ...absolute };
+      if (toolboxPosition === Position.LEFT) {
+        adjusted.left = Math.max(0, adjusted.left - flyoutMetrics.width);
+      } else if (toolboxPosition === Position.TOP) {
+        adjusted.top = Math.max(0, adjusted.top - flyoutMetrics.height);
+      }
+
+      return adjusted;
+    }
+
+    getViewMetrics(opt_getWorkspaceCoordinates) {
+      const view = super.getViewMetrics(opt_getWorkspaceCoordinates);
+      const flyout = this.workspace_.getFlyout?.();
+      if (!flyout || flyout.autoClose) return view;
+
+      const flyoutMetrics = this.getFlyoutMetrics();
+      const toolboxPosition = this.getToolboxMetrics().position;
+      const Position = Blockly.utils.toolbox.Position;
+      const scale = opt_getWorkspaceCoordinates ? this.workspace_.scale : 1;
+      const flyoutWidth = flyoutMetrics.width / scale;
+      const flyoutHeight = flyoutMetrics.height / scale;
+      const adjusted = { ...view };
+
+      if (toolboxPosition === Position.LEFT) {
+        adjusted.left -= flyoutWidth;
+        adjusted.width += flyoutWidth;
+      } else if (toolboxPosition === Position.RIGHT) {
+        adjusted.width += flyoutWidth;
+      } else if (toolboxPosition === Position.TOP) {
+        adjusted.top -= flyoutHeight;
+        adjusted.height += flyoutHeight;
+      } else if (toolboxPosition === Position.BOTTOM) {
+        adjusted.height += flyoutHeight;
+      }
+
+      return adjusted;
+    }
+  }
+
   // Register the custom renderer
   Blockly.registry.register(
     Blockly.registry.Type.RENDERER,
@@ -636,6 +685,7 @@ export function createBlocklyWorkspace() {
   );
 
   workspace = Blockly.inject("blocklyDiv", options);
+  workspace.setMetricsManager(new OverlayMetricsManager(workspace));
 
   // Initialize keyboard navigation.
 
@@ -949,48 +999,6 @@ export function createBlocklyWorkspace() {
 
     shortcutRegistry.removeAllKeyMappings?.("toolbox");
     shortcutRegistry.register(wrappedShortcut, true);
-  })();
-
-  // Keep scrolling; remove only the obvious flyout-width bump.
-  (function simpleNoBumpTranslate() {
-    const ws = Blockly.getMainWorkspace();
-    const original = ws.translate.bind(ws);
-
-    ws.translate = function (requestedX, newY) {
-      const tb = this.getToolbox?.();
-      const fo = this.getFlyout?.();
-      const mm = this.getMetricsManager?.();
-
-      // Toolbox edge on the left. Prefer toolbox.getWidth(); fallback to absolute metrics.
-      const tbW =
-        (tb && tb.getWidth?.()) ??
-        (mm && mm.getAbsoluteMetrics ? mm.getAbsoluteMetrics().left : 0) ??
-        0;
-
-      let x = requestedX;
-
-      // Only adjust when the flyout is actually visible.
-      if (fo && fo.isVisible?.()) {
-        const foW = fo.getWidth?.() || 0;
-        const EPS = 1; // small float tolerance
-
-        if (foW > 0) {
-          // Case 1: absolute shove to ≈ toolbox + flyout
-          if (x >= tbW + foW - EPS) {
-            x -= foW;
-          }
-          // Case 2: relative shove by ≈ flyout from current position
-          else if (x - this.scrollX >= foW - EPS) {
-            x -= foW;
-          }
-        }
-      }
-
-      // Never allow the origin to go left of the toolbox edge.
-      if (x < tbW) x = tbW;
-
-      return original(x, newY);
-    };
   })();
 
   // ------- Pointer tracking for "paste at pointer" -------

--- a/main/blocklyinit.js
+++ b/main/blocklyinit.js
@@ -607,44 +607,6 @@ export function initializeWorkspace() {
 
 export function createBlocklyWorkspace() {
   class OverlayMetricsManager extends Blockly.MetricsManager {
-    constructor(workspaceRef) {
-      super(workspaceRef);
-      this.stableToolboxWidth_ = 0;
-      this.stableToolboxHeight_ = 0;
-    }
-
-    getToolboxMetrics() {
-      const toolboxMetrics = super.getToolboxMetrics();
-      const Position = Blockly.utils.toolbox.Position;
-      const isVertical =
-        toolboxMetrics.position === Position.LEFT ||
-        toolboxMetrics.position === Position.RIGHT;
-      const isHorizontal =
-        toolboxMetrics.position === Position.TOP ||
-        toolboxMetrics.position === Position.BOTTOM;
-
-      if (isVertical && toolboxMetrics.width > 0) {
-        this.stableToolboxWidth_ = Math.max(
-          this.stableToolboxWidth_,
-          toolboxMetrics.width,
-        );
-      }
-      if (isHorizontal && toolboxMetrics.height > 0) {
-        this.stableToolboxHeight_ = Math.max(
-          this.stableToolboxHeight_,
-          toolboxMetrics.height,
-        );
-      }
-
-      return {
-        ...toolboxMetrics,
-        width: isVertical ? this.stableToolboxWidth_ || toolboxMetrics.width : toolboxMetrics.width,
-        height: isHorizontal
-          ? this.stableToolboxHeight_ || toolboxMetrics.height
-          : toolboxMetrics.height,
-      };
-    }
-
     getAbsoluteMetrics() {
       const absolute = super.getAbsoluteMetrics();
       const flyout = this.workspace_.getFlyout?.();
@@ -659,34 +621,6 @@ export function createBlocklyWorkspace() {
         adjusted.left = Math.max(0, adjusted.left - flyoutMetrics.width);
       } else if (toolboxPosition === Position.TOP) {
         adjusted.top = Math.max(0, adjusted.top - flyoutMetrics.height);
-      }
-
-      return adjusted;
-    }
-
-    getViewMetrics(opt_getWorkspaceCoordinates) {
-      const view = super.getViewMetrics(opt_getWorkspaceCoordinates);
-      const flyout = this.workspace_.getFlyout?.();
-      if (!flyout || flyout.autoClose) return view;
-
-      const flyoutMetrics = this.getFlyoutMetrics();
-      const toolboxPosition = this.getToolboxMetrics().position;
-      const Position = Blockly.utils.toolbox.Position;
-      const scale = opt_getWorkspaceCoordinates ? this.workspace_.scale : 1;
-      const flyoutWidth = flyoutMetrics.width / scale;
-      const flyoutHeight = flyoutMetrics.height / scale;
-      const adjusted = { ...view };
-
-      if (toolboxPosition === Position.LEFT) {
-        adjusted.left -= flyoutWidth;
-        adjusted.width += flyoutWidth;
-      } else if (toolboxPosition === Position.RIGHT) {
-        adjusted.width += flyoutWidth;
-      } else if (toolboxPosition === Position.TOP) {
-        adjusted.top -= flyoutHeight;
-        adjusted.height += flyoutHeight;
-      } else if (toolboxPosition === Position.BOTTOM) {
-        adjusted.height += flyoutHeight;
       }
 
       return adjusted;

--- a/main/blocklyinit.js
+++ b/main/blocklyinit.js
@@ -607,6 +607,44 @@ export function initializeWorkspace() {
 
 export function createBlocklyWorkspace() {
   class OverlayMetricsManager extends Blockly.MetricsManager {
+    constructor(workspaceRef) {
+      super(workspaceRef);
+      this.stableToolboxWidth_ = 0;
+      this.stableToolboxHeight_ = 0;
+    }
+
+    getToolboxMetrics() {
+      const toolboxMetrics = super.getToolboxMetrics();
+      const Position = Blockly.utils.toolbox.Position;
+      const isVertical =
+        toolboxMetrics.position === Position.LEFT ||
+        toolboxMetrics.position === Position.RIGHT;
+      const isHorizontal =
+        toolboxMetrics.position === Position.TOP ||
+        toolboxMetrics.position === Position.BOTTOM;
+
+      if (isVertical && toolboxMetrics.width > 0) {
+        this.stableToolboxWidth_ = Math.max(
+          this.stableToolboxWidth_,
+          toolboxMetrics.width,
+        );
+      }
+      if (isHorizontal && toolboxMetrics.height > 0) {
+        this.stableToolboxHeight_ = Math.max(
+          this.stableToolboxHeight_,
+          toolboxMetrics.height,
+        );
+      }
+
+      return {
+        ...toolboxMetrics,
+        width: isVertical ? this.stableToolboxWidth_ || toolboxMetrics.width : toolboxMetrics.width,
+        height: isHorizontal
+          ? this.stableToolboxHeight_ || toolboxMetrics.height
+          : toolboxMetrics.height,
+      };
+    }
+
     getAbsoluteMetrics() {
       const absolute = super.getAbsoluteMetrics();
       const flyout = this.workspace_.getFlyout?.();


### PR DESCRIPTION
### Motivation
- Prevent workspace content from shifting when a non-auto-closing flyout (overlay) is visible by computing workspace metrics that exclude the flyout area instead of mutating translation behavior.

### Description
- Add `OverlayMetricsManager` (subclass of `Blockly.MetricsManager`) that overrides `getAbsoluteMetrics` and `getViewMetrics` to adjust metrics when the flyout is visible and `autoClose` is false, taking `toolbox` position and workspace `scale` into account.
- Install the custom metrics manager via `workspace.setMetricsManager(new OverlayMetricsManager(workspace))` immediately after `Blockly.inject`.
- Remove the previous `simpleNoBumpTranslate` monkeypatch that altered `workspace.translate` to remove the flyout-width bump.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2711a34188326be6e9a1d54367c3b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace metrics now account for visible toolbox overlays and toolbox position, improving element placement and spacing.
  * Avoids metric shrinking when overlay/toolbox dimensions fluctuate by tracking stable toolbox size.
  * Removes prior panning/workspace-translation workaround that could cause incorrect horizontal limits and offsets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->