### PR TITLE
Keyboard controls for Select gizmo

### DIFF
--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -945,16 +945,22 @@ function handleSelectGizmo() {
   // Wait until the click has propagated otherwise
   // the keyboard mode gets cancelled immediately
   setTimeout(() => {
-    startCanvasKeyboardMode((x, y) => {
-      if (gizmoManager.attachedMesh) {
-        resetAttachedMesh();
-        blockKey = findParentWithBlockId(gizmoManager.attachedMesh)?.metadata
-          ?.blockKey;
-      }
-      const pick = flock.scene.pick(x, y);
-      applySelection(pick?.pickedMesh, pick?.pickedPoint);
-      stopCanvasKeyboardMode();
-    });
+    startCanvasKeyboardMode(
+      (x, y) => {
+        if (gizmoManager.attachedMesh) {
+          resetAttachedMesh();
+          blockKey = findParentWithBlockId(gizmoManager.attachedMesh)?.metadata
+            ?.blockKey;
+        }
+        const pick = flock.scene.pick(x, y);
+        applySelection(pick?.pickedMesh, pick?.pickedPoint);
+        stopCanvasKeyboardMode();
+      },
+      false,
+      (x, y) =>
+        !!flock.scene.pick(x, y, (m) => m.isPickable && m.name !== "ground")
+          ?.hit,
+    );
   }, 0);
 
   // Store the pointer observable

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -900,6 +900,63 @@ function handleSelectGizmo() {
   let blockKey;
   gizmoManager.selectGizmoEnabled = true;
 
+  function applySelection(pickedMesh, pickedPoint) {
+    if (pickedMesh && pickedMesh.name !== "ground") {
+      const position = pickedMesh.getAbsolutePosition();
+      const roundedPosition = roundVectorToFixed(position, 2);
+      flock.printText({
+        text: translate("position_readout").replace(
+          "{position}",
+          String(roundedPosition),
+        ),
+        duration: 30,
+        color: "black",
+      });
+      if (flock.meshDebug) console.log(pickedMesh.parent);
+      if (pickedMesh.parent) {
+        pickedMesh = getRootMesh(pickedMesh.parent);
+        if (flock.meshDebug) console.log(pickedMesh.visibility);
+        pickedMesh.visibility = 0.001;
+        if (flock.meshDebug) console.log(pickedMesh.visibility);
+      }
+      const block = meshMap[blockKey];
+      highlightBlockById(Blockly.getMainWorkspace(), block);
+      gizmoManager.attachToMesh(pickedMesh);
+      pickedMesh.showBoundingBox = true;
+    } else {
+      if (pickedMesh && pickedMesh.name === "ground") {
+        const roundedPosition = roundVectorToFixed(pickedPoint, 2);
+        flock.printText({
+          text: translate("position_readout").replace(
+            "{position}",
+            String(roundedPosition),
+          ),
+          duration: 30,
+          color: "black",
+        });
+      }
+      if (gizmoManager.attachedMesh) {
+        resetChildMeshesOfAttachedMesh();
+        gizmoManager.attachToMesh(null);
+      }
+    }
+  }
+
+  // Wait until the click has propagated otherwise
+  // the keyboard mode gets cancelled immediately
+  setTimeout(() => {
+    startCanvasKeyboardMode((x, y) => {
+      if (gizmoManager.attachedMesh) {
+        resetAttachedMesh();
+        blockKey = findParentWithBlockId(gizmoManager.attachedMesh)?.metadata
+          ?.blockKey;
+      }
+      const pick = flock.scene.pick(x, y);
+      applySelection(pick?.pickedMesh, pick?.pickedPoint);
+      stopCanvasKeyboardMode();
+    });
+  }, 0);
+
   // Store the pointer observable
   const pointerObservable = flock.scene.onPointerObservable;
 
@@ -911,62 +968,8 @@ function handleSelectGizmo() {
         blockKey = findParentWithBlockId(gizmoManager.attachedMesh)?.metadata
           ?.blockKey;
       }
-      let pickedMesh = event.pickInfo.pickedMesh;
 
-      if (pickedMesh && pickedMesh.name !== "ground") {
-        const position = pickedMesh.getAbsolutePosition();
-
-        // Round the coordinates to 2 decimal places
-        const roundedPosition = roundVectorToFixed(position, 2);
-
-        flock.printText({
-          text: translate("position_readout").replace(
-            "{position}",
-            String(roundedPosition),
-          ),
-          duration: 30,
-          color: "black",
-        });
-
-        if (flock.meshDebug) console.log(pickedMesh.parent);
-
-        if (pickedMesh.parent) {
-          pickedMesh = getRootMesh(pickedMesh.parent);
-          if (flock.meshDebug) console.log(pickedMesh.visibility);
-          pickedMesh.visibility = 0.001;
-          if (flock.meshDebug) console.log(pickedMesh.visibility);
-        }
-
-        const block = meshMap[blockKey];
-        highlightBlockById(Blockly.getMainWorkspace(), block);
-
-        // Attach the gizmo to the selected mesh
-        gizmoManager.attachToMesh(pickedMesh);
-
-        // Show bounding box for the selected mesh
-        pickedMesh.showBoundingBox = true;
-      } else {
-        if (pickedMesh && pickedMesh.name === "ground") {
-          const position = event.pickInfo.pickedPoint;
-
-          const roundedPosition = roundVectorToFixed(position, 2);
-
-          flock.printText({
-            text: translate("position_readout").replace(
-              "{position}",
-              String(roundedPosition),
-            ),
-            duration: 30,
-            color: "black",
-          });
-        }
-
-        // Deselect if no mesh is picked
-        if (gizmoManager.attachedMesh) {
-          resetChildMeshesOfAttachedMesh();
-          gizmoManager.attachToMesh(null); // Detach the gizmo
-        }
-      }
+      applySelection(event.pickInfo.pickedMesh, event.pickInfo.pickedPoint);
 
       pointerObservable.remove(pointerObserver);
     }

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -919,7 +919,7 @@ function handleSelectGizmo() {
         pickedMesh.visibility = 0.001;
         if (flock.meshDebug) console.log(pickedMesh.visibility);
       }
-      const block = meshMap[blockKey];
+      const block = meshMap[pickedMesh?.metadata?.blockKey];
       highlightBlockById(Blockly.getMainWorkspace(), block);
       gizmoManager.attachToMesh(pickedMesh);
       pickedMesh.showBoundingBox = true;


### PR DESCRIPTION
# Summary
- The select (arrow) gizmo can now be controlled by the arrow keys to move, and Enter to choose
- The cursor displays as a 🚫 if the cursor is not hovering on something selectable

## Things this does NOT do
- The canvas cursor does NOT automatically appear if keyboard controls are being used, pending a decision on #542 - I'll alter this everywhere in a separate PR if it's decided that is what we want. 
- The corresponding block is displayed correctly in the editor when you select a mesh. HOWEVER the keyboard focus is not transferred to that block. This is because it isn't a simple thing to do without getting into a fight with Blockly. 

Claude Sonnet 4.6 wrote the `applySelection` function within gizmos.js but this reuses most of the existing code. It's mainly there so that both mouse and keyboard controls can use the same code. 

Part of #360 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added position readouts when selecting gizmos or picking points on the canvas.

* **Improvements**
  * Enhanced selection and deselection handling for improved consistency.
  * Better differentiation between ground picks and mesh selections with appropriate responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->