### PR TITLE
Move gizmo: keyboard controls

### DIFF
--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -958,6 +958,10 @@ function handleRotationGizmo() {
 function handlePositionGizmo() {
   configurePositionGizmo(gizmoManager);
 
+  // Highlight the move button
+  const positionButton = document.getElementById("positionButton");
+  positionButton.classList.add("active");
+
   const mesh = gizmoManager.attachedMesh;
   if (mesh) {
     const original = mesh.position.clone();
@@ -967,18 +971,29 @@ function handlePositionGizmo() {
           mesh.position.x += dx;
           mesh.position.y += dy;
           mesh.position.z += dz;
-        },
-        onConfirm: () => {
+          // Update the blockly block
           mesh.computeWorldMatrix(true);
           const block = meshMap[mesh?.metadata?.blockKey];
           if (block) {
             const pos = flock.getBlockPositionFromMesh(mesh);
             setBlockXYZ(block, pos.x, pos.y, pos.z);
           }
+        },
+        onConfirm: () => {
+          positionButton.classList.remove("active");
           disableGizmos();
         },
         onCancel: () => {
+          positionButton.classList.remove("active");
+          // Replace mesh
           mesh.position.copyFrom(original);
+          // Replace blockly block
+          mesh.computeWorldMatrix(true);
+          const block = meshMap[mesh?.metadata?.blockKey];
+          if (block) {
+            const pos = flock.getBlockPositionFromMesh(mesh);
+            setBlockXYZ(block, pos.x, pos.y, pos.z);
+          }
           disableGizmos();
         },
         stepNormal: 0.1,

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -34,6 +34,9 @@ const blueColor = flock.BABYLON.Color3.FromHexString("#0072B2"); // Colour for X
 const greenColor = flock.BABYLON.Color3.FromHexString("#009E73"); // Colour for Y-axis
 const orangeColor = flock.BABYLON.Color3.FromHexString("#D55E00"); // Colour for Z-axis
 
+const FAST_CURSOR = 1; // Step for moving KB cursor quickly
+const DEFAULT_CURSOR = 0.1; // Step for moving KB cursor slowly (default)
+
 window.selectedColor = "#ffffff"; // Default color
 let colorPicker = null;
 
@@ -44,6 +47,7 @@ let textOrigScaleZ = 1;
 let cameraMode = "play";
 let activeDuplicatePickHandler = null; // Are they in the middle of a duplication?
 let stopAxisKeyboard = null; // Are they transforming?
+let positionGizmoObserver = null; // Are they in [move mesh] state?
 
 // Track DO sections and their associated blocks for cleanup
 const gizmoCreatedBlocks = new Map(); // blockId -> { parentId, createdDoSection, timestamp }
@@ -493,6 +497,52 @@ function getScaledSize(mesh) {
     y: baseY * Math.abs(mesh.scaling.y),
     z: baseZ * Math.abs(mesh.scaling.z),
   };
+}
+
+// Clean up gizmo state if aborted
+function exitGizmoState() {
+  // Stop the axis keyboard
+  stopAxisKeyboard?.();
+  stopAxisKeyboard = null;
+  // Remove position observer
+  if (positionGizmoObserver) {
+    gizmoManager.onAttachedToMeshObservable.remove(positionGizmoObserver);
+    positionGizmoObserver = null;
+  }
+  // Remove active class from all buttons
+  document
+    .querySelectorAll(".gizmo-button")
+    .forEach((btn) => btn.classList.remove("active"));
+  disableGizmos();
+  document.body.style.cursor = "default";
+}
+
+// Start the keyboard handler for moving a mesh
+function startMoveKeyboardHandler(mesh) {
+  stopAxisKeyboard?.();
+  stopAxisKeyboard = null;
+  setTimeout(() => {
+    stopAxisKeyboard = createAxisKeyboardHandler({
+      onMove: (dx, dy, dz) => {
+        mesh.position.x += dx;
+        mesh.position.y += dy;
+        mesh.position.z += dz;
+        mesh.computeWorldMatrix(true);
+        const block = meshMap[mesh?.metadata?.blockKey];
+        if (block) {
+          const pos = flock.getBlockPositionFromMesh(mesh);
+          setBlockXYZ(block, pos.x, pos.y, pos.z);
+        }
+      },
+      onConfirm: () => {
+        exitGizmoState();
+        document.getElementById("positionButton")?.focus();
+      },
+      onCancel: () => exitGizmoState(),
+      stepNormal: DEFAULT_CURSOR,
+      stepFast: FAST_CURSOR,
+    });
+  }, 0);
 }
 
 export function disableGizmos() {
@@ -964,53 +1014,30 @@ function handlePositionGizmo() {
 
   const mesh = gizmoManager.attachedMesh;
   if (mesh) {
-    const original = mesh.position.clone();
-    setTimeout(() => {
-      stopAxisKeyboard = createAxisKeyboardHandler({
-        onMove: (dx, dy, dz) => {
-          mesh.position.x += dx;
-          mesh.position.y += dy;
-          mesh.position.z += dz;
-          // Update the blockly block
-          mesh.computeWorldMatrix(true);
-          const block = meshMap[mesh?.metadata?.blockKey];
-          if (block) {
-            const pos = flock.getBlockPositionFromMesh(mesh);
-            setBlockXYZ(block, pos.x, pos.y, pos.z);
-          }
-        },
-        onConfirm: () => {
-          positionButton.classList.remove("active");
-          disableGizmos();
-        },
-        onCancel: () => {
-          positionButton.classList.remove("active");
-          // Replace mesh
-          mesh.position.copyFrom(original);
-          // Replace blockly block
-          mesh.computeWorldMatrix(true);
-          const block = meshMap[mesh?.metadata?.blockKey];
-          if (block) {
-            const pos = flock.getBlockPositionFromMesh(mesh);
-            setBlockXYZ(block, pos.x, pos.y, pos.z);
-          }
-          disableGizmos();
-        },
-        stepNormal: 0.1,
-        stepFast: 1,
-      });
-    }, 0);
+    startMoveKeyboardHandler(mesh);
   }
 
-  gizmoManager.onAttachedToMeshObservable.add((mesh) => {
-    if (!mesh) return;
+  // Don't attach to multiple meshes
+  if (positionGizmoObserver) {
+    gizmoManager.onAttachedToMeshObservable.remove(positionGizmoObserver);
+  }
 
-    const blockKey = mesh?.metadata?.blockKey;
-    const blockId = blockKey ? meshMap[blockKey] : null;
-    if (!blockId) return;
+  positionGizmoObserver = gizmoManager.onAttachedToMeshObservable.add(
+    (mesh) => {
+      if (!mesh) {
+        exitGizmoState();
+        return;
+      }
 
-    highlightBlockById(Blockly.getMainWorkspace(), blockId);
-  });
+      startMoveKeyboardHandler(mesh); // Reattach
+
+      const blockKey = mesh?.metadata?.blockKey;
+      const blockId = blockKey ? meshMap[blockKey] : null;
+      if (!blockId) return;
+
+      highlightBlockById(Blockly.getMainWorkspace(), blockId);
+    },
+  );
 
   gizmoManager.gizmos.positionGizmo.onDragStartObservable.add(() => {
     const mesh = gizmoManager.attachedMesh;

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -28,7 +28,11 @@ import {
   stopCanvasKeyboardMode,
 } from "./canvas-utils.js";
 import { createAxisKeyboardHandler } from "./axis-keyboard.js";
+import { cleanup } from "manifold-3d/lib/animation.js";
 export let gizmoManager;
+
+// Enable debug messages
+const DEBUG = true;
 
 const blueColor = flock.BABYLON.Color3.FromHexString("#0072B2"); // Colour for X-axis
 const greenColor = flock.BABYLON.Color3.FromHexString("#009E73"); // Colour for Y-axis
@@ -44,10 +48,12 @@ let colorPicker = null;
 let textScaleAxis = null;
 let textOrigScaleZ = 1;
 
+// Track state
 let cameraMode = "play";
-let activeDuplicatePickHandler = null; // Are they in the middle of a duplication?
-let stopAxisKeyboard = null; // Are they transforming?
-let positionGizmoObserver = null; // Are they in [move mesh] state?
+let activePick = null; // [Select mesh?]
+let activeDuplicatePickHandler = null; // [Clone mesh?]
+let stopAxisKeyboard = null; // Axis keyboard active?
+let positionGizmoObserver = null; // [Move mesh?]
 
 // Track DO sections and their associated blocks for cleanup
 const gizmoCreatedBlocks = new Map(); // blockId -> { parentId, createdDoSection, timestamp }
@@ -501,6 +507,7 @@ function getScaledSize(mesh) {
 
 // Clean up gizmo state if aborted
 function exitGizmoState() {
+  cleanupScenePick(); // Stop picking
   // Stop the axis keyboard
   stopAxisKeyboard?.();
   stopAxisKeyboard = null;
@@ -553,13 +560,25 @@ function startMoveKeyboardHandler(mesh) {
 
 // Pick a mesh (used by multiple gizmos)
 function pickMeshFromScene(onPicked) {
+  cleanupScenePick(); // Stop picking
   resetAttachedMesh();
+
+  const pointerObservable = flock.scene.onPointerObservable;
+  const pointerObserver = pointerObservable.add((event) => {
+    if (event.type === flock.BABYLON.PointerEventTypes.POINTERPICK) {
+      cleanupScenePick();
+      onPicked(event.pickInfo.pickedMesh, event.pickInfo.pickedPoint);
+    }
+  });
+
+  activePick = { pointerObservable, pointerObserver };
+
   setTimeout(() => {
     startCanvasKeyboardMode(
       (x, y) => {
         const pick = flock.scene.pick(x, y);
+        cleanupScenePick();
         onPicked(pick?.pickedMesh, pick?.pickedPoint);
-        stopCanvasKeyboardMode();
       },
       false,
       (x, y) =>
@@ -568,14 +587,16 @@ function pickMeshFromScene(onPicked) {
     );
     document.body.style.cursor = "crosshair";
   }, 0);
+}
 
-  const pointerObservable = flock.scene.onPointerObservable;
-  const pointerObserver = pointerObservable.add((event) => {
-    if (event.type === flock.BABYLON.PointerEventTypes.POINTERPICK) {
-      onPicked(event.pickInfo.pickedMesh, event.pickInfo.pickedPoint);
-      pointerObservable.remove(pointerObserver);
-    }
-  });
+// Clean up after picking
+function cleanupScenePick() {
+  if (activePick) {
+    activePick.pointerObservable.remove(activePick.pointerObserver);
+    activePick = null;
+  }
+  stopCanvasKeyboardMode();
+  document.body.style.cursor = "default";
 }
 
 export function disableGizmos() {
@@ -1707,3 +1728,6 @@ export function configureScaleGizmo(
 // Export functions for global access
 window.toggleGizmo = toggleGizmo;
 window.turnOffAllGizmos = turnOffAllGizmos;
+if (DEBUG) {
+  window._debugPick = () => flock.scene.onPointerObservable._observers.length;
+}

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -508,6 +508,13 @@ function getScaledSize(mesh) {
 // Clean up gizmo state if aborted
 function exitGizmoState() {
   cleanupScenePick(); // Stop picking
+
+  // Properly clean up if duplicating
+  if (activeDuplicatePickHandler) {
+    window.removeEventListener("click", activeDuplicatePickHandler);
+    activeDuplicatePickHandler = null;
+  }
+
   // Stop the axis keyboard
   stopAxisKeyboard?.();
   stopAxisKeyboard = null;
@@ -624,10 +631,9 @@ export function toggleGizmo(gizmoType) {
     .forEach((btn) => btn.classList.remove("active"));
 
   // If they abandoned a duplicate half way, remove listener
-  if (activeDuplicatePickHandler) {
-    window.removeEventListener("click", activeDuplicatePickHandler);
-    activeDuplicatePickHandler = null;
-    if (gizmoType === "duplicate") return;
+  if (gizmoType === "duplicate" && activeDuplicatePickHandler) {
+    exitGizmoState();
+    return;
   }
 
   // If they were mid-transform, clean up

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -519,6 +519,7 @@ function exitGizmoState() {
 
 // Start the keyboard handler for moving a mesh
 function startMoveKeyboardHandler(mesh) {
+  document.body.style.cursor = "default";
   stopAxisKeyboard?.();
   stopAxisKeyboard = null;
   setTimeout(() => {
@@ -538,11 +539,43 @@ function startMoveKeyboardHandler(mesh) {
         exitGizmoState();
         document.getElementById("positionButton")?.focus();
       },
-      onCancel: () => exitGizmoState(),
+      onCancel: () => {
+        exitGizmoState();
+        // Deselect so you get [select mesh] for next tool
+        gizmoManager.attachToMesh(null);
+        document.getElementById("positionButton")?.focus();
+      },
       stepNormal: DEFAULT_CURSOR,
       stepFast: FAST_CURSOR,
     });
   }, 0);
+}
+
+// Pick a mesh (used by multiple gizmos)
+function pickMeshFromScene(onPicked) {
+  resetAttachedMesh();
+  setTimeout(() => {
+    startCanvasKeyboardMode(
+      (x, y) => {
+        const pick = flock.scene.pick(x, y);
+        onPicked(pick?.pickedMesh, pick?.pickedPoint);
+        stopCanvasKeyboardMode();
+      },
+      false,
+      (x, y) =>
+        !!flock.scene.pick(x, y, (m) => m.isPickable && m.name !== "ground")
+          ?.hit,
+    );
+    document.body.style.cursor = "crosshair";
+  }, 0);
+
+  const pointerObservable = flock.scene.onPointerObservable;
+  const pointerObserver = pointerObservable.add((event) => {
+    if (event.type === flock.BABYLON.PointerEventTypes.POINTERPICK) {
+      onPicked(event.pickInfo.pickedMesh, event.pickInfo.pickedPoint);
+      pointerObservable.remove(pointerObserver);
+    }
+  });
 }
 
 export function disableGizmos() {
@@ -557,6 +590,13 @@ export function disableGizmos() {
 
 // Toggle which Gizmo is being used
 export function toggleGizmo(gizmoType) {
+  // Is this gizmo already active? If so, toggle it off
+  const button = document.getElementById(`${gizmoType}Button`);
+  if (button?.classList.contains("active")) {
+    exitGizmoState();
+    return;
+  }
+
   // No buttons should be highlighted
   document
     .querySelectorAll(".gizmo-button")
@@ -1015,6 +1055,12 @@ function handlePositionGizmo() {
   const mesh = gizmoManager.attachedMesh;
   if (mesh) {
     startMoveKeyboardHandler(mesh);
+  } else {
+    pickMeshFromScene((pickedMesh) => {
+      if (!pickedMesh || pickedMesh.name === "ground") return;
+      if (pickedMesh.parent) pickedMesh = getRootMesh(pickedMesh.parent);
+      gizmoManager.attachToMesh(pickedMesh);
+    });
   }
 
   // Don't attach to multiple meshes
@@ -1118,7 +1164,6 @@ function handleBoundsGizmo() {
 
 // Select: Allow the user to select a mesh by clicking on it
 function handleSelectGizmo() {
-  let blockKey;
   gizmoManager.selectGizmoEnabled = true;
 
   function applySelection(pickedMesh, pickedPoint) {
@@ -1163,44 +1208,8 @@ function handleSelectGizmo() {
     }
   }
 
-  // Wait until the click has propagated otherwise
-  // the keyboard mode gets cancelled immediately
-  setTimeout(() => {
-    startCanvasKeyboardMode(
-      (x, y) => {
-        if (gizmoManager.attachedMesh) {
-          resetAttachedMesh();
-          blockKey = findParentWithBlockId(gizmoManager.attachedMesh)?.metadata
-            ?.blockKey;
-        }
-        const pick = flock.scene.pick(x, y);
-        applySelection(pick?.pickedMesh, pick?.pickedPoint);
-        stopCanvasKeyboardMode();
-      },
-      false,
-      (x, y) =>
-        !!flock.scene.pick(x, y, (m) => m.isPickable && m.name !== "ground")
-          ?.hit,
-    );
-  }, 0);
-
-  // Store the pointer observable
-  const pointerObservable = flock.scene.onPointerObservable;
-
-  // Add the observer
-  const pointerObserver = pointerObservable.add((event) => {
-    if (event.type === flock.BABYLON.PointerEventTypes.POINTERPICK) {
-      if (gizmoManager.attachedMesh) {
-        resetAttachedMesh();
-        blockKey = findParentWithBlockId(gizmoManager.attachedMesh)?.metadata
-          ?.blockKey;
-      }
-
-      applySelection(event.pickInfo.pickedMesh, event.pickInfo.pickedPoint);
-
-      pointerObservable.remove(pointerObserver);
-    }
-  });
+  // Use helper function to pick the mesh
+  pickMeshFromScene(applySelection);
 }
 
 // Duplicate: Create a copy of the selected mesh and its corresponding block,


### PR DESCRIPTION
# Summary
Add keyboard controls for move gizmo 

When the move gizmo is selected:
- If there is no current selection, allow mouse/keyboard cursor selection, otherwise use current selection
- Move the object using axis controls
    Arrow keys plus page up/page down
    X, Y or Z to fix on an axis, then use arrow keys to move only on that axis
- Press Enter to confirm the move - **keeps current selection**
- Press Esc to escape move mode - **removes current selection** 
- Blockly block properly updates values on move

### Known issues
- If you select a mesh, move it, then **click on another mesh**, move handles still display on that mesh. Moving the mesh using the cursor works fine but using the arrow keys to move the mesh also moves the camera. You can't get into this situation using keyboard controls only. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Refactor**
  * Improved gizmo interaction workflow with more reliable state management
  * Enhanced keyboard and mouse control integration for position and selection gizmos
  * Fixed inconsistent behavior when toggling between different gizmos
  * Better cleanup and cursor handling during gizmo interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->