### PR TITLE
Add safety checks and debug warning for BLOCK_CHANGE events referencing missing blocks

### DIFF
--- a/ui/blockmesh.js
+++ b/ui/blockmesh.js
@@ -1185,9 +1185,35 @@ export function updateMeshFromBlock(meshesOrMesh, block, changeEvent) {
     return;
   }
 
+  const mainWorkspace = Blockly.getMainWorkspace();
   const changedBlock = changeEvent.blockId
-    ? Blockly.getMainWorkspace().getBlockById(changeEvent.blockId)
+    ? mainWorkspace?.getBlockById(changeEvent.blockId)
     : null;
+
+  if (
+    changeEvent?.type === Blockly.Events.BLOCK_CHANGE &&
+    changeEvent?.blockId &&
+    !changedBlock
+  ) {
+    const eventWorkspace =
+      Blockly.Workspace?.getById?.(changeEvent.workspaceId) || null;
+    const blockInEventWorkspace = eventWorkspace?.getBlockById?.(
+      changeEvent.blockId,
+    );
+
+    console.warn(
+      "[blockmesh debug] BLOCK_CHANGE for missing block in main workspace",
+      {
+        blockId: changeEvent.blockId,
+        eventWorkspaceId: changeEvent.workspaceId,
+        mainWorkspaceId: mainWorkspace?.id,
+        foundInEventWorkspace: Boolean(blockInEventWorkspace),
+        eventType: changeEvent.type,
+        eventElement: changeEvent.element,
+        eventName: changeEvent.name,
+      },
+    );
+  }
 
   const parent = changedBlock?.getParent() || changedBlock;
 


### PR DESCRIPTION
### Motivation

- Fix cases where `BLOCK_CHANGE` events reference a block ID that is not present in the main workspace, which could lead to unexpected behavior or null dereferences.  
- Reduce duplicate calls to `Blockly.getMainWorkspace()` and make block lookup more robust with optional chaining.  
- Surface actionable debug information when live updates are skipped due to missing blocks to aid troubleshooting.

### Description

- Cache `mainWorkspace` with `const mainWorkspace = Blockly.getMainWorkspace();` and use `mainWorkspace?.getBlockById(changeEvent.blockId)` to safely resolve the changed block.  
- When a `BLOCK_CHANGE` event contains a `blockId` but the block is missing from the main workspace, attempt to find the workspace via `Blockly.Workspace.getById(changeEvent.workspaceId)` and check for the block there.  
- Emit a structured `console.warn` containing `blockId`, workspace IDs, whether the block was found in the event workspace, and event metadata to aid debugging, while preserving existing early returns for `change_color` and special block types.

### Testing

- Ran linter with `npm run lint` and it succeeded.  
- Ran unit tests with `npm test` and they all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec3b3a5ef88326bb3a0ae8c981609e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for block tracking across multiple workspaces. The system now provides better diagnostic information when blocks cannot be found, including workspace identifiers and event details to aid in troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->