### PR TITLE
Add 3MF export support (UI, exporter, and tests)

### DIFF
--- a/api/xr.js
+++ b/api/xr.js
@@ -1,4 +1,5 @@
 import { translate } from "../main/translation.js";
+import * as fflate from "fflate";
 
 let flock;
 
@@ -178,6 +179,9 @@ export const flockXR = {
           flock.EXPORT.OBJExport.OBJ(mesh);
         } else if (format === "3MF") {
           try {
+            if (!globalThis.fflate) {
+              globalThis.fflate = fflate;
+            }
             const serializer = new flock.EXPORT.ThreeMfSerializer();
             const data = await flock.EXPORT.ThreeMf.SerializeToMemoryAsync(
               serializer,

--- a/api/xr.js
+++ b/api/xr.js
@@ -176,6 +176,24 @@ export const flockXR = {
           );
         } else if (format === "OBJ") {
           flock.EXPORT.OBJExport.OBJ(mesh);
+        } else if (format === "3MF") {
+          try {
+            const serializer = new flock.EXPORT.ThreeMfSerializer();
+            const data = await flock.EXPORT.ThreeMf.SerializeToMemoryAsync(
+              serializer,
+              ...meshList,
+            );
+            if (data?.length) {
+              flock.download(`${mesh.name}.3mf`, data, "model/3mf");
+            } else {
+              console.error(
+                "3MF export did not produce output data for mesh:",
+                mesh.name,
+              );
+            }
+          } catch (error) {
+            console.error("3MF export failed:", error);
+          }
         } else if (format === "GLB") {
           const ghostMat = new flock.BABYLON.PBRMaterial(
             "_tmpExportWrapperGhost",

--- a/blocks/connect.js
+++ b/blocks/connect.js
@@ -314,6 +314,7 @@ export function defineConnectBlocks() {
               ["STL", "STL"],
               ["OBJ", "OBJ"],
               ["GLB", "GLB"],
+              ["3MF", "3MF"],
             ],
           },
         ],

--- a/tests/xr-export.test.js
+++ b/tests/xr-export.test.js
@@ -108,5 +108,50 @@ export function runXRExportTests(flock) {
         .filter((mesh) => shouldExportNode(mesh));
       expect(exportedDescendants.length).to.be.greaterThan(0);
     });
+
+    it("exports 3MF using Babylon serializer and downloads file", async function () {
+      const treeId = flock.createObject({
+        modelName: "tree.glb",
+        modelId: `tree.glb__3mf_export_${Date.now()}`,
+        position: { x: 1, y: 0, z: 0 },
+      });
+      const treeMesh = await waitForModel(flock, treeId);
+
+      const originalSerializer = flock.EXPORT.ThreeMfSerializer;
+      const originalSerializeToMemoryAsync = flock.EXPORT.ThreeMf.SerializeToMemoryAsync;
+      const originalDownload = flock.download;
+
+      let serializerInstance;
+      let serializeMeshes;
+      let downloadedFile = null;
+
+      flock.EXPORT.ThreeMfSerializer = function MockThreeMfSerializer() {
+        serializerInstance = this;
+      };
+      flock.EXPORT.ThreeMf.SerializeToMemoryAsync = async (serializer, ...meshes) => {
+        serializeMeshes = meshes;
+        expect(serializer).to.equal(serializerInstance);
+        return new Uint8Array([1, 2, 3]);
+      };
+      flock.download = (filename, data, mimeType) => {
+        downloadedFile = { filename, data, mimeType };
+      };
+
+      try {
+        await flock.exportMesh(treeId, "3MF");
+      } finally {
+        flock.EXPORT.ThreeMfSerializer = originalSerializer;
+        flock.EXPORT.ThreeMf.SerializeToMemoryAsync = originalSerializeToMemoryAsync;
+        flock.download = originalDownload;
+      }
+
+      expect(serializeMeshes).to.be.an("array");
+      expect(serializeMeshes.length).to.be.greaterThan(0);
+      expect(serializeMeshes[0]).to.equal(treeMesh);
+      expect(downloadedFile).to.not.equal(null);
+      expect(downloadedFile.filename).to.equal(`${treeMesh.name}.3mf`);
+      expect(downloadedFile.mimeType).to.equal("model/3mf");
+      expect(downloadedFile.data).to.be.instanceof(Uint8Array);
+    });
   });
 }


### PR DESCRIPTION
### Motivation

- Provide 3MF export as an additional export format so meshes can be exported in the 3MF container format.

### Description

- Added a `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da502c71f88326b3a58f6888be2e3e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for exporting 3D models in 3MF format, now available alongside existing export options in the export menu.
  * The export block in the visual editor now includes a 3MF option.

* **Tests**
  * Added test coverage for 3MF export to verify serialization and download behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->