### PR TITLE
Keyboard controls for Duplicate gizmo

### DIFF
--- a/ui/canvas-utils.js
+++ b/ui/canvas-utils.js
@@ -7,6 +7,7 @@ let canvasCirclePosition = { x: 0, y: 0 };
 let keyboardCursorActive = false;
 let keyboardCursorCallback = null;
 let hitChecker = null;
+let previouslyFocusedElement = null; // Save previous focus to return to later
 
 // Returns a reference to the canvasCircle
 export function getCanvasCircle() {
@@ -28,6 +29,7 @@ export function createCanvasCircle() {
   // Create the visual indicator circle
   canvasCircle = document.createElement("div");
   canvasCircle.className = "canvas-selector-circle"; // Set style
+  canvasCircle.tabIndex = -1;
   document.body.appendChild(canvasCircle);
 
   // Initialize position to canvas center
@@ -92,12 +94,15 @@ export function startCanvasKeyboardMode(
   isValidPosition = null,
 ) {
   stopCanvasKeyboardMode(); // Ensure any existing mode is cleared
+  previouslyFocusedElement = document.activeElement; // Save current focus
   keyboardCursorActive = true;
   keyboardCursorCallback = callback;
   hitChecker = isValidPosition;
   document.addEventListener("keydown", handleKeydown);
   if (showCircleImmediately) {
     createCanvasCircle();
+
+    canvasCircle.focus({ preventScroll: true }); // Focus the circle
     document.body.style.cursor = "none"; // Hide cursor when circle is active
   } else {
     document.body.style.cursor = "default";
@@ -115,12 +120,17 @@ export function stopCanvasKeyboardMode() {
   const canvas = flock.scene?.getEngine?.()?.getRenderingCanvas?.();
   if (canvas) canvas.style.cursor = "";
   document.body.style.cursor = "default";
+  // Reinstate focus to element in focus prior to entering
+  // canvas cursor mode (otherwise this is annoying for kb users)
+  previouslyFocusedElement?.focus({ preventScroll: true });
+  previouslyFocusedElement = null;
 }
 
 // Make sure there actually is a circle
 function ensureCircle() {
   if (!getCanvasCircle()) {
     createCanvasCircle();
+    canvasCircle.focus({ preventScroll: true }); // Focus the circle
     // Remove cursor otherwise you get both which is confusing
     const canvas = flock.scene.getEngine().getRenderingCanvas();
     canvas.style.cursor = "none";
@@ -132,6 +142,20 @@ function ensureCircle() {
 function handleKeydown(event) {
   if (!keyboardCursorActive) return;
 
+  // If a button was focused and they pressed enter/space, don't
+  // move the circle, interact with the button
+  const tag = (event.target?.tagName || "").toLowerCase();
+  if (
+    (tag === "button" ||
+      tag === "input" ||
+      tag === "textarea" ||
+      tag === "select" ||
+      event.target?.isContentEditable) &&
+    (event.key === "Enter" || event.key === " " || event.key === "Spacebar")
+  ) {
+    console.log("Button interaction, not moving canvas circle");
+    return;
+  }
   const moveDistance = event.shiftKey ? 10 : 2;
   switch (event.key) {
     case "ArrowRight":

--- a/ui/canvas-utils.js
+++ b/ui/canvas-utils.js
@@ -182,6 +182,12 @@ function handleKeydown(event) {
       moveCanvasCircle(0, -moveDistance);
       break;
 
+    // Tab is assumed to restart keyboard nav mode
+    case "Tab":
+      event.preventDefault(); // don't actually tab!
+      stopCanvasKeyboardMode();
+      break;
+
     case "Enter":
     case " ":
     case "Spacebar":

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -1029,6 +1029,10 @@ function handleDuplicateGizmo() {
 
     if (eventIsOutOfCanvasBounds(event, canvasRect)) {
       window.removeEventListener("click", onPickMesh);
+      // Clean up the mid-duplicate state
+      activeDuplicatePickHandler = null;
+      duplicateButton.classList.remove("active");
+      meshToClone.showBoundingBox = false;
       document.body.style.cursor = "default";
       return;
     }

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -1002,6 +1002,10 @@ function handleDuplicateGizmo() {
   const meshToClone = gizmoManager.attachedMesh;
   meshToClone.showBoundingBox = true;
 
+  // Highlight the duplicate button until the clone is placed
+  const duplicateButton = document.getElementById("duplicateButton");
+  duplicateButton.classList.add("active");
+
   blockId = meshBlockIdMap[blockKey];
 
   document.body.style.cursor = "crosshair"; // Change cursor to indicate picking mode
@@ -1040,6 +1044,7 @@ function handleDuplicateGizmo() {
       const workspace = Blockly.getMainWorkspace();
       const originalBlock = workspace.getBlockById(blockId);
       meshToClone.showBoundingBox = false; // Hide bounding box of original mesh
+      duplicateButton.classList.remove("active"); // Unhighlight the button
       duplicateBlockAndInsert(originalBlock, workspace, pickedPosition);
     }
   };
@@ -1058,6 +1063,7 @@ function handleDuplicateGizmo() {
           const workspace = Blockly.getMainWorkspace();
           const originalBlock = workspace.getBlockById(blockId);
           meshToClone.showBoundingBox = false; // Hide bounding box of original mesh
+          duplicateButton.classList.remove("active"); // Unhighlight the button
           duplicateBlockAndInsert(
             originalBlock,
             workspace,

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -392,6 +392,7 @@ export function toggleGizmo(gizmoType) {
   if (activeDuplicatePickHandler) {
     window.removeEventListener("click", activeDuplicatePickHandler);
     activeDuplicatePickHandler = null;
+    if (gizmoType === "duplicate") return;
   }
   disableGizmos();
   resetAttachedMeshIfMeshAttached();
@@ -1060,15 +1061,8 @@ function handleDuplicateGizmo() {
 
     if (pickResult.hit) {
       const pickedPosition = pickResult.pickedPoint;
-      window.removeEventListener("click", onPickMesh);
-      activeDuplicatePickHandler = null;
-      document.body.style.cursor = "default";
-      stopCanvasKeyboardMode();
-
       const workspace = Blockly.getMainWorkspace();
       const originalBlock = workspace.getBlockById(blockId);
-      meshToClone.showBoundingBox = false; // Hide bounding box of original mesh
-      duplicateButton.classList.remove("active"); // Unhighlight the button
       duplicateBlockAndInsert(originalBlock, workspace, pickedPosition);
     }
   };
@@ -1090,18 +1084,12 @@ function handleDuplicateGizmo() {
         if (pickResult?.hit) {
           const workspace = Blockly.getMainWorkspace();
           const originalBlock = workspace.getBlockById(blockId);
-          meshToClone.showBoundingBox = false; // Hide bounding box of original mesh
-          duplicateButton.classList.remove("active"); // Unhighlight the button
           duplicateBlockAndInsert(
             originalBlock,
             workspace,
             pickResult.pickedPoint,
           );
         }
-        window.removeEventListener("click", onPickMesh);
-        activeDuplicatePickHandler = null;
-        document.body.style.cursor = "default";
-        stopCanvasKeyboardMode();
       },
       false,
       (x, y) => !!flock.scene.pick(x, y, (mesh) => mesh.isPickable)?.hit,

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -996,6 +996,12 @@ function handleDuplicateGizmo() {
   }
   blockKey = findParentWithBlockId(gizmoManager.attachedMesh)?.metadata
     ?.blockKey;
+
+  // Make sure that if there is already a selected mesh
+  // its bounding box is visible so the user knows what they are duplicating
+  const meshToClone = gizmoManager.attachedMesh;
+  meshToClone.showBoundingBox = true;
+
   blockId = meshBlockIdMap[blockKey];
 
   document.body.style.cursor = "crosshair"; // Change cursor to indicate picking mode
@@ -1027,18 +1033,45 @@ function handleDuplicateGizmo() {
 
     if (pickResult.hit) {
       const pickedPosition = pickResult.pickedPoint;
+      window.removeEventListener("click", onPickMesh);
+      document.body.style.cursor = "default";
+      stopCanvasKeyboardMode();
 
       const workspace = Blockly.getMainWorkspace();
       const originalBlock = workspace.getBlockById(blockId);
+      meshToClone.showBoundingBox = false; // Hide bounding box of original mesh
       duplicateBlockAndInsert(originalBlock, workspace, pickedPosition);
     }
   };
 
   // Use setTimeout to defer listener setup
-  document.body.style.cursor = "crosshair";
   setTimeout(() => {
     window.addEventListener("click", onPickMesh);
   }, 50);
+
+  // Keyboard mode: use canvas circle to place the duplicate
+  setTimeout(() => {
+    startCanvasKeyboardMode(
+      (x, y) => {
+        const pickResult = flock.scene.pick(x, y, (mesh) => mesh.isPickable);
+        if (pickResult?.hit) {
+          const workspace = Blockly.getMainWorkspace();
+          const originalBlock = workspace.getBlockById(blockId);
+          meshToClone.showBoundingBox = false; // Hide bounding box of original mesh
+          duplicateBlockAndInsert(
+            originalBlock,
+            workspace,
+            pickResult.pickedPoint,
+          );
+        }
+        window.removeEventListener("click", onPickMesh);
+        document.body.style.cursor = "default";
+        stopCanvasKeyboardMode();
+      },
+      false,
+      (x, y) => !!flock.scene.pick(x, y, (mesh) => mesh.isPickable)?.hit,
+    );
+  }, 0);
 }
 
 // Delete: Remove the selected mesh and its corresponding block

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -68,6 +68,14 @@ document.addEventListener("DOMContentLoaded", function () {
 
       // If gizmos are on, disable them
       try {
+        // If they are mid-duplicate, clean up that state and UI
+        if (activeDuplicatePickHandler) {
+          window.removeEventListener("click", activeDuplicatePickHandler);
+          activeDuplicatePickHandler = null;
+          document
+            .getElementById("duplicateButton")
+            ?.classList.remove("active");
+        }
         disableGizmos();
       } catch {
         // fail-safe: still attempt to disable
@@ -375,9 +383,6 @@ export function disableGizmos() {
 
 // Toggle which Gizmo is being used
 export function toggleGizmo(gizmoType) {
-  disableGizmos();
-  resetAttachedMeshIfMeshAttached();
-
   // No buttons should be highlighted
   document
     .querySelectorAll(".gizmo-button")
@@ -388,6 +393,8 @@ export function toggleGizmo(gizmoType) {
     window.removeEventListener("click", activeDuplicatePickHandler);
     activeDuplicatePickHandler = null;
   }
+  disableGizmos();
+  resetAttachedMeshIfMeshAttached();
 
   document.body.style.cursor = "default";
 

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -40,6 +40,7 @@ let textScaleAxis = null;
 let textOrigScaleZ = 1;
 
 let cameraMode = "play";
+let activeDuplicatePickHandler = null; // Are they in the middle of a duplication?
 
 // Track DO sections and their associated blocks for cleanup
 const gizmoCreatedBlocks = new Map(); // blockId -> { parentId, createdDoSection, timestamp }
@@ -376,6 +377,17 @@ export function disableGizmos() {
 export function toggleGizmo(gizmoType) {
   disableGizmos();
   resetAttachedMeshIfMeshAttached();
+
+  // No buttons should be highlighted
+  document
+    .querySelectorAll(".gizmo-button")
+    .forEach((btn) => btn.classList.remove("active"));
+
+  // If they abandoned a duplicate half way, remove listener
+  if (activeDuplicatePickHandler) {
+    window.removeEventListener("click", activeDuplicatePickHandler);
+    activeDuplicatePickHandler = null;
+  }
 
   document.body.style.cursor = "default";
 
@@ -1038,6 +1050,7 @@ function handleDuplicateGizmo() {
     if (pickResult.hit) {
       const pickedPosition = pickResult.pickedPoint;
       window.removeEventListener("click", onPickMesh);
+      activeDuplicatePickHandler = null;
       document.body.style.cursor = "default";
       stopCanvasKeyboardMode();
 
@@ -1048,6 +1061,10 @@ function handleDuplicateGizmo() {
       duplicateBlockAndInsert(originalBlock, workspace, pickedPosition);
     }
   };
+
+  // Store a reference to this listener so we can get rid of it
+  // if they abort half way through a duplication
+  activeDuplicatePickHandler = onPickMesh;
 
   // Use setTimeout to defer listener setup
   setTimeout(() => {
@@ -1071,6 +1088,7 @@ function handleDuplicateGizmo() {
           );
         }
         window.removeEventListener("click", onPickMesh);
+        activeDuplicatePickHandler = null;
         document.body.style.cursor = "default";
         stopCanvasKeyboardMode();
       },


### PR DESCRIPTION
# Summary
- When the duplicate gizmo is pressed (assuming a mesh is previously selected) allow the canvas cursor to be used to select where to place the duplicate

## Intricacies
- Makes sure that the bounding box of the selected mesh you will be duplicating is shown, as there was an existing bug where sometimes a mesh was selected but the box wasn't visible, resulting in sometimes surprising behaviour
- When the duplicate button is selected, highlight it until the duplicate is placed to provide a visual cue
<img width="619" height="396" alt="image" src="https://github.com/user-attachments/assets/e50ea157-9dd2-4d15-ac1d-eb84ad8bde23" />

- If the user abandons a duplicate part way through (i.e. selects a mesh, presses duplicate, then clicks a different gizmo before placing the clone) the listener is removed and all buttons are unhighlighted.
- Duplicate mode stays ON until it is turned off by either pressing `Esc` or toggling the duplicate button, so that you can place multiple clones. 
- Pressing `Tab` when the duplicate mode is on returns focus to the duplicate button so you can continue keyboard navigation. This is because it was previously really annoying to get out of duplicate mode using only the keyboard because you had to tab through from the top left (as focus is moved to the circle when you enter circle cursor mode). 


Claude Sonnet 4.6 generated a lot of the code in this PR, however it was added by hand as a safeguard to check understanding of what the code does. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a keyboard/canvas placement mode for duplicating objects and ensured keyboard-focused canvas interaction.

* **Bug Fixes**
  * Fixed click-handler conflicts and ensured pending duplicate handlers are cleared when switching tools or aborting.
  * Restored UI/focus state on cancel (including cursor, button active states, and bounding-box visibility).
  * Prevented unintended canvas interactions via improved Tab/Enter/Space handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->