### PR TITLE
Guard editor initialization when #blocklyDiv is missing and verify workspace creation

### DIFF
--- a/main/main.js
+++ b/main/main.js
@@ -408,6 +408,21 @@ function initializeApp() {
 }
 
 window.onload = async function () {
+  const blocklyContainer = document.getElementById("blocklyDiv");
+  if (!blocklyContainer) {
+    const standaloneScript = document.getElementById("flock");
+    if (standaloneScript) {
+      console.log(
+        "Skipping editor initialization: standalone script detected without #blocklyDiv.",
+      );
+    } else {
+      console.warn(
+        "Skipping editor initialization: missing required #blocklyDiv container.",
+      );
+    }
+    return;
+  }
+
   // Resize Blockly workspace and Babylon.js canvas when the window is resized
   window.addEventListener("resize", onResize);
 
@@ -417,6 +432,10 @@ window.onload = async function () {
   addExportContextMenuOptions();
 
   createBlocklyWorkspace();
+  if (!workspace) {
+    console.error("Blockly workspace failed to initialize; aborting editor setup.");
+    return;
+  }
   registerBlocklyPlayShortcut();
   initializeWorkspace();
   overrideSearchPlugin(workspace);


### PR DESCRIPTION
### Motivation

- Prevent runtime errors when the editor initializes in contexts that don't include the Blockly container and provide clearer diagnostic logs for standalone script embeds.

### Description

- Added a check in `window.onload` for the presence of `#blocklyDiv` and an early return if it's missing, with a distinct console message when a `#flock` standalone script is detected via `document.getElementById('flock')`.
- Added a post-`createBlocklyWorkspace()` guard that logs an error and aborts initialization when the `workspace` failed to initialize.
- Preserved existing initialization flow for resize handling, language setup, autosave, and Flock initialization while preventing further setup when prerequisites are absent.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e48e403658832695766ec06092a2b5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added startup validation to detect missing or failed initialization of required components, preventing cascading errors and improving diagnostic logging when prerequisites are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->