### PR TITLE
Add axis-colored outlines for X/Y/Z inputs in model blocks

### DIFF
--- a/blocks/blocks.js
+++ b/blocks/blocks.js
@@ -57,6 +57,36 @@ if (!fieldColourPrototype[flockFocusPatchKey]) {
   };
 }
 
+const getAxisInputClass = (field) => {
+  const svgRoot = field?.getSourceBlock?.()?.getSvgRoot?.();
+  if (!svgRoot?.classList) return null;
+  if (svgRoot.classList.contains("blocklyAxisInputX")) return "blocklyAxisInputX";
+  if (svgRoot.classList.contains("blocklyAxisInputY")) return "blocklyAxisInputY";
+  if (svgRoot.classList.contains("blocklyAxisInputZ")) return "blocklyAxisInputZ";
+  return null;
+};
+
+const flockNumberAxisPatchKey = Symbol.for("flock.fieldNumberAxisPatch");
+const fieldNumberPrototype = Blockly.FieldNumber?.prototype;
+if (fieldNumberPrototype && !fieldNumberPrototype[flockNumberAxisPatchKey]) {
+  const originalShowEditor = fieldNumberPrototype.showEditor_;
+  fieldNumberPrototype.showEditor_ = function (...args) {
+    originalShowEditor.call(this, ...args);
+
+    const widgetDiv = document.querySelector(".blocklyWidgetDiv");
+    if (!widgetDiv) return;
+
+    widgetDiv.classList.remove(
+      "blocklyAxisInputX",
+      "blocklyAxisInputY",
+      "blocklyAxisInputZ",
+    );
+
+    const axisInputClass = getAxisInputClass(this);
+    if (axisInputClass) widgetDiv.classList.add(axisInputClass);
+  };
+}
+
 export let nextVariableIndexes = Object.create(null);
 
 // ---------------------------------------------------------------------------

--- a/blocks/models.js
+++ b/blocks/models.js
@@ -219,6 +219,20 @@ export function defineModelBlocks() {
       this.setHelpUrl(getHelpUrlFor(this.type));
       this.setStyle("scene_blocks");
 
+      const applyAxisInputOutlineClasses = () => {
+        const axisClassMap = {
+          X: "blocklyAxisInputX",
+          Y: "blocklyAxisInputY",
+          Z: "blocklyAxisInputZ",
+        };
+
+        Object.entries(axisClassMap).forEach(([inputName, className]) => {
+          const targetBlock = this.getInput(inputName)?.connection?.targetBlock();
+          const svgRoot = targetBlock?.getSvgRoot?.();
+          if (svgRoot) svgRoot.classList.add(className);
+        });
+      };
+
       // Function to update the COLOR field based on the selected model
       const updateColorField = () => {
         const selectedObject = this.getFieldValue("MODELS");
@@ -234,6 +248,7 @@ export function defineModelBlocks() {
       };
 
       updateColorField();
+      applyAxisInputOutlineClasses();
 
       registerBlockHandler(this, (changeEvent) => {
         if (
@@ -246,6 +261,7 @@ export function defineModelBlocks() {
         }
 
         handleBlockChange(this, changeEvent, variableNamePrefix);
+        applyAxisInputOutlineClasses();
 
         if (
           this.id !== changeEvent.blockId &&

--- a/blocks/models.js
+++ b/blocks/models.js
@@ -225,11 +225,15 @@ export function defineModelBlocks() {
           Y: "blocklyAxisInputY",
           Z: "blocklyAxisInputZ",
         };
+        const axisClasses = Object.values(axisClassMap);
 
         Object.entries(axisClassMap).forEach(([inputName, className]) => {
           const targetBlock = this.getInput(inputName)?.connection?.targetBlock();
           const svgRoot = targetBlock?.getSvgRoot?.();
-          if (svgRoot) svgRoot.classList.add(className);
+          if (!svgRoot) return;
+
+          svgRoot.classList.remove(...axisClasses);
+          svgRoot.classList.add(className);
         });
       };
 

--- a/style/blockly.css
+++ b/style/blockly.css
@@ -9,6 +9,9 @@
   --color-shadow: grey;
   --color-outline-focus: #fc3;
   --block-outline-focus: #fff200;
+  --color-axis-x: #0072b2;
+  --color-axis-y: #009e73;
+  --color-axis-z: #d55e00;
 
   /* Dropdown & menu semantics */
   --color-dropdown-text: var(--color-text);
@@ -31,6 +34,9 @@
   --color-search-highlight: #ed808b;
   --color-shadow: grey;
   --color-outline-focus: #fc3;
+  --color-axis-x: #0072b2;
+  --color-axis-y: #009e73;
+  --color-axis-z: #d55e00;
 
   /* Dropdown & menu semantics */
   --color-dropdown-text: var(--color-text);
@@ -41,6 +47,24 @@
     --color-dropdown-menu-border,
     1px solid rgba(0, 0, 0, 0.1)
   );
+}
+
+g.blocklyAxisInputX .blocklyEditableText[style*="cursor: text"] > rect,
+g.blocklyAxisInputX .blocklyFieldRect {
+  stroke: var(--color-axis-x) !important;
+  stroke-width: 1px !important;
+}
+
+g.blocklyAxisInputY .blocklyEditableText[style*="cursor: text"] > rect,
+g.blocklyAxisInputY .blocklyFieldRect {
+  stroke: var(--color-axis-y) !important;
+  stroke-width: 1px !important;
+}
+
+g.blocklyAxisInputZ .blocklyEditableText[style*="cursor: text"] > rect,
+g.blocklyAxisInputZ .blocklyFieldRect {
+  stroke: var(--color-axis-z) !important;
+  stroke-width: 1px !important;
 }
 
 [data-theme="dark-contrast"] .blocklyInsertionMarker path {

--- a/style/blockly.css
+++ b/style/blockly.css
@@ -9,9 +9,9 @@
   --color-shadow: grey;
   --color-outline-focus: #fc3;
   --block-outline-focus: #fff200;
-  --color-axis-x: #0072b2;
-  --color-axis-y: #009e73;
-  --color-axis-z: #d55e00;
+  --color-axis-x: #ff4d4d;
+  --color-axis-y: #59c173;
+  --color-axis-z: #4d9dff;
 
   /* Dropdown & menu semantics */
   --color-dropdown-text: var(--color-text);
@@ -34,9 +34,9 @@
   --color-search-highlight: #ed808b;
   --color-shadow: grey;
   --color-outline-focus: #fc3;
-  --color-axis-x: #0072b2;
-  --color-axis-y: #009e73;
-  --color-axis-z: #d55e00;
+  --color-axis-x: #ff4d4d;
+  --color-axis-y: #59c173;
+  --color-axis-z: #4d9dff;
 
   /* Dropdown & menu semantics */
   --color-dropdown-text: var(--color-text);
@@ -49,22 +49,37 @@
   );
 }
 
-g.blocklyAxisInputX .blocklyEditableText[style*="cursor: text"] > rect,
+g.blocklyAxisInputX .blocklyEditableText > rect,
 g.blocklyAxisInputX .blocklyFieldRect {
   stroke: var(--color-axis-x) !important;
   stroke-width: 1px !important;
 }
 
-g.blocklyAxisInputY .blocklyEditableText[style*="cursor: text"] > rect,
+g.blocklyAxisInputY .blocklyEditableText > rect,
 g.blocklyAxisInputY .blocklyFieldRect {
   stroke: var(--color-axis-y) !important;
   stroke-width: 1px !important;
 }
 
-g.blocklyAxisInputZ .blocklyEditableText[style*="cursor: text"] > rect,
+g.blocklyAxisInputZ .blocklyEditableText > rect,
 g.blocklyAxisInputZ .blocklyFieldRect {
   stroke: var(--color-axis-z) !important;
   stroke-width: 1px !important;
+}
+
+.blocklyWidgetDiv.blocklyAxisInputX input.blocklyHtmlInput {
+  border-color: var(--color-axis-x) !important;
+  box-shadow: inset 0 0 0 1px var(--color-axis-x) !important;
+}
+
+.blocklyWidgetDiv.blocklyAxisInputY input.blocklyHtmlInput {
+  border-color: var(--color-axis-y) !important;
+  box-shadow: inset 0 0 0 1px var(--color-axis-y) !important;
+}
+
+.blocklyWidgetDiv.blocklyAxisInputZ input.blocklyHtmlInput {
+  border-color: var(--color-axis-z) !important;
+  box-shadow: inset 0 0 0 1px var(--color-axis-z) !important;
 }
 
 [data-theme="dark-contrast"] .blocklyInsertionMarker path {


### PR DESCRIPTION
### Motivation
- Improve visual clarity of numeric axis inputs on model-related blocks by giving X, Y and Z inputs distinct, axis-colored outlines so users can more easily identify axes.

### Description
- Add `applyAxisInputOutlineClasses` to `blocks/models.js` to attach SVG classes `blocklyAxisInputX`, `blocklyAxisInputY`, and `blocklyAxisInputZ` to the connected blocks for inputs named `X`, `Y`, and `Z`, and call it during init and on block change events.
- Add CSS variables `--color-axis-x`, `--color-axis-y`, and `--color-axis-z` in `style/blockly.css` (for default and `dark-contrast` themes) and style rules to stroke the input field rectangles and field rects using those variables.
- Keep existing color-update logic for the `COLOR` field intact and ensure axis classes are applied after initialization and on relevant events.

### Testing
- Ran the frontend linter with `yarn lint` and the unit test suite with `yarn test`, and both succeeded.
- No new automated tests were added for the visual change; existing tests passed without regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e22996a4dc8326bfcb7bbd25334c94)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added color-coded visual styling for axis-related inputs (X, Y, Z) to enhance visual distinction in the block editor.
  * Implemented automatic styling updates to ensure axis inputs maintain proper visual appearance during block interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->