### PR TITLE
Use anchor/base semantics for getProperty POSITION_* on meshes

### DIFF
--- a/API.md
+++ b/API.md
@@ -570,6 +570,11 @@ whenActionEvent("BUTTON1", async () => {
 
 Gets a property value from a mesh.
 
+Position properties use these coordinate semantics:
+
+- For meshes, `POSITION_X`, `POSITION_Y`, and `POSITION_Z` report the mesh anchor/base position (Y defaults to the mesh base/min Y), not raw absolute origin.
+- For `__active_camera__` and `__main_light__`, position properties report absolute world position.
+
 ### Events and Control Flow
 
 #### `forever(callback)`

--- a/api/sensing.js
+++ b/api/sensing.js
@@ -22,11 +22,42 @@ export const flockSensing = {
     // Ensure world transforms are current.
     mesh.computeWorldMatrix(true);
 
-    // Use a consistent world position call (works for meshes and cameras).
-    const position =
+    // Use a consistent world position call (works for meshes, lights, and cameras).
+    const absolutePosition =
       typeof mesh.getAbsolutePosition === "function"
         ? mesh.getAbsolutePosition()
         : (mesh.globalPosition ?? mesh.position);
+
+    const usesAbsolutePosition =
+      modelName === "__active_camera__" || modelName === "__main_light__";
+
+    const hasNumericXYZ = (value) =>
+      value &&
+      Number.isFinite(value.x) &&
+      Number.isFinite(value.y) &&
+      Number.isFinite(value.z);
+
+    const position = (() => {
+      if (usesAbsolutePosition) {
+        return absolutePosition;
+      }
+
+      const anchor =
+        typeof flock._getAnchor === "function" ? flock._getAnchor(mesh) : null;
+      if (hasNumericXYZ(anchor)) {
+        return anchor;
+      }
+
+      const blockPosition =
+        typeof flock.getBlockPositionFromMesh === "function"
+          ? flock.getBlockPositionFromMesh(mesh)
+          : null;
+      if (hasNumericXYZ(blockPosition)) {
+        return blockPosition;
+      }
+
+      return absolutePosition;
+    })();
 
     // Robust rotation: prefer quaternion if present, else fall back to Euler.
     const rotEuler = mesh.absoluteRotationQuaternion

--- a/tests/characterAnimations.test.js
+++ b/tests/characterAnimations.test.js
@@ -232,5 +232,33 @@ export function runCharacterAnimationTests(flock) {
       expect(info?.name).to.equal("Jump");
       expect(jumpGroup.isPlaying).to.equal(false);
     });
+
+    it("keeps mesh POSITION_Y on the anchor/base during physics glide and animation switches", async function () {
+      const meshId = animationMeshIds[0];
+
+      await flock.setPhysics(meshId, "DYNAMIC");
+
+      await pumpAnimation(
+        flock,
+        flock.switchAnimation(meshId, {
+          animationName: "Walk",
+          loop: true,
+          restart: true,
+        }),
+        "Walk",
+      );
+
+      await pumpAnimation(
+        flock,
+        flock.glideTo(meshId, {
+          x: 2,
+          y: 0,
+          z: 1,
+          duration: 0.2,
+        }),
+      );
+
+      expect(flock.getProperty(meshId, "POSITION_Y")).to.equal(0);
+    });
   });
 }

--- a/tests/getProperty.test.js
+++ b/tests/getProperty.test.js
@@ -79,7 +79,7 @@ export function runGetPropertyTests(flock) {
       expect(result).to.be.null;
     });
 
-    it("reads position values from a mesh", function () {
+    it("reads position values from mesh anchor/base coordinates", function () {
       const meshId = flock.createBox("getProperty-position", {
         width: 2,
         height: 4,
@@ -89,7 +89,7 @@ export function runGetPropertyTests(flock) {
       createdIds.push(meshId);
 
       const mesh = flock.scene.getMeshByName(meshId);
-      const position = mesh.getAbsolutePosition();
+      const position = flock._getAnchor(mesh);
 
       expect(flock.getProperty(meshId, "POSITION_X")).to.equal(
         toFixedNumber(position.x),
@@ -100,6 +100,35 @@ export function runGetPropertyTests(flock) {
       expect(flock.getProperty(meshId, "POSITION_Z")).to.equal(
         toFixedNumber(position.z),
       );
+    });
+
+    it("falls back to getBlockPositionFromMesh when anchor data is unavailable", function () {
+      const meshId = flock.createBox("getProperty-position-fallback", {
+        width: 2,
+        height: 4,
+        depth: 2,
+        position: [4, 3, -2],
+      });
+      createdIds.push(meshId);
+
+      const mesh = flock.scene.getMeshByName(meshId);
+      const expected = flock.getBlockPositionFromMesh(mesh);
+      const originalGetAnchor = flock._getAnchor;
+
+      flock._getAnchor = () => null;
+      try {
+        expect(flock.getProperty(meshId, "POSITION_X")).to.equal(
+          toFixedNumber(expected.x),
+        );
+        expect(flock.getProperty(meshId, "POSITION_Y")).to.equal(
+          toFixedNumber(expected.y),
+        );
+        expect(flock.getProperty(meshId, "POSITION_Z")).to.equal(
+          toFixedNumber(expected.z),
+        );
+      } finally {
+        flock._getAnchor = originalGetAnchor;
+      }
     });
 
     it("returns rotation in degrees from quaternions", function () {


### PR DESCRIPTION
## Summary
- updated `api/sensing.js` `getProperty(modelName, propertyName)` so mesh `POSITION_X/Y/Z` values come from anchor semantics
  - prefers `flock._getAnchor(mesh)`
  - falls back to `flock.getBlockPositionFromMesh(mesh)` for base/min-Y behavior
  - keeps `__active_camera__` and `__main_light__` on absolute world position
- adjusted and expanded getProperty tests:
  - position assertions now validate anchor/base coordinates
  - added fallback coverage when `_getAnchor` is unavailable
- added regression coverage in `tests/characterAnimations.test.js` for a character mesh with physics + animation switching + `glideTo(... y: 0 ...)`, asserting `POSITION_Y === 0`
- updated `API.md` getProperty docs to explicitly describe mesh anchor/base position semantics and camera/light absolute semantics

## Testing
- attempted: `npm run test:api getProperty -- --verbose`
  - failed in this environment because Playwright Chromium is not installed
- attempted dependency install: `npx playwright install chromium`
  - failed with 403 responses from the CDN in this environment

## Notes
- This change preserves existing absolute-position behavior for camera/light objects while aligning mesh position reads with movement/anchor expectations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c675d1a483268dce0ee41dd47344)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated position property reporting (`POSITION_X/Y/Z`) to use anchor-based coordinates for models with intelligent fallback handling.
  * Special objects (`__active_camera__`, `__main_light__`) now correctly report absolute world positions.

* **Documentation**
  * Clarified coordinate semantics for position properties in API documentation.

* **Tests**
  * Added validation tests for position property accuracy and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->