### PR TITLE
Fix camera target Y position fallback in flock transform

### DIFF
--- a/api/transform.js
+++ b/api/transform.js
@@ -545,7 +545,7 @@ export const flockTransform = {
       const tgtPos = (
         mesh2.getAbsolutePosition?.() ?? mesh2.absolutePosition
       ).clone();
-      if (!useY) tgtPos.y = camPos.y;
+      if (!useY) tgtPos.y = mesh1.target?.y ?? camPos.y;
       mesh1.setTarget(tgtPos);
       await new Promise((resolve) => {
         const cb = () => {


### PR DESCRIPTION
## Summary
Updated the camera target Y position logic in the flock transform to use the existing mesh target's Y coordinate as the primary fallback before defaulting to the camera position.

## Key Changes
- Modified the Y position assignment for `tgtPos` to check `mesh1.target?.y` first before falling back to `camPos.y`
- This ensures that if a target Y position was previously set on the mesh, it will be preserved rather than always resetting to the camera's Y position

## Implementation Details
The change improves the behavior when `useY` is false by maintaining consistency with any previously established target Y values, providing a more predictable camera positioning experience during flock transformations.

https://claude.ai/code/session_012ASzHmpUWv39A2j5hiFzyc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved camera target positioning logic to use the mesh's vertical coordinate when the vertical-axis constraint is disabled, rather than always defaulting to the camera's position. When no mesh target is available, the camera position is used as a fallback. This ensures more accurate and consistent camera behavior when working with constrained camera controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->