### PR TITLE
Fix stale mesh references and execution state on project reload

### DIFF
--- a/main/execution.js
+++ b/main/execution.js
@@ -105,3 +105,10 @@ export function stopCode() {
 window.stopCode = stopCode;
 
 window.executeCode = executeCode;
+
+// Exposed so loadWorkspaceAndExecute can reset the guard before triggering a
+// fresh run.  The new runCode() call will abort the previous one via its own
+// abort-controller / run-token mechanism.
+window.cancelExecution = () => {
+  isExecuting = false;
+};

--- a/main/files.js
+++ b/main/files.js
@@ -3,6 +3,7 @@ import { workspace } from "./blocklyinit.js";
 import { translate } from "./translation.js";
 import { getMetadata } from "meta-png";
 import { AUTOSAVE_KEY } from "../config.js";
+import { clearMeshMaps } from "../generators/mesh-state.js";
 
 // Function to save the current workspace state
 export function saveWorkspace(workspace) {
@@ -327,9 +328,22 @@ export function loadWorkspaceAndExecute(json, workspace, executeCallback) {
     // Validate JSON before loading into workspace
     const validatedJson = validateBlocklyJson(json);
 
+    // Clear stale mesh-map entries (disposed block references from any previous
+    // run) before loading.  This is critical when the same project is reloaded
+    // because block IDs are identical, so a stale meshMap["abc123"] = oldBlock
+    // entry would otherwise shadow the workspace-lookup fallback and cause
+    // gizmo / block colour updates to silently fail.
+    clearMeshMaps();
+
     // Load the validated JSON
     Blockly.serialization.workspaces.load(validatedJson, workspace);
     workspace.scroll(0, 0);
+
+    // Allow execution to proceed even if a previous run hasn't fully wound
+    // down yet (isExecuting guard).  runCode() aborts the old run internally
+    // via its abort-controller / run-token mechanism.
+    window.cancelExecution?.();
+
     executeCallback();
   } catch (error) {
     console.error("Failed to load workspace:", error);

--- a/ui/blockmesh.js
+++ b/ui/blockmesh.js
@@ -2276,7 +2276,9 @@ export function updateBlockColorAndHighlight(mesh, selectedColor) {
   const root = getAttachedAwareRoot(mesh);
   const blockKey = root?.metadata?.blockKey;
 
-  if (!blockKey || !meshMap?.[blockKey]) {
+  if (!blockKey || !meshMap?.[blockKey] ||
+      meshMap[blockKey].disposed ||
+      !meshMap[blockKey].workspace) {
     const ws = Blockly.getMainWorkspace();
     const fallbackBlock = blockKey ? ws?.getBlockById(blockKey) : null;
     if (fallbackBlock) {

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -418,7 +418,7 @@ function focusCameraOnMesh() {
   let mesh = gizmoManager.attachedMesh;
   if (mesh && mesh.name === "ground") mesh = null;
   if (!mesh && window.currentMesh) {
-    const blockKey = getBlockKeyFromBlock(window.currentBlock);
+    const blockKey = getBlockKeyFromBlock(window.currentBlock) ?? window.currentBlock?.id ?? null;
     mesh = getMeshFromBlockKey(blockKey);
   }
   if (!mesh) return;


### PR DESCRIPTION
## Summary
This PR fixes issues that occur when reloading a project by clearing stale mesh-map entries and resetting execution state before loading a new workspace. It also adds defensive checks to handle disposed blocks and improves block key resolution in the gizmo system.

## Key Changes

- **Clear stale mesh maps on reload**: Added `clearMeshMaps()` call in `loadWorkspaceAndExecute()` to remove disposed block references from previous runs. This prevents stale entries from shadowing workspace lookups when reloading projects with identical block IDs.

- **Reset execution guard on reload**: Exposed `cancelExecution()` function to allow `loadWorkspaceAndExecute()` to reset the `isExecuting` guard before triggering a fresh run. The new execution will abort any previous run via its own abort-controller mechanism.

- **Add defensive checks for disposed blocks**: Enhanced `updateBlockColorAndHighlight()` to check if a block is disposed or lacks a workspace before using it from the mesh map, falling back to workspace lookup if needed.

- **Improve block key resolution**: Updated `focusCameraOnMesh()` to fall back to `window.currentBlock?.id` when `getBlockKeyFromBlock()` returns undefined, providing more robust block identification.

## Implementation Details

The core issue addressed is that when a project is reloaded, block IDs remain identical, so stale `meshMap` entries from the previous run would shadow the workspace-lookup fallback and cause gizmo/block color updates to silently fail. The fix ensures a clean state by clearing the mesh maps before loading the new workspace and resetting the execution guard to allow the new run to proceed cleanly.

https://claude.ai/code/session_01TYhT3DLqdA1jpETGJpxpBy