### PR TITLE
Clear workspace and blockhander registry before loading files

### DIFF
--- a/main/files.js
+++ b/main/files.js
@@ -1,8 +1,10 @@
 import * as Blockly from "blockly";
 import { workspace } from "./blocklyinit.js";
+import { flock } from "../flock.js";
 import { translate } from "./translation.js";
 import { getMetadata } from "meta-png";
 import { AUTOSAVE_KEY } from "../config.js";
+import { blockHandlerRegistry } from "../blocks/blocks.js";
 
 // Function to save the current workspace state
 export function saveWorkspace(workspace) {
@@ -327,8 +329,16 @@ export function loadWorkspaceAndExecute(json, workspace, executeCallback) {
     // Validate JSON before loading into workspace
     const validatedJson = validateBlocklyJson(json);
 
-    // Load the validated JSON
+    // Clear workspace and handlers
+    const eventsWereEnabled = Blockly.Events.isEnabled();
+    if (eventsWereEnabled) Blockly.Events.disable();
+    workspace.clear();
+    blockHandlerRegistry.clear();
+    if (eventsWereEnabled) Blockly.Events.enable();
+
+     // Load the validated JSON
     Blockly.serialization.workspaces.load(validatedJson, workspace);
+
     workspace.scroll(0, 0);
     executeCallback();
   } catch (error) {


### PR DESCRIPTION
Avoid the cases where deletes of matching existing blocks were deleting the new event handlers.

Use Codex 5.4 to add debug and help troubleshoot. But rejected its overcomplex solutions.