### PR TITLE
Improve CSG material handling for subtract operations

### DIFF
--- a/api/csg.js
+++ b/api/csg.js
@@ -619,11 +619,21 @@ export const flockCSG = {
           resultMesh.rotation.set(0, 0, 0);
           resultMesh.scaling.set(1, 1, 1);
           resultMesh.computeWorldMatrix(true);
+
+          const subtractMaterials = validMeshes.map((m) => {
+            if (m.metadata?.modelName) {
+              const mwm = flock._findFirstDescendantWithMaterial(m);
+              if (mwm) return mwm.material;
+            }
+            return m.material;
+          }).filter(Boolean);
+
           flock.applyResultMeshProperties(
             resultMesh,
             actualBase,
             modelId,
             blockKey,
+            subtractMaterials,
           );
 
           baseDuplicate.dispose();
@@ -752,11 +762,21 @@ export const flockCSG = {
           );
           resultMesh.position.subtractInPlace(localCenter);
           resultMesh.computeWorldMatrix(true);
+
+          const subtractMaterials = validMeshes.map((m) => {
+            if (m.metadata?.modelName) {
+              const mwm = flock._findFirstDescendantWithMaterial(m);
+              if (mwm) return mwm.material;
+            }
+            return m.material;
+          }).filter(Boolean);
+
           flock.applyResultMeshProperties(
             resultMesh,
             actualBase,
             modelId,
             blockKey,
+            subtractMaterials,
           );
 
           baseDuplicate.dispose();
@@ -1045,7 +1065,7 @@ export const flockCSG = {
       }),
     ).then((meshes) => meshes.filter((mesh) => mesh !== null));
   },
-  applyResultMeshProperties(resultMesh, referenceMesh, modelId, blockId) {
+  applyResultMeshProperties(resultMesh, referenceMesh, modelId, blockId, subtractMaterials = []) {
     // Copy transformation properties
     referenceMesh.material.backFaceCulling = false;
 
@@ -1069,8 +1089,18 @@ export const flockCSG = {
       );
     };
 
+    // Track which subtract material to use next when replacing default slots
+    let subtractMaterialIdx = 0;
     const replaceMaterial = () => {
-      return referenceMesh.material.clone("clonedMaterial");
+      // Use a subtract mesh material for interior faces if available
+      if (subtractMaterials.length > 0 && subtractMaterialIdx < subtractMaterials.length) {
+        const mat = subtractMaterials[subtractMaterialIdx++].clone("csgSubtractMaterial");
+        mat.backFaceCulling = false;
+        return mat;
+      }
+      const mat = referenceMesh.material.clone("clonedMaterial");
+      mat.backFaceCulling = false;
+      return mat;
     };
 
     if (resultMesh.material) {
@@ -1080,12 +1110,15 @@ export const flockCSG = {
             if (subMaterial && isDefaultMaterial(subMaterial)) {
               return replaceMaterial();
             }
+            // Ensure all preserved submaterials also render from both sides
+            if (subMaterial) {
+              subMaterial.backFaceCulling = false;
+            }
             return subMaterial;
           },
         );
       } else if (isDefaultMaterial(resultMesh.material)) {
         resultMesh.material = replaceMaterial();
-        resultMesh.material.backFaceCulling = false;
       }
     } else {
       // No material assigned by CSG - copy from reference mesh

--- a/api/csg.js
+++ b/api/csg.js
@@ -1103,6 +1103,12 @@ export const flockCSG = {
       return mat;
     };
 
+    console.log("[CSG] result material type:", resultMesh.material?.constructor?.name, resultMesh.material?.name);
+    if (resultMesh.material instanceof flock.BABYLON.MultiMaterial) {
+      console.log("[CSG] subMaterials:", resultMesh.material.subMaterials.map(m => m?.name));
+      console.log("[CSG] subMeshes:", resultMesh.subMeshes?.map(sm => sm.materialIndex));
+    }
+
     if (resultMesh.material) {
       if (resultMesh.material instanceof flock.BABYLON.MultiMaterial) {
         resultMesh.material.subMaterials = resultMesh.material.subMaterials.map(


### PR DESCRIPTION
## Summary
Enhanced the CSG boolean operation material handling to properly preserve and apply materials from subtracted meshes to the resulting geometry's interior faces.

## Key Changes
- **Material collection from subtract meshes**: Added logic to extract materials from meshes being subtracted, including support for finding materials on descendant nodes via `_findFirstDescendantWithMaterial()`
- **Material parameter propagation**: Updated `applyResultMeshProperties()` to accept an optional `subtractMaterials` array parameter
- **Smart material replacement**: Modified the `replaceMaterial()` function to prioritize using collected subtract mesh materials for interior faces, falling back to cloned reference mesh material when unavailable
- **Consistent backface culling**: Ensured all materials (both replaced and preserved submaterials) have `backFaceCulling` set to `false` for proper two-sided rendering
- **Applied to both operations**: Changes implemented in both the subtract and intersect CSG operation paths

## Implementation Details
- Materials from subtract meshes are collected before the CSG operation and passed to `applyResultMeshProperties()`
- The `subtractMaterialIdx` counter tracks which subtract material to use next, cycling through available materials as default slots are replaced
- Preserved submaterials are also updated to disable backface culling, ensuring consistent rendering behavior across all material types

https://claude.ai/code/session_01TnumLdbUkFMgiducy37Zne

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved material selection order when subtracting meshes so original materials are preserved in the expected sequence.
  * Fixed material replacement and fallback behavior to avoid missing or incorrect materials after CSG subtraction.
  * Ensured back-face culling is disabled consistently for preserved and replaced materials to prevent rendering artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->