### PR TITLE
Refactor block cleanup: extract layout routine and add variable pruning

### DIFF
--- a/main/blockhandling.js
+++ b/main/blockhandling.js
@@ -240,11 +240,20 @@ export function initializeBlockHandling() {
   function pruneUnusedVariables() {
     const usedModels = Blockly.Variables.allUsedVarModels(workspace);
     const usedIds = new Set(usedModels.map((model) => model.getId()));
-    const allModels = workspace.getVariableMap().getAllVariables();
-    for (const model of allModels) {
-      if (!usedIds.has(model.getId())) {
-        workspace.deleteVariableById(model.getId());
+    const allVariableIds = workspace
+      .getVariableMap()
+      .getAllVariables()
+      .map((model) => model.getId());
+    const unusedVariableIds = allVariableIds.filter((id) => !usedIds.has(id));
+    if (!unusedVariableIds.length) return;
+
+    Blockly.Events.setGroup(true);
+    try {
+      for (const id of unusedVariableIds) {
+        workspace.deleteVariableById(id);
       }
+    } finally {
+      Blockly.Events.setGroup(false);
     }
   }
 

--- a/main/blockhandling.js
+++ b/main/blockhandling.js
@@ -138,8 +138,7 @@ export function initializeBlockHandling() {
     "microbit_input",
   ];
 
-  // Preserve selection/cursor focus while tidying.
-  workspace.cleanUp = function () {
+  function layoutTopLevelBlocks() {
     const spacing = 40;
     const cursorX = 10;
     let cursorY = 10;
@@ -236,6 +235,24 @@ export function initializeBlockHandling() {
         }
       }
     }
+  }
+
+  function pruneUnusedVariables() {
+    const usedModels = Blockly.Variables.allUsedVarModels(workspace);
+    const usedIds = new Set(usedModels.map((model) => model.getId()));
+    const allModels = workspace.getVariableMap().getAllVariables();
+    for (const model of allModels) {
+      if (!usedIds.has(model.getId())) {
+        workspace.deleteVariableById(model.getId());
+      }
+    }
+  }
+
+  // Preserve selection/cursor focus while tidying.
+  // This is invoked by explicit "Clean up blocks" actions.
+  workspace.cleanUp = function () {
+    layoutTopLevelBlocks();
+    pruneUnusedVariables();
   };
 
   workspace.addChangeListener(Blockly.Events.disableOrphans);
@@ -481,7 +498,7 @@ export function initializeBlockHandling() {
         const wasEnabled = Blockly.Events.isEnabled();
         try {
           if (wasEnabled) Blockly.Events.disable(); // don't create undo entries
-          workspace.cleanUp();
+          layoutTopLevelBlocks();
         } finally {
           if (wasEnabled) Blockly.Events.enable();
         }
@@ -496,7 +513,7 @@ export function initializeBlockHandling() {
     ) {
       const block = workspace.getBlockById(event.blockId);
       if (block && !block.getParent()) {
-        workspace.cleanUp();
+        layoutTopLevelBlocks();
       }
     }
 

--- a/main/files.js
+++ b/main/files.js
@@ -1,6 +1,5 @@
 import * as Blockly from "blockly";
 import { workspace } from "./blocklyinit.js";
-import { flock } from "../flock.js";
 import { translate } from "./translation.js";
 import { getMetadata } from "meta-png";
 import { AUTOSAVE_KEY } from "../config.js";
@@ -8,15 +7,6 @@ import { blockHandlerRegistry } from "../blocks/blocks.js";
 
 // Function to save the current workspace state
 export function saveWorkspace(workspace) {
-  if (workspace && workspace.getAllBlocks) {
-    const usedModels = Blockly.Variables.allUsedVarModels(workspace);
-    const allModels = workspace.getVariableMap().getAllVariables();
-    for (const model of allModels) {
-      if (!usedModels.find((element) => element.getId() === model.getId())) {
-        workspace.deleteVariableById(model.getId());
-      }
-    }
-  }
   const state = Blockly.serialization.workspaces.save(workspace);
   const key = AUTOSAVE_KEY;
   localStorage.setItem(key, JSON.stringify(state));


### PR DESCRIPTION
### Motivation
- Centralize and clarify the block cleanup behavior by separating layout and variable pruning responsibilities into distinct routines.
- Preserve focus/selection and reduce side-effects while laying out top-level blocks during tidy operations.
- Avoid deleting unused variables during autosave and instead perform explicit pruning during explicit cleanup actions.

### Description
- Extracted the layout logic into a new `layoutTopLevelBlocks()` function and preserved the previous focus/selection restoration and event grouping behavior inside it.
- Added a new `pruneUnusedVariables()` function that uses `Blockly.Variables.allUsedVarModels(workspace)` to remove unused variable models via `workspace.deleteVariableById()`.
- Implemented `workspace.cleanUp = function () { layoutTopLevelBlocks(); pruneUnusedVariables(); }` and updated debounced and collapse-triggered cleanup to call `layoutTopLevelBlocks()` directly so pruning only happens on explicit cleanup.
- Removed an unused `flock` import from `main/files.js` and removed the previous variable-pruning code from `saveWorkspace()` so autosave no longer deletes variables.

### Testing
- Ran unit tests with `npm test`, which completed successfully.
- Ran linting with `npm run lint`, which completed successfully.
- Built the project with `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e795e37ec48326bd81f4a6776d4e90)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace cleanup now both reorganizes blocks and removes unused variables when run explicitly.

* **Improvements**
  * Automatic/delayed block reorganization (e.g., after moves, creates, deletes, or collapse/expand) no longer deletes variables.
  * Saving the workspace no longer removes variables as a side effect.

* **Bug Fixes**
  * Fixed unintended variable deletion during save and automatic cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->