### PR TITLE
Axis keyboard handler and Move gizmo keyboard controls

### DIFF
--- a/ui/axis-keyboard.js
+++ b/ui/axis-keyboard.js
@@ -1,0 +1,107 @@
+import { flock } from "../flock.js";
+
+// A generic handler to be used for axis-constrained
+// keyboard movement in various tools (move, scale, etc)
+export function createAxisKeyboardHandler({
+  onMove,
+  onConfirm,
+  onCancel,
+  stepNormal = 0.1,
+  stepFast = 1,
+}) {
+  let axis = null;
+
+  function handler(event) {
+    const step = event.shiftKey ? stepFast : stepNormal;
+
+    switch (event.key) {
+      case "x":
+      case "X":
+        axis = axis === "x" ? null : "x";
+        flock.printText({
+          text: axis ? "X axis" : "Free",
+          duration: 10,
+          color: "black",
+        });
+        event.preventDefault();
+        break;
+
+      case "y":
+      case "Y":
+        axis = axis === "y" ? null : "y";
+        flock.printText({
+          text: axis ? "Y axis" : "Free",
+          duration: 10,
+          color: "black",
+        });
+        event.preventDefault();
+        break;
+
+      case "z":
+      case "Z":
+        axis = axis === "z" ? null : "z";
+        flock.printText({
+          text: axis ? "Z axis" : "Free",
+          duration: 10,
+          color: "black",
+        });
+        event.preventDefault();
+        break;
+
+      case "ArrowRight":
+      case "ArrowLeft":
+      case "ArrowUp":
+      case "ArrowDown": {
+        event.preventDefault();
+        const sign =
+          event.key === "ArrowRight" || event.key === "ArrowUp" ? 1 : -1;
+        if (axis) {
+          onMove(
+            axis === "x" ? step * sign : 0,
+            axis === "y" ? step * sign : 0,
+            axis === "z" ? step * sign : 0,
+          );
+        } else {
+          if (event.key === "ArrowRight") onMove(step, 0, 0);
+          else if (event.key === "ArrowLeft") onMove(-step, 0, 0);
+          else if (event.key === "ArrowUp") onMove(0, 0, step);
+          else if (event.key === "ArrowDown") onMove(0, 0, -step);
+        }
+        break;
+      }
+
+      case "PageUp":
+        event.preventDefault();
+        if (!axis) onMove(0, step, 0);
+        break;
+
+      case "PageDown":
+        event.preventDefault();
+        if (!axis) onMove(0, -step, 0);
+        break;
+
+      case "Enter":
+      case " ": {
+        event.preventDefault();
+        onConfirm();
+        stop();
+        break;
+      }
+
+      case "Escape":
+        event.preventDefault();
+        onCancel();
+        stop();
+        break;
+    }
+  }
+
+  document.addEventListener("keydown", handler);
+
+  function stop() {
+    axis = null;
+    document.removeEventListener("keydown", handler);
+  }
+
+  return stop;
+}

--- a/ui/axis-keyboard.js
+++ b/ui/axis-keyboard.js
@@ -83,15 +83,21 @@ export function createAxisKeyboardHandler({
       case "Enter":
       case " ": {
         event.preventDefault();
-        onConfirm();
-        stop();
+        try {
+          onConfirm();
+        } finally {
+          stop();
+        }
         break;
       }
 
       case "Escape":
         event.preventDefault();
-        onCancel();
-        stop();
+        try {
+          onCancel();
+        } finally {
+          stop();
+        }
         break;
     }
   }

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -26,6 +26,7 @@ import {
   startCanvasKeyboardMode,
   stopCanvasKeyboardMode,
 } from "./canvas-utils.js";
+import { createAxisKeyboardHandler } from "./axis-keyboard.js";
 export let gizmoManager;
 
 const blueColor = flock.BABYLON.Color3.FromHexString("#0072B2"); // Colour for X-axis
@@ -41,6 +42,7 @@ let textOrigScaleZ = 1;
 
 let cameraMode = "play";
 let activeDuplicatePickHandler = null; // Are they in the middle of a duplication?
+let stopAxisKeyboard = null; // Are they transforming?
 
 // Track DO sections and their associated blocks for cleanup
 const gizmoCreatedBlocks = new Map(); // blockId -> { parentId, createdDoSection, timestamp }
@@ -75,6 +77,9 @@ document.addEventListener("DOMContentLoaded", function () {
           document
             .getElementById("duplicateButton")
             ?.classList.remove("active");
+          // Clean up mid-transform state if relevant
+          stopAxisKeyboard?.();
+          stopAxisKeyboard = null;
         }
         disableGizmos();
       } catch {
@@ -394,6 +399,11 @@ export function toggleGizmo(gizmoType) {
     activeDuplicatePickHandler = null;
     if (gizmoType === "duplicate") return;
   }
+
+  // If they were mid-transform, clean up
+  stopAxisKeyboard?.();
+  stopAxisKeyboard = null;
+
   disableGizmos();
   resetAttachedMeshIfMeshAttached();
 
@@ -828,6 +838,36 @@ function handleRotationGizmo() {
 // Position: Allow the user to move the mesh by dragging it
 function handlePositionGizmo() {
   configurePositionGizmo(gizmoManager);
+
+  const mesh = gizmoManager.attachedMesh;
+  if (mesh) {
+    const original = mesh.position.clone();
+    setTimeout(() => {
+      stopAxisKeyboard = createAxisKeyboardHandler({
+        onMove: (dx, dy, dz) => {
+          mesh.position.x += dx;
+          mesh.position.y += dy;
+          mesh.position.z += dz;
+        },
+        onConfirm: () => {
+          mesh.computeWorldMatrix(true);
+          const block = meshMap[mesh?.metadata?.blockKey];
+          if (block) {
+            const pos = flock.getBlockPositionFromMesh(mesh);
+            setBlockXYZ(block, pos.x, pos.y, pos.z);
+          }
+          disableGizmos();
+        },
+        onCancel: () => {
+          mesh.position.copyFrom(original);
+          disableGizmos();
+        },
+        stepNormal: 0.1,
+        stepFast: 1,
+      });
+    }, 0);
+  }
+
   gizmoManager.onAttachedToMeshObservable.add((mesh) => {
     if (!mesh) return;
 


### PR DESCRIPTION
# Summary
- Add a generic 'axis keyboard handler' which can be passed behaviours 
- Implement the movement behaviour using this handler, so that keyboard controls can be used to move objects

## Usage
With a mesh selected, select the move gizmo, then:

- Press X, Y, Z to fix axis, then right/left arrows move on selected axis
- Press X, Y, Z again to return to free movement

If no axis fixed:
- ArrowLeft/Right moves on X
- ArrowUp/Down moves on Z
- PageUp/Down moves on Y (mirrors flycam controls)

- Holding Shift moves by larger increments
- Enter / Space - confirms movement
- Escape - restores original mesh position

A message is displayed in the canvas: either X axis, Y axis, Z axis or free, depending on which movement mode you are in. 

### AI involvement
I drafted a plan for this implementation after research on Blender functionality/talking to Tracy. Claude Sonnet 4.6 provided the steps to implement my plan. All steps were implemented manually and code was checked so that I understood its function. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard-based axis-constrained movement control with X, Y, and Z axis toggling via dedicated keys.
  * Arrow keys enable directional movement; Shift accelerates input speed.
  * PageUp/PageDown supports vertical adjustment.
  * Enter/Space confirm changes; Escape cancels operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->