### PR TITLE
Add canvas focus functionality after render initialization

### DIFF
--- a/flock.js
+++ b/flock.js
@@ -886,6 +886,14 @@ export const flock = {
         ),
       ]);
 
+      if (focusCanvas === true) {
+        // focus canvas if present
+        (
+          document.getElementById("renderCanvas") ||
+          doc.getElementById("renderCanvas")
+        )?.focus();
+      }
+
     } catch (error) {
       const enhancedError = this.createEnhancedError?.(error, code) ?? error;
       console.error("Enhanced error details:", enhancedError);


### PR DESCRIPTION
## Summary
Added automatic canvas focus capability to the flock render initialization process. When enabled, the render canvas will receive focus after being set up.

## Key Changes
- Added conditional canvas focus logic that executes after render setup completes
- Implements fallback element selection using both `document.getElementById()` and `doc.getElementById()` to handle different DOM contexts
- Uses optional chaining (`?.focus()`) to safely call focus only if the canvas element exists
- Focus is controlled by a `focusCanvas` boolean parameter

## Implementation Details
- The focus operation is placed after all render initialization steps complete but before error handling
- The dual getElementById approach ensures compatibility with both standard DOM and custom document references
- Safe null-coalescing prevents errors if the render canvas element is not found

https://claude.ai/code/session_01NuUggK5ehmMACBZKVfdgUk