### PR TITLE
Treat printText duration 0 as persistent and add test

### DIFF
--- a/api/ui.js
+++ b/api/ui.js
@@ -731,12 +731,17 @@ export const flockUI = {
         });
       };
 
-      const timeoutId = setTimeout(fadeOut, safeDuration * 1000);
+      let timeoutId = null;
+      if (safeDuration > 0) {
+        timeoutId = setTimeout(fadeOut, safeDuration * 1000);
+      }
 
       flock.abortController.signal.addEventListener(
         "abort",
         () => {
-          clearTimeout(timeoutId);
+          if (timeoutId !== null) {
+            clearTimeout(timeoutId);
+          }
           if (flock.stackPanel) {
             flock.stackPanel.removeControl(bg);
             bg.dispose();

--- a/tests/printtext.test.js
+++ b/tests/printtext.test.js
@@ -64,5 +64,15 @@ export function runPrintTextTests(flock) {
         done();
       }, 3000);
     });
+
+    it("should keep the control when duration is 0", function (done) {
+      this.timeout(2000);
+      flock.printText({ text: "Persist", duration: 0 });
+      setTimeout(() => {
+        const bg = advancedTexture.getControlByName("textBackground");
+        expect(bg).to.exist;
+        done();
+      }, 250);
+    });
   });
 }


### PR DESCRIPTION
### Motivation
- Ensure `printText` treats a `duration` of `0` as “persistent” (no auto-fade) instead of scheduling a timeout to remove it. 
- Add a test to prevent regressions and verify persistent behavior.

### Description
- Change `timeoutId` from a `const` to `let` and initialize it to `null` in `api/ui.js` to represent no scheduled timeout. 
- Only call `setTimeout(fadeOut, ...)` when `safeDuration > 0`, so a `duration` of `0` will not schedule an automatic fade. 
- Guard the abort handler to only call `clearTimeout` when `timeoutId !== null`, avoiding unnecessary clearing when no timeout was scheduled. 
- Add a test `should keep the control when duration is 0` in `tests/printtext.test.js` that asserts the background control still exists after a short delay.

### Testing
- Ran the print text test suite including the new `should keep the control when duration is 0` test, and all tests passed. 
- Existing tests for text content and color behavior (`should print text`, `should use white as the default text color`, `should use the specified text color`, `should remove the control after the duration expires`) were run and remained green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd3947f78c832694c4ba615e7c7f45)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text fade-out behavior to only activate when a specific duration is configured, improving edge case handling
  * Improved timeout cleanup logic to prevent unintended text removal when duration is zero

* **Tests**
  * Added test coverage for persistent text display when duration is zero

<!-- end of auto-generated comment: release notes by coderabbit.ai -->