### PR TITLE
Guard menu wiring when standalone DOM elements are absent

### DIFF
--- a/main/menu.js
+++ b/main/menu.js
@@ -24,6 +24,9 @@ function canRestoreFocus(element) {
 }
 
 function openInfoModal() {
+  if (!infoModal || !closeInfoModal) {
+    return;
+  }
   previouslyFocused = document.activeElement;
   infoModal.classList.remove("hidden");
   infoModal.setAttribute("aria-hidden", "false");
@@ -35,13 +38,16 @@ function openInfoModal() {
 }
 
 function hideInfoModal() {
+  if (!infoModal) {
+    return;
+  }
   infoModal.classList.add("hidden");
   infoModal.setAttribute("aria-hidden", "true");
   infoModal.removeAttribute("aria-modal");
 
   if (canRestoreFocus(previouslyFocused)) {
     previouslyFocused.focus();
-  } else {
+  } else if (menuBtn) {
     menuBtn.focus();
   }
 
@@ -52,11 +58,16 @@ class AccessibleFlyoutMenu {
   constructor() {
     this.menuButton = document.getElementById("menuBtn");
     this.menuDropdown = document.getElementById("menuDropdown");
-    this.menuItems = this.menuDropdown.querySelectorAll(".menu-item");
+    this.menuItems = [];
     this.isMenuOpen = false;
     this.currentFocus = -1;
     this.currentOpenSubmenu = null;
 
+    if (!this.menuButton || !this.menuDropdown) {
+      return;
+    }
+
+    this.menuItems = this.menuDropdown.querySelectorAll(".menu-item");
     this.init();
   }
 
@@ -147,7 +158,7 @@ class AccessibleFlyoutMenu {
 
         let handled = false;
 
-        if (!infoModal.classList.contains("hidden")) {
+        if (infoModal && !infoModal.classList.contains("hidden")) {
           hideInfoModal();
           handled = true;
         }
@@ -202,6 +213,9 @@ class AccessibleFlyoutMenu {
   }
 
   focusFirstMenuItem() {
+    if (this.menuItems.length === 0) {
+      return;
+    }
     this.currentFocus = 0;
     this.menuItems[0].focus();
   }
@@ -369,56 +383,67 @@ class AccessibleFlyoutMenu {
 // Initialize the menu when DOM is loaded
 let menuFlyout;
 document.addEventListener("DOMContentLoaded", () => {
+  if (!menuBtn || !document.getElementById("menuDropdown")) {
+    return;
+  }
   menuFlyout = new AccessibleFlyoutMenu();
 });
 
-hubMenuItem.addEventListener("click", (e) => {
-  e.preventDefault();
-  menuFlyout?.closeAllMenus();
-  menuBtn.focus();
-  window.open("https://hub.flockxr.com/", "_blank", "noopener,noreferrer");
-});
+if (hubMenuItem) {
+  hubMenuItem.addEventListener("click", (e) => {
+    e.preventDefault();
+    menuFlyout?.closeAllMenus();
+    menuBtn?.focus();
+    window.open("https://hub.flockxr.com/", "_blank", "noopener,noreferrer");
+  });
+}
 
 // Language menu interactions are now handled in main/translation.js
 
 // Open modal when About is clicked
-openAbout.addEventListener("click", (e) => {
-  e.preventDefault();
-  menuFlyout?.closeAllMenus();
-  openInfoModal();
-});
+if (openAbout) {
+  openAbout.addEventListener("click", (e) => {
+    e.preventDefault();
+    menuFlyout?.closeAllMenus();
+    openInfoModal();
+  });
+}
 
 // Close modal on close button
-closeInfoModal.addEventListener("click", () => {
-  hideInfoModal();
-});
+if (closeInfoModal) {
+  closeInfoModal.addEventListener("click", () => {
+    hideInfoModal();
+  });
+}
 
 // Handle keyboard events for modal
-infoModal.addEventListener("keydown", (e) => {
-  if (e.key === "Escape") {
-    e.preventDefault();
-    e.stopPropagation();
-    hideInfoModal();
-  } else if (e.key === "Tab") {
-    // Trap focus within modal
-    const focusableElements = infoModal.querySelectorAll(
-      'button, input, select, textarea, [href], [tabindex]:not([tabindex="-1"])',
-    );
-    const firstElement = focusableElements[0];
-    const lastElement = focusableElements[focusableElements.length - 1];
+if (infoModal) {
+  infoModal.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      e.stopPropagation();
+      hideInfoModal();
+    } else if (e.key === "Tab") {
+      // Trap focus within modal
+      const focusableElements = infoModal.querySelectorAll(
+        'button, input, select, textarea, [href], [tabindex]:not([tabindex="-1"])',
+      );
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
 
-    if (e.shiftKey && document.activeElement === firstElement) {
-      e.preventDefault();
-      lastElement.focus();
-    } else if (!e.shiftKey && document.activeElement === lastElement) {
-      e.preventDefault();
-      firstElement.focus();
+      if (e.shiftKey && document.activeElement === firstElement) {
+        e.preventDefault();
+        lastElement.focus();
+      } else if (!e.shiftKey && document.activeElement === lastElement) {
+        e.preventDefault();
+        firstElement.focus();
+      }
     }
-  }
-});
+  });
 
-window.addEventListener("click", (e) => {
-  if (e.target === infoModal) {
-    hideInfoModal();
-  }
-});
+  window.addEventListener("click", (e) => {
+    if (e.target === infoModal) {
+      hideInfoModal();
+    }
+  });
+}


### PR DESCRIPTION
### Motivation
- The editor runtime can be imported by standalone pages, which caused unguarded menu code to throw `null` property errors when editor DOM nodes (menu, modal) are missing.  
- Prevent startup crashes in reduced/standalone DOMs (e.g. `cubeart.html`) by making menu and modal wiring defensive.  
- Keep full-editor behavior unchanged when the expected DOM is present.

### Description
- Added early-return guards to modal helpers (`openInfoModal`, `hideInfoModal`) so they no-op if `infoModal`/`closeInfoModal` are not present and only restore focus to `menuBtn` when it exists.  
- Hardened `AccessibleFlyoutMenu` constructor to bail out if `menuBtn` or `menuDropdown` are missing and defer calling `querySelectorAll`/`init` until elements exist.  
- Wrapped top-level listener registrations (e.g. `hub-menu-item`, `about-menu-item`, modal key/click handlers) and the `DOMContentLoaded` menu initialization in element-existence checks so the shared runtime can safely run in standalone pages.

### Testing
- Ran a production build with `npm run build`, which completed successfully and emitted the updated bundle.  
- No automated test suites were modified; only the build step was executed as a verification of the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3242da3888326aa4a5a92b9c6fc0d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced stability of menu and modal interactions with improved defensive error handling
* Fixed potential crashes caused by null reference errors in menu initialization and focus operations
* Better handling of missing or unavailable user interface elements throughout the application
* Improved robustness of focus management and restoration during menu interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->