### PR TITLE
Introduce dynamic `--app-height` variable and prefer `100dvh` where supported

### DIFF
--- a/main/view.js
+++ b/main/view.js
@@ -227,6 +227,14 @@ function addButtonListener() {
   }
 
   switchViewsBtn.addEventListener("click", togglePanels);
+  switchViewsBtn.addEventListener(
+    "touchend",
+    (e) => {
+      e.preventDefault();
+      togglePanels();
+    },
+    { passive: false },
+  );
 }
 
 // Alternative approach: Instead of CSS transforms, actually reposition elements in DOM

--- a/main/view.js
+++ b/main/view.js
@@ -4,10 +4,7 @@ import { flock } from "../flock.js";
 
 // Add this helper function at the top
 export const isNarrowScreen = () => {
-  return (
-    window.innerWidth <= 1024 ||
-    window.matchMedia("(hover: none) and (pointer: coarse)").matches
-  );
+  return window.innerWidth <= 1024;
 };
 
 const isMobile = () => {
@@ -514,12 +511,10 @@ export function toggleDesignMode() {
 }
 
 const adjustViewport = () => {
-  const vh = window.innerHeight * 0.01;
+  const viewportHeight = window.visualViewport?.height || window.innerHeight;
+  const vh = viewportHeight * 0.01;
   document.documentElement.style.setProperty("--vh", `${vh}px`);
-  document.documentElement.style.setProperty(
-    "--app-height",
-    `${window.innerHeight}px`,
-  );
+  document.documentElement.style.setProperty("--app-height", `${viewportHeight}px`);
 };
 
 // Adjust viewport on page load and resize

--- a/main/view.js
+++ b/main/view.js
@@ -4,7 +4,7 @@ import { flock } from "../flock.js";
 
 // Add this helper function at the top
 export const isNarrowScreen = () => {
-  return window.innerWidth <= 768;
+  return window.innerWidth <= 1024;
 };
 
 const isMobile = () => {

--- a/main/view.js
+++ b/main/view.js
@@ -516,11 +516,21 @@ export function toggleDesignMode() {
 const adjustViewport = () => {
   const vh = window.innerHeight * 0.01;
   document.documentElement.style.setProperty("--vh", `${vh}px`);
+  document.documentElement.style.setProperty(
+    "--app-height",
+    `${window.innerHeight}px`,
+  );
 };
 
 // Adjust viewport on page load and resize
 window.addEventListener("load", adjustViewport);
 window.addEventListener("resize", adjustViewport);
+window.addEventListener("orientationchange", adjustViewport);
+document.addEventListener("fullscreenchange", adjustViewport);
+
+if (window.visualViewport) {
+  window.visualViewport.addEventListener("resize", adjustViewport);
+}
 
 /*
 function toggleToolbox() {

--- a/main/view.js
+++ b/main/view.js
@@ -4,7 +4,10 @@ import { flock } from "../flock.js";
 
 // Add this helper function at the top
 export const isNarrowScreen = () => {
-  return window.innerWidth <= 1024;
+  return (
+    window.innerWidth <= 1024 ||
+    window.matchMedia("(hover: none) and (pointer: coarse)").matches
+  );
 };
 
 const isMobile = () => {

--- a/style.css
+++ b/style.css
@@ -745,12 +745,10 @@ button {
 
   #bottomBar {
     position: fixed;
-    bottom: 0;
+    bottom: env(safe-area-inset-bottom, 0px);
     left: 0;
     width: 100vw;
-    height: calc(
-      var(--switch-bar-base-height) + env(safe-area-inset-bottom, 0px)
-    );
+    height: var(--switch-bar-base-height);
     background-color: var(--color-primary);
     color: var(--color-text-on-primary);
     text-align: center;
@@ -784,6 +782,7 @@ button {
     bottom: calc(
       var(--switch-bar-base-height) + env(safe-area-inset-bottom, 0px) + 2px
     );
+    padding: 0;
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -748,9 +748,7 @@ button {
     bottom: 0;
     left: 0;
     width: 100vw;
-    height: calc(
-      var(--switch-bar-base-height) + env(safe-area-inset-bottom, 0px)
-    );
+    height: var(--switch-bar-base-height);
     background-color: var(--color-primary);
     color: var(--color-text-on-primary);
     text-align: center;
@@ -781,7 +779,7 @@ button {
   }
 
   #site-footer {
-    bottom: calc(var(--switch-bar-base-height) + 2px);
+    bottom: var(--switch-bar-base-height);
     padding: 0;
   }
 }

--- a/style.css
+++ b/style.css
@@ -744,7 +744,7 @@ button {
     bottom: 0;
     left: 0;
     width: 100vw;
-    height: calc(48px + env(safe-area-inset-bottom, 0px));
+    height: calc(40px + env(safe-area-inset-bottom, 0px));
     background-color: var(--color-primary);
     color: var(--color-text-on-primary);
     text-align: center;

--- a/style.css
+++ b/style.css
@@ -744,7 +744,7 @@ button {
     bottom: 0;
     left: 0;
     width: 100vw;
-    height: calc(40px + env(safe-area-inset-bottom, 0px));
+    height: calc(34px + env(safe-area-inset-bottom, 0px));
     background-color: var(--color-primary);
     color: var(--color-text-on-primary);
     text-align: center;
@@ -772,6 +772,10 @@ button {
     align-items: center;
     justify-content: center;
     touch-action: manipulation;
+  }
+
+  #site-footer {
+    bottom: calc(34px + env(safe-area-inset-bottom, 0px) + 4px);
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -720,7 +720,7 @@ button {
 }
 @media (max-width: 1024px) {
   :root {
-    --switch-bar-base-height: 36px;
+    --switch-bar-base-height: 44px;
   }
 
   #maincontent {
@@ -786,7 +786,7 @@ button {
 
 @media (min-width: 769px) and (max-width: 1024px) {
   :root {
-    --switch-bar-base-height: 26px;
+    --switch-bar-base-height: 34px;
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -719,6 +719,10 @@ button {
   height: 15px;
 }
 @media (max-width: 1024px) {
+  :root {
+    --switch-bar-base-height: 40px;
+  }
+
   #maincontent {
     width: 200vw;
     height: calc(var(--app-height) - var(--dynamic-offset));
@@ -744,7 +748,9 @@ button {
     bottom: 0;
     left: 0;
     width: 100vw;
-    height: calc(28px + env(safe-area-inset-bottom, 0px));
+    height: calc(
+      var(--switch-bar-base-height) + env(safe-area-inset-bottom, 0px)
+    );
     background-color: var(--color-primary);
     color: var(--color-text-on-primary);
     text-align: center;
@@ -775,7 +781,15 @@ button {
   }
 
   #site-footer {
-    bottom: calc(28px + env(safe-area-inset-bottom, 0px) + 1px);
+    bottom: calc(
+      var(--switch-bar-base-height) + env(safe-area-inset-bottom, 0px) + 2px
+    );
+  }
+}
+
+@media (min-width: 769px) and (max-width: 1024px) {
+  :root {
+    --switch-bar-base-height: 30px;
   }
 }
 
@@ -785,7 +799,7 @@ button {
   }
 
   #site-footer {
-    padding-bottom: 2px;
+    padding-bottom: 0;
     padding-right: 8px;
   }
 
@@ -800,7 +814,7 @@ button {
   }
 
   #site-footer {
-    padding-bottom: 2px;
+    padding-bottom: 0;
     padding-right: 8px;
   }
 

--- a/style.css
+++ b/style.css
@@ -723,7 +723,7 @@ button {
 #flocklink img {
   height: 15px;
 }
-@media (max-width: 1024px) {
+@media (max-width: 1024px), (hover: none) and (pointer: coarse) {
   #maincontent {
     width: 200vw;
     height: calc(var(--app-height) - var(--dynamic-offset));
@@ -774,7 +774,9 @@ button {
   }
 }
 
-@media only screen and (orientation: landscape) and (max-width: 1024px) {
+@media
+  only screen and (orientation: landscape) and (max-width: 1024px),
+  only screen and (orientation: landscape) and (hover: none) and (pointer: coarse) {
   #info-panel {
     display: none;
   }
@@ -789,7 +791,9 @@ button {
   }
 }
 
-@media only screen and (orientation: portrait) and (max-width: 1024px) {
+@media
+  only screen and (orientation: portrait) and (max-width: 1024px),
+  only screen and (orientation: portrait) and (hover: none) and (pointer: coarse) {
   #info-panel {
     display: block;
   }
@@ -804,7 +808,7 @@ button {
   }
 }
 
-@media (min-width: 1025px) {
+@media (min-width: 1025px) and (hover: hover) and (pointer: fine) {
   #bottomBar {
     display: none !important;
   }

--- a/style.css
+++ b/style.css
@@ -720,7 +720,7 @@ button {
 }
 @media (max-width: 1024px) {
   :root {
-    --switch-bar-base-height: 40px;
+    --switch-bar-base-height: 36px;
   }
 
   #maincontent {
@@ -745,10 +745,12 @@ button {
 
   #bottomBar {
     position: fixed;
-    bottom: env(safe-area-inset-bottom, 0px);
+    bottom: 0;
     left: 0;
     width: 100vw;
-    height: var(--switch-bar-base-height);
+    height: calc(
+      var(--switch-bar-base-height) + env(safe-area-inset-bottom, 0px)
+    );
     background-color: var(--color-primary);
     color: var(--color-text-on-primary);
     text-align: center;
@@ -767,7 +769,7 @@ button {
     color: var(--color-text-on-primary);
     width: 100%;
     height: 100%;
-    padding: 0;
+    padding: 0 0 env(safe-area-inset-bottom, 0px) 0;
     margin: 0;
     font-size: 16px;
     cursor: pointer;
@@ -779,16 +781,14 @@ button {
   }
 
   #site-footer {
-    bottom: calc(
-      var(--switch-bar-base-height) + env(safe-area-inset-bottom, 0px) + 2px
-    );
+    bottom: calc(var(--switch-bar-base-height) + 2px);
     padding: 0;
   }
 }
 
 @media (min-width: 769px) and (max-width: 1024px) {
   :root {
-    --switch-bar-base-height: 30px;
+    --switch-bar-base-height: 26px;
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -744,7 +744,7 @@ button {
     bottom: 0;
     left: 0;
     width: 100vw;
-    height: 30px;
+    height: calc(48px + env(safe-area-inset-bottom, 0px));
     background-color: var(--color-primary);
     color: var(--color-text-on-primary);
     text-align: center;
@@ -753,7 +753,7 @@ button {
     justify-content: center;
     align-items: center;
     box-sizing: border-box;
-    padding: 0 2px;
+    padding: 0;
     z-index: 1000;
   }
 
@@ -761,11 +761,17 @@ button {
     background-color: transparent;
     border: none;
     color: var(--color-text-on-primary);
-    padding: 5px 10px;
+    width: 100%;
+    height: 100%;
+    padding: 0;
     margin: 0;
     font-size: 16px;
     cursor: pointer;
-    border-radius: 5px;
+    border-radius: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    touch-action: manipulation;
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -723,7 +723,7 @@ button {
 #flocklink img {
   height: 15px;
 }
-@media (max-width: 768px) {
+@media (max-width: 1024px) {
   #maincontent {
     width: 200vw;
     height: calc(var(--app-height) - var(--dynamic-offset));
@@ -774,7 +774,7 @@ button {
   }
 }
 
-@media only screen and (orientation: landscape) and (max-width: 768px) {
+@media only screen and (orientation: landscape) and (max-width: 1024px) {
   #info-panel {
     display: none;
   }
@@ -789,7 +789,7 @@ button {
   }
 }
 
-@media only screen and (orientation: portrait) and (max-width: 768px) {
+@media only screen and (orientation: portrait) and (max-width: 1024px) {
   #info-panel {
     display: block;
   }
@@ -804,7 +804,7 @@ button {
   }
 }
 
-@media (min-width: 769px) {
+@media (min-width: 1025px) {
   #bottomBar {
     display: none !important;
   }

--- a/style.css
+++ b/style.css
@@ -752,7 +752,7 @@ button {
     background-color: var(--color-primary);
     color: var(--color-text-on-primary);
     text-align: center;
-    line-height: 16px;
+    line-height: normal;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -769,7 +769,8 @@ button {
     height: 100%;
     padding: 0 0 env(safe-area-inset-bottom, 0px) 0;
     margin: 0;
-    font-size: 16px;
+    font-size: 15px;
+    line-height: 1.2;
     cursor: pointer;
     border-radius: 0;
     display: flex;

--- a/style.css
+++ b/style.css
@@ -2,6 +2,8 @@
 @import url("./ui/colourpicker.css");
 
 :root {
+  --app-height: 100vh;
+
   /* Primary Brand Colors */
   --color-primary: #511d91;
   --color-primary-light: #fc3;
@@ -51,6 +53,12 @@
   /* Shadow Colors */
   --color-shadow: rgba(0, 0, 0, 0.1);
   --color-shadow-medium: rgba(0, 0, 0, 0.2);
+}
+
+@supports (height: 100dvh) {
+  :root {
+    --app-height: 100dvh;
+  }
 }
 
 /* Dark theme */
@@ -383,7 +391,7 @@ body {
   user-select: none;
   outline: none;
   -webkit-tap-highlight-color: transparent;
-  height: 100vh;
+  height: var(--app-height);
   width: 100vw;
 }
 
@@ -435,7 +443,7 @@ button {
 /* Layout Styles */
 #maincontent {
   width: 100vw;
-  height: calc(100vh - 50px);
+  height: calc(var(--app-height) - 50px);
   display: flex;
   margin: 0;
   gap: 0;
@@ -718,7 +726,7 @@ button {
 @media (max-width: 768px) {
   #maincontent {
     width: 200vw;
-    height: calc(100vh - var(--dynamic-offset));
+    height: calc(var(--app-height) - var(--dynamic-offset));
     overflow-x: auto;
   }
 
@@ -732,7 +740,7 @@ button {
   #canvasArea {
     flex-basis: 100vw;
     max-width: 100vw;
-    height: calc(100vh - var(--dynamic-offset));
+    height: calc(var(--app-height) - var(--dynamic-offset));
     flex-grow: 1;
   }
 

--- a/style.css
+++ b/style.css
@@ -744,7 +744,7 @@ button {
     bottom: 0;
     left: 0;
     width: 100vw;
-    height: calc(34px + env(safe-area-inset-bottom, 0px));
+    height: calc(28px + env(safe-area-inset-bottom, 0px));
     background-color: var(--color-primary);
     color: var(--color-text-on-primary);
     text-align: center;
@@ -775,7 +775,7 @@ button {
   }
 
   #site-footer {
-    bottom: calc(34px + env(safe-area-inset-bottom, 0px) + 4px);
+    bottom: calc(28px + env(safe-area-inset-bottom, 0px) + 1px);
   }
 }
 
@@ -785,7 +785,7 @@ button {
   }
 
   #site-footer {
-    padding-bottom: 18px;
+    padding-bottom: 2px;
     padding-right: 8px;
   }
 
@@ -800,7 +800,7 @@ button {
   }
 
   #site-footer {
-    padding-bottom: 18px;
+    padding-bottom: 2px;
     padding-right: 8px;
   }
 

--- a/style.css
+++ b/style.css
@@ -55,12 +55,6 @@
   --color-shadow-medium: rgba(0, 0, 0, 0.2);
 }
 
-@supports (height: 100dvh) {
-  :root {
-    --app-height: 100dvh;
-  }
-}
-
 /* Dark theme */
 [data-theme="dark"] {
   /* Core colours */

--- a/style.css
+++ b/style.css
@@ -3,6 +3,7 @@
 
 :root {
   --app-height: 100vh;
+  --dynamic-offset: 65px;
 
   /* Primary Brand Colors */
   --color-primary: #511d91;
@@ -717,7 +718,7 @@ button {
 #flocklink img {
   height: 15px;
 }
-@media (max-width: 1024px), (hover: none) and (pointer: coarse) {
+@media (max-width: 1024px) {
   #maincontent {
     width: 200vw;
     height: calc(var(--app-height) - var(--dynamic-offset));
@@ -768,9 +769,7 @@ button {
   }
 }
 
-@media
-  only screen and (orientation: landscape) and (max-width: 1024px),
-  only screen and (orientation: landscape) and (hover: none) and (pointer: coarse) {
+@media only screen and (orientation: landscape) and (max-width: 1024px) {
   #info-panel {
     display: none;
   }
@@ -785,9 +784,7 @@ button {
   }
 }
 
-@media
-  only screen and (orientation: portrait) and (max-width: 1024px),
-  only screen and (orientation: portrait) and (hover: none) and (pointer: coarse) {
+@media only screen and (orientation: portrait) and (max-width: 1024px) {
   #info-panel {
     display: block;
   }
@@ -802,7 +799,7 @@ button {
   }
 }
 
-@media (min-width: 1025px) and (hover: hover) and (pointer: fine) {
+@media (min-width: 1025px) {
   #bottomBar {
     display: none !important;
   }


### PR DESCRIPTION
### Motivation
- Replace hard-coded `100vh` usages to avoid mobile viewport/address-bar sizing issues by using a single adjustable height variable.
- Prefer the dynamic viewport unit `100dvh` when supported so the app fills the visible viewport on modern browsers.

### Description
- Add `--app-height` to `:root` with a default of `100vh` and a feature-detection block `@supports (height: 100dvh)` that sets `--app-height: 100dvh`.
- Replace direct `100vh` usages with `var(--app-height)` in `html, body`, `#maincontent` height calculations, and mobile media-query height calculations.
- Make corresponding layout adjustments to ensure `calc()` usages reference `var(--app-height)` instead of `100vh` to keep spacing consistent across viewports.

### Testing
- No automated tests were run for this stylesheet change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92ea1ffc48326ad7f62d2ae400fe3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Added a dynamic app-height CSS variable and switched layout sizing to use it for more consistent viewport handling (including safe-area-aware bottom bar and mobile layout tweaks).
  * Broadened responsive breakpoints and updated viewport update triggers (orientation, fullscreen and visual-viewport changes).

* **New Features**
  * Expanded the narrow-screen threshold to more devices (including touch/coarse-pointer devices).
  * Added touch support for the view-switch control to toggle panels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->