### PR TITLE
Ensure workspace.clear runs with events enabled and add workspace-safety + debug logs for color resolution

### DIFF
--- a/blocks/blocks.js
+++ b/blocks/blocks.js
@@ -209,6 +209,31 @@ export function getHandlerDebugForBlock(workspace, blockId) {
   };
 }
 
+export function getHandlerRegistryDebugSnapshot(workspace, sampleSize = 20) {
+  const sample = [];
+  let index = 0;
+  for (const [blockId, handler] of blockHandlerRegistry.entries()) {
+    if (index >= sampleSize) break;
+    const block = workspace?.getBlockById?.(blockId) ?? null;
+    sample.push({
+      blockId,
+      blockType: block?.type ?? null,
+      blockWorkspaceId: block?.workspace?.id ?? null,
+      blockExistsInWorkspace: Boolean(block),
+      hasHandlerFunction: typeof handler === "function",
+      hasHandlerRefOnBlock: Boolean(block?.[flockHandlerRefKey]),
+    });
+    index += 1;
+  }
+
+  return {
+    workspaceId: workspace?.id ?? null,
+    registrySize: blockHandlerRegistry.size,
+    sampledEntries: sample.length,
+    sample,
+  };
+}
+
 export const inlineIcon = makeInlineIcon("white");
 
 export function getHelpUrlFor(_blockType) {

--- a/blocks/blocks.js
+++ b/blocks/blocks.js
@@ -130,18 +130,7 @@ export function rebuildBlockHandlerRegistryFromWorkspace(workspace) {
   let restored = 0;
   const missingHandlerRefBlocks = [];
   const blocks = workspace.getAllBlocks(false);
-  const meshDriverBlocks = blocks.filter((block) => {
-    const type = block?.type || "";
-    return (
-      type.startsWith("create_") ||
-      type.startsWith("load_") ||
-      type === "set_sky_color" ||
-      type === "set_background_color" ||
-      type === "create_ground" ||
-      type === "create_map"
-    );
-  });
-  const meshDriverBlockCount = meshDriverBlocks.length;
+  const blocksWithHandlerRef = [];
   for (const block of blocks) {
     if (!block || block.workspace?.isFlyout) continue;
     const handler = block[flockHandlerRefKey];
@@ -152,13 +141,14 @@ export function rebuildBlockHandlerRegistryFromWorkspace(workspace) {
       });
       continue;
     }
+    blocksWithHandlerRef.push(block);
     blockHandlerRegistry.set(block.id, handler);
     restored += 1;
   }
   const rebuildSummary = {
     workspaceId: workspace.id,
     blockCount: blocks.length,
-    meshDriverBlockCount,
+    blocksWithHandlerRefCount: blocksWithHandlerRef.length,
     restoredHandlers: restored,
     blocksMissingHandlerRef: missingHandlerRefBlocks.length,
     missingHandlerRefSample: missingHandlerRefBlocks.slice(0, 10),
@@ -166,27 +156,27 @@ export function rebuildBlockHandlerRegistryFromWorkspace(workspace) {
   };
   console.log("[workspace-debug] rebuildBlockHandlerRegistryFromWorkspace", rebuildSummary);
   console.log(
-    `[workspace-debug] rebuild summary workspaceId=${rebuildSummary.workspaceId} blockCount=${rebuildSummary.blockCount} meshDriverBlockCount=${rebuildSummary.meshDriverBlockCount} restoredHandlers=${rebuildSummary.restoredHandlers} blocksMissingHandlerRef=${rebuildSummary.blocksMissingHandlerRef} registrySize=${rebuildSummary.registrySize}`,
+    `[workspace-debug] rebuild summary workspaceId=${rebuildSummary.workspaceId} blockCount=${rebuildSummary.blockCount} blocksWithHandlerRefCount=${rebuildSummary.blocksWithHandlerRefCount} restoredHandlers=${rebuildSummary.restoredHandlers} blocksMissingHandlerRef=${rebuildSummary.blocksMissingHandlerRef} registrySize=${rebuildSummary.registrySize}`,
   );
-  const missingMeshDriverHandlers = meshDriverBlocks
+  const missingRegistryEntries = blocksWithHandlerRef
     .filter((block) => !blockHandlerRegistry.has(block.id))
     .map((block) => ({ id: block.id, type: block.type }));
-  if (missingMeshDriverHandlers.length > 0) {
+  if (missingRegistryEntries.length > 0) {
     console.warn(
-      "[workspace-debug] mesh-driving blocks missing handler registration after rebuild",
+      "[workspace-debug] blocks with handler refs missing registry entry after rebuild",
       {
         workspaceId: workspace.id,
-        missingMeshDriverHandlerCount: missingMeshDriverHandlers.length,
-        missingMeshDriverHandlerSample: missingMeshDriverHandlers.slice(0, 10),
+        missingRegistryEntryCount: missingRegistryEntries.length,
+        missingRegistryEntrySample: missingRegistryEntries.slice(0, 10),
       },
     );
   }
-  if (meshDriverBlockCount > 0 && restored === 0) {
+  if (blocksWithHandlerRef.length > 0 && restored === 0) {
     console.warn(
-      "[workspace-debug] Registry rebuild restored 0 handlers despite mesh-driving blocks",
+      "[workspace-debug] Registry rebuild restored 0 handlers despite handler refs",
       {
         workspaceId: workspace.id,
-        meshDriverBlockCount,
+        blocksWithHandlerRefCount: blocksWithHandlerRef.length,
         blocksMissingHandlerRef: missingHandlerRefBlocks.length,
       },
     );

--- a/blocks/blocks.js
+++ b/blocks/blocks.js
@@ -141,6 +141,31 @@ export function rebuildBlockHandlerRegistryFromWorkspace(workspace) {
   return restored;
 }
 
+export function getHandlerDebugForBlock(workspace, blockId) {
+  if (!workspace || !blockId) {
+    return {
+      blockId: blockId ?? null,
+      workspaceId: workspace?.id ?? null,
+      blockExistsInWorkspace: false,
+      blockType: null,
+      hasHandlerRefOnBlock: false,
+      hasRegistryEntry: false,
+      registrySize: blockHandlerRegistry.size,
+    };
+  }
+
+  const block = workspace.getBlockById(blockId);
+  return {
+    blockId,
+    workspaceId: workspace.id,
+    blockExistsInWorkspace: Boolean(block),
+    blockType: block?.type ?? null,
+    hasHandlerRefOnBlock: Boolean(block?.[flockHandlerRefKey]),
+    hasRegistryEntry: blockHandlerRegistry.has(blockId),
+    registrySize: blockHandlerRegistry.size,
+  };
+}
+
 export const inlineIcon = makeInlineIcon("white");
 
 export function getHelpUrlFor(_blockType) {

--- a/blocks/blocks.js
+++ b/blocks/blocks.js
@@ -86,7 +86,7 @@ class HandlerRegistry extends Map {
   }
 
   clear() {
-    console.warn("[workspace-debug] blockHandlerRegistry.clear()", {
+    console.log("[workspace-debug] blockHandlerRegistry.clear() [debug trace]", {
       sizeBefore: this.size,
       stack: new Error().stack,
     });
@@ -155,7 +155,7 @@ export function rebuildBlockHandlerRegistryFromWorkspace(workspace) {
     blockHandlerRegistry.set(block.id, handler);
     restored += 1;
   }
-  console.log("[workspace-debug] rebuildBlockHandlerRegistryFromWorkspace", {
+  const rebuildSummary = {
     workspaceId: workspace.id,
     blockCount: blocks.length,
     meshDriverBlockCount,
@@ -163,7 +163,11 @@ export function rebuildBlockHandlerRegistryFromWorkspace(workspace) {
     blocksMissingHandlerRef: missingHandlerRefBlocks.length,
     missingHandlerRefSample: missingHandlerRefBlocks.slice(0, 10),
     registrySize: blockHandlerRegistry.size,
-  });
+  };
+  console.log("[workspace-debug] rebuildBlockHandlerRegistryFromWorkspace", rebuildSummary);
+  console.log(
+    `[workspace-debug] rebuild summary workspaceId=${rebuildSummary.workspaceId} blockCount=${rebuildSummary.blockCount} meshDriverBlockCount=${rebuildSummary.meshDriverBlockCount} restoredHandlers=${rebuildSummary.restoredHandlers} blocksMissingHandlerRef=${rebuildSummary.blocksMissingHandlerRef} registrySize=${rebuildSummary.registrySize}`,
+  );
   const missingMeshDriverHandlers = meshDriverBlocks
     .filter((block) => !blockHandlerRegistry.has(block.id))
     .map((block) => ({ id: block.id, type: block.type }));

--- a/blocks/blocks.js
+++ b/blocks/blocks.js
@@ -128,6 +128,7 @@ export function registerBlockHandler(block, handler) {
 export function rebuildBlockHandlerRegistryFromWorkspace(workspace) {
   if (!workspace) return 0;
   let restored = 0;
+  const missingHandlerRefBlocks = [];
   const blocks = workspace.getAllBlocks(false);
   const meshDriverBlockCount = blocks.filter((block) => {
     const type = block?.type || "";
@@ -143,7 +144,13 @@ export function rebuildBlockHandlerRegistryFromWorkspace(workspace) {
   for (const block of blocks) {
     if (!block || block.workspace?.isFlyout) continue;
     const handler = block[flockHandlerRefKey];
-    if (typeof handler !== "function") continue;
+    if (typeof handler !== "function") {
+      missingHandlerRefBlocks.push({
+        id: block.id,
+        type: block.type,
+      });
+      continue;
+    }
     blockHandlerRegistry.set(block.id, handler);
     restored += 1;
   }
@@ -152,8 +159,20 @@ export function rebuildBlockHandlerRegistryFromWorkspace(workspace) {
     blockCount: blocks.length,
     meshDriverBlockCount,
     restoredHandlers: restored,
+    blocksMissingHandlerRef: missingHandlerRefBlocks.length,
+    missingHandlerRefSample: missingHandlerRefBlocks.slice(0, 10),
     registrySize: blockHandlerRegistry.size,
   });
+  if (meshDriverBlockCount > 0 && restored === 0) {
+    console.warn(
+      "[workspace-debug] Registry rebuild restored 0 handlers despite mesh-driving blocks",
+      {
+        workspaceId: workspace.id,
+        meshDriverBlockCount,
+        blocksMissingHandlerRef: missingHandlerRefBlocks.length,
+      },
+    );
+  }
   return restored;
 }
 

--- a/blocks/blocks.js
+++ b/blocks/blocks.js
@@ -130,7 +130,7 @@ export function rebuildBlockHandlerRegistryFromWorkspace(workspace) {
   let restored = 0;
   const missingHandlerRefBlocks = [];
   const blocks = workspace.getAllBlocks(false);
-  const meshDriverBlockCount = blocks.filter((block) => {
+  const meshDriverBlocks = blocks.filter((block) => {
     const type = block?.type || "";
     return (
       type.startsWith("create_") ||
@@ -140,7 +140,8 @@ export function rebuildBlockHandlerRegistryFromWorkspace(workspace) {
       type === "create_ground" ||
       type === "create_map"
     );
-  }).length;
+  });
+  const meshDriverBlockCount = meshDriverBlocks.length;
   for (const block of blocks) {
     if (!block || block.workspace?.isFlyout) continue;
     const handler = block[flockHandlerRefKey];
@@ -163,6 +164,19 @@ export function rebuildBlockHandlerRegistryFromWorkspace(workspace) {
     missingHandlerRefSample: missingHandlerRefBlocks.slice(0, 10),
     registrySize: blockHandlerRegistry.size,
   });
+  const missingMeshDriverHandlers = meshDriverBlocks
+    .filter((block) => !blockHandlerRegistry.has(block.id))
+    .map((block) => ({ id: block.id, type: block.type }));
+  if (missingMeshDriverHandlers.length > 0) {
+    console.warn(
+      "[workspace-debug] mesh-driving blocks missing handler registration after rebuild",
+      {
+        workspaceId: workspace.id,
+        missingMeshDriverHandlerCount: missingMeshDriverHandlers.length,
+        missingMeshDriverHandlerSample: missingMeshDriverHandlers.slice(0, 10),
+      },
+    );
+  }
   if (meshDriverBlockCount > 0 && restored === 0) {
     console.warn(
       "[workspace-debug] Registry rebuild restored 0 handlers despite mesh-driving blocks",

--- a/blocks/blocks.js
+++ b/blocks/blocks.js
@@ -86,6 +86,10 @@ class HandlerRegistry extends Map {
   }
 
   clear() {
+    console.warn("[workspace-debug] blockHandlerRegistry.clear()", {
+      sizeBefore: this.size,
+      stack: new Error().stack,
+    });
     this.#snapshot = null;
     return super.clear();
   }
@@ -125,6 +129,17 @@ export function rebuildBlockHandlerRegistryFromWorkspace(workspace) {
   if (!workspace) return 0;
   let restored = 0;
   const blocks = workspace.getAllBlocks(false);
+  const meshDriverBlockCount = blocks.filter((block) => {
+    const type = block?.type || "";
+    return (
+      type.startsWith("create_") ||
+      type.startsWith("load_") ||
+      type === "set_sky_color" ||
+      type === "set_background_color" ||
+      type === "create_ground" ||
+      type === "create_map"
+    );
+  }).length;
   for (const block of blocks) {
     if (!block || block.workspace?.isFlyout) continue;
     const handler = block[flockHandlerRefKey];
@@ -135,6 +150,7 @@ export function rebuildBlockHandlerRegistryFromWorkspace(workspace) {
   console.log("[workspace-debug] rebuildBlockHandlerRegistryFromWorkspace", {
     workspaceId: workspace.id,
     blockCount: blocks.length,
+    meshDriverBlockCount,
     restoredHandlers: restored,
     registrySize: blockHandlerRegistry.size,
   });
@@ -164,11 +180,6 @@ export function getHandlerDebugForBlock(workspace, blockId) {
     hasRegistryEntry: blockHandlerRegistry.has(blockId),
     registrySize: blockHandlerRegistry.size,
   };
-}
-
-export function dispatchBlockUpdateFromEvent(block, changeEvent) {
-  if (!block || !changeEvent) return;
-  updateOrCreateMeshFromBlock(block, changeEvent);
 }
 
 export const inlineIcon = makeInlineIcon("white");

--- a/blocks/blocks.js
+++ b/blocks/blocks.js
@@ -166,6 +166,11 @@ export function getHandlerDebugForBlock(workspace, blockId) {
   };
 }
 
+export function dispatchBlockUpdateFromEvent(block, changeEvent) {
+  if (!block || !changeEvent) return;
+  updateOrCreateMeshFromBlock(block, changeEvent);
+}
+
 export const inlineIcon = makeInlineIcon("white");
 
 export function getHelpUrlFor(_blockType) {

--- a/blocks/blocks.js
+++ b/blocks/blocks.js
@@ -111,6 +111,12 @@ export const blockHandlerRegistry = new HandlerRegistry();
 export function registerBlockHandler(block, handler) {
   if (!block.workspace || block.workspace.isFlyout) return;
   blockHandlerRegistry.set(block.id, handler);
+  console.log("[workspace-debug] registerBlockHandler", {
+    blockId: block.id,
+    blockType: block.type,
+    workspaceId: block.workspace.id,
+    registrySize: blockHandlerRegistry.size,
+  });
 }
 
 export const inlineIcon = makeInlineIcon("white");

--- a/blocks/blocks.js
+++ b/blocks/blocks.js
@@ -99,6 +99,7 @@ class HandlerRegistry extends Map {
 
 /** @type {HandlerRegistry} */
 export const blockHandlerRegistry = new HandlerRegistry();
+const flockHandlerRefKey = Symbol.for("flock.blockHandlerRef");
 
 /**
  * Register a block's change handler with the workspace dispatcher.
@@ -110,6 +111,7 @@ export const blockHandlerRegistry = new HandlerRegistry();
  */
 export function registerBlockHandler(block, handler) {
   if (!block.workspace || block.workspace.isFlyout) return;
+  block[flockHandlerRefKey] = handler;
   blockHandlerRegistry.set(block.id, handler);
   console.log("[workspace-debug] registerBlockHandler", {
     blockId: block.id,
@@ -117,6 +119,26 @@ export function registerBlockHandler(block, handler) {
     workspaceId: block.workspace.id,
     registrySize: blockHandlerRegistry.size,
   });
+}
+
+export function rebuildBlockHandlerRegistryFromWorkspace(workspace) {
+  if (!workspace) return 0;
+  let restored = 0;
+  const blocks = workspace.getAllBlocks(false);
+  for (const block of blocks) {
+    if (!block || block.workspace?.isFlyout) continue;
+    const handler = block[flockHandlerRefKey];
+    if (typeof handler !== "function") continue;
+    blockHandlerRegistry.set(block.id, handler);
+    restored += 1;
+  }
+  console.log("[workspace-debug] rebuildBlockHandlerRegistryFromWorkspace", {
+    workspaceId: workspace.id,
+    blockCount: blocks.length,
+    restoredHandlers: restored,
+    registrySize: blockHandlerRegistry.size,
+  });
+  return restored;
 }
 
 export const inlineIcon = makeInlineIcon("white");

--- a/main/blockhandling.js
+++ b/main/blockhandling.js
@@ -3,7 +3,6 @@ import { workspace } from "./blocklyinit.js";
 import { translate } from "./translation.js";
 import {
   blockHandlerRegistry,
-  dispatchBlockUpdateFromEvent,
   getHandlerDebugForBlock,
 } from "../blocks/blocks.js";
 import { announceToScreenReader } from "./input.js";
@@ -590,31 +589,6 @@ export function initializeBlockHandling() {
             registrySize: blockHandlerRegistry.size,
           },
         );
-      }
-      if (
-        handlers.length === 0 &&
-        (event.type === Blockly.Events.BLOCK_CHANGE ||
-          event.type === Blockly.Events.BLOCK_MOVE)
-      ) {
-        const fallbackBlock = eventAncestorBlocks.find((block) => {
-          const type = block?.type || "";
-          return (
-            type.startsWith("create_") ||
-            type.startsWith("load_") ||
-            type === "set_sky_color" ||
-            type === "set_background_color" ||
-            type === "create_ground" ||
-            type === "create_map"
-          );
-        });
-        if (fallbackBlock) {
-          console.warn("[workspace-debug] Fallback dispatch without registry", {
-            eventBlockId: event.blockId ?? null,
-            fallbackBlockId: fallbackBlock.id,
-            fallbackBlockType: fallbackBlock.type,
-          });
-          dispatchBlockUpdateFromEvent(fallbackBlock, event);
-        }
       }
     }
     for (const handler of handlers) {

--- a/main/blockhandling.js
+++ b/main/blockhandling.js
@@ -3,6 +3,7 @@ import { workspace } from "./blocklyinit.js";
 import { translate } from "./translation.js";
 import {
   blockHandlerRegistry,
+  dispatchBlockUpdateFromEvent,
   getHandlerDebugForBlock,
 } from "../blocks/blocks.js";
 import { announceToScreenReader } from "./input.js";
@@ -552,9 +553,13 @@ export function initializeBlockHandling() {
         event.blockId && typeof workspace.getBlockById === "function"
           ? workspace.getBlockById(event.blockId)
           : null;
-      const eventAncestorIds =
+      const eventAncestorBlocks =
         typeof eventBlock?.getAncestors === "function"
-          ? eventBlock.getAncestors().map((block) => block.id)
+          ? eventBlock.getAncestors()
+          : [];
+      const eventAncestorIds =
+        eventAncestorBlocks.length > 0
+          ? eventAncestorBlocks.map((block) => block.id)
           : [];
       const matchingAncestorHandlerIds = eventAncestorIds.filter((id) =>
         blockHandlerRegistry.has(id),
@@ -585,6 +590,31 @@ export function initializeBlockHandling() {
             registrySize: blockHandlerRegistry.size,
           },
         );
+      }
+      if (
+        handlers.length === 0 &&
+        (event.type === Blockly.Events.BLOCK_CHANGE ||
+          event.type === Blockly.Events.BLOCK_MOVE)
+      ) {
+        const fallbackBlock = eventAncestorBlocks.find((block) => {
+          const type = block?.type || "";
+          return (
+            type.startsWith("create_") ||
+            type.startsWith("load_") ||
+            type === "set_sky_color" ||
+            type === "set_background_color" ||
+            type === "create_ground" ||
+            type === "create_map"
+          );
+        });
+        if (fallbackBlock) {
+          console.warn("[workspace-debug] Fallback dispatch without registry", {
+            eventBlockId: event.blockId ?? null,
+            fallbackBlockId: fallbackBlock.id,
+            fallbackBlockType: fallbackBlock.type,
+          });
+          dispatchBlockUpdateFromEvent(fallbackBlock, event);
+        }
       }
     }
     for (const handler of handlers) {

--- a/main/blockhandling.js
+++ b/main/blockhandling.js
@@ -1,7 +1,10 @@
 import * as Blockly from "blockly";
 import { workspace } from "./blocklyinit.js";
 import { translate } from "./translation.js";
-import { blockHandlerRegistry } from "../blocks/blocks.js";
+import {
+  blockHandlerRegistry,
+  getHandlerDebugForBlock,
+} from "../blocks/blocks.js";
 import { announceToScreenReader } from "./input.js";
 
 function asBlocklyBlock(candidate) {
@@ -545,6 +548,10 @@ export function initializeBlockHandling() {
       event.type === Blockly.Events.BLOCK_MOVE ||
       event.type === Blockly.Events.BLOCK_CREATE
     ) {
+      const handlerDebug = getHandlerDebugForBlock(
+        workspace,
+        event.blockId ?? null,
+      );
       console.log("[workspace-debug] dispatching block event", {
         eventType: event.type,
         eventElement: event.element ?? null,
@@ -552,6 +559,7 @@ export function initializeBlockHandling() {
         eventBlockId: event.blockId ?? null,
         eventWorkspaceId: event.workspaceId ?? null,
         handlerCount: handlers.length,
+        handlerDebug,
       });
     }
     for (const handler of handlers) {

--- a/main/blockhandling.js
+++ b/main/blockhandling.js
@@ -4,6 +4,7 @@ import { translate } from "./translation.js";
 import {
   blockHandlerRegistry,
   getHandlerDebugForBlock,
+  getHandlerRegistryDebugSnapshot,
 } from "../blocks/blocks.js";
 import { announceToScreenReader } from "./input.js";
 
@@ -567,6 +568,18 @@ export function initializeBlockHandling() {
         workspace,
         event.blockId ?? null,
       );
+      const isColourFieldChange =
+        event.type === Blockly.Events.BLOCK_CHANGE &&
+        event.element === "field" &&
+        event.name === "COLOR";
+      if (isColourFieldChange) {
+        console.log("[workspace-debug] colour-change registry snapshot", {
+          eventBlockId: event.blockId ?? null,
+          eventWorkspaceId: event.workspaceId ?? null,
+          handlerDebug,
+          registrySnapshot: getHandlerRegistryDebugSnapshot(workspace),
+        });
+      }
       console.log("[workspace-debug] dispatching block event", {
         eventType: event.type,
         eventElement: event.element ?? null,
@@ -597,6 +610,7 @@ export function initializeBlockHandling() {
             eventBlockType: eventBlock?.type ?? null,
             eventAncestorIds,
             registrySize: blockHandlerRegistry.size,
+            registrySnapshot: getHandlerRegistryDebugSnapshot(workspace),
           },
         );
       } else if (matchingAncestorHandlerIds.length === 0 && handlers.length > 0) {

--- a/main/blockhandling.js
+++ b/main/blockhandling.js
@@ -579,10 +579,20 @@ export function initializeBlockHandling() {
         matchingAncestorHandlerIds,
         handlerDebug,
       });
-      if (matchingAncestorHandlerIds.length === 0 && handlers.length === 0) {
+      const isActionableMeshUpdateEvent =
+        event.type === Blockly.Events.BLOCK_CHANGE ||
+        event.type === Blockly.Events.BLOCK_MOVE;
+      if (
+        matchingAncestorHandlerIds.length === 0 &&
+        handlers.length === 0 &&
+        isActionableMeshUpdateEvent
+      ) {
         console.warn(
-          "[workspace-debug] Handler registry is empty for dispatched event",
+          "[workspace-debug] Handler registry is empty for dispatched actionable event",
           {
+            eventType: event.type,
+            eventElement: event.element ?? null,
+            eventName: event.name ?? null,
             eventBlockId: event.blockId ?? null,
             eventBlockType: eventBlock?.type ?? null,
             eventAncestorIds,

--- a/main/blockhandling.js
+++ b/main/blockhandling.js
@@ -579,14 +579,24 @@ export function initializeBlockHandling() {
         matchingAncestorHandlerIds,
         handlerDebug,
       });
-      if (matchingAncestorHandlerIds.length === 0) {
+      if (matchingAncestorHandlerIds.length === 0 && handlers.length === 0) {
         console.warn(
-          "[workspace-debug] No handler registered for event block or its ancestors",
+          "[workspace-debug] Handler registry is empty for dispatched event",
           {
             eventBlockId: event.blockId ?? null,
             eventBlockType: eventBlock?.type ?? null,
             eventAncestorIds,
             registrySize: blockHandlerRegistry.size,
+          },
+        );
+      } else if (matchingAncestorHandlerIds.length === 0 && handlers.length > 0) {
+        console.log(
+          "[workspace-debug] No direct ancestor handler match; event will still fan out to registered handlers",
+          {
+            eventBlockId: event.blockId ?? null,
+            eventBlockType: eventBlock?.type ?? null,
+            eventAncestorIds,
+            handlerCount: handlers.length,
           },
         );
       }

--- a/main/blockhandling.js
+++ b/main/blockhandling.js
@@ -548,6 +548,17 @@ export function initializeBlockHandling() {
       event.type === Blockly.Events.BLOCK_MOVE ||
       event.type === Blockly.Events.BLOCK_CREATE
     ) {
+      const eventBlock =
+        event.blockId && typeof workspace.getBlockById === "function"
+          ? workspace.getBlockById(event.blockId)
+          : null;
+      const eventAncestorIds =
+        typeof eventBlock?.getAncestors === "function"
+          ? eventBlock.getAncestors().map((block) => block.id)
+          : [];
+      const matchingAncestorHandlerIds = eventAncestorIds.filter((id) =>
+        blockHandlerRegistry.has(id),
+      );
       const handlerDebug = getHandlerDebugForBlock(
         workspace,
         event.blockId ?? null,
@@ -559,8 +570,22 @@ export function initializeBlockHandling() {
         eventBlockId: event.blockId ?? null,
         eventWorkspaceId: event.workspaceId ?? null,
         handlerCount: handlers.length,
+        eventBlockType: eventBlock?.type ?? null,
+        eventAncestorIds,
+        matchingAncestorHandlerIds,
         handlerDebug,
       });
+      if (matchingAncestorHandlerIds.length === 0) {
+        console.warn(
+          "[workspace-debug] No handler registered for event block or its ancestors",
+          {
+            eventBlockId: event.blockId ?? null,
+            eventBlockType: eventBlock?.type ?? null,
+            eventAncestorIds,
+            registrySize: blockHandlerRegistry.size,
+          },
+        );
+      }
     }
     for (const handler of handlers) {
       handler(event);

--- a/main/blockhandling.js
+++ b/main/blockhandling.js
@@ -540,6 +540,20 @@ export function initializeBlockHandling() {
     // mid-iteration mutations (e.g. a handler that creates or deletes blocks)
     // without allocating a new array on every event.
     const handlers = blockHandlerRegistry.cachedValues();
+    if (
+      event.type === Blockly.Events.BLOCK_CHANGE ||
+      event.type === Blockly.Events.BLOCK_MOVE ||
+      event.type === Blockly.Events.BLOCK_CREATE
+    ) {
+      console.log("[workspace-debug] dispatching block event", {
+        eventType: event.type,
+        eventElement: event.element ?? null,
+        eventName: event.name ?? null,
+        eventBlockId: event.blockId ?? null,
+        eventWorkspaceId: event.workspaceId ?? null,
+        handlerCount: handlers.length,
+      });
+    }
     for (const handler of handlers) {
       handler(event);
     }

--- a/main/files.js
+++ b/main/files.js
@@ -337,7 +337,7 @@ export function loadWorkspaceAndExecute(json, workspace, executeCallback) {
 
     // Load the validated JSON
     Blockly.serialization.workspaces.load(validatedJson, workspace);
-    console.error("[workspace-debug] about to rebuild block handler registry", {
+    console.log("[workspace-debug] about to rebuild block handler registry", {
       workspaceId: workspace.id,
       topBlockCount: workspace.getTopBlocks(false).length,
     });

--- a/main/files.js
+++ b/main/files.js
@@ -323,17 +323,30 @@ export function loadWorkspaceAndExecute(json, workspace, executeCallback) {
     const validatedJson = validateBlocklyJson(json);
 
     // Clear workspace with events enabled so normal delete/trash semantics run.
-    const eventsWereEnabled = Blockly.Events.isEnabled();
-    if (!eventsWereEnabled) Blockly.Events.enable();
-    workspace.clear();
+    // Preserve nested event-disable depth and restore it afterward.
+    let disabledDepth = 0;
+    while (!Blockly.Events.isEnabled()) {
+      Blockly.Events.enable();
+      disabledDepth += 1;
+    }
+    try {
+      workspace.clear();
 
-    // Keep registry clearing isolated from workspace clear events.
-    Blockly.Events.disable();
-    blockHandlerRegistry.clear();
-    console.log("[workspace-debug] blockHandlerRegistry cleared", {
-      size: blockHandlerRegistry.size,
-    });
-    if (eventsWereEnabled) Blockly.Events.enable();
+      // Keep registry clearing isolated from workspace clear events.
+      Blockly.Events.disable();
+      try {
+        blockHandlerRegistry.clear();
+        console.log("[workspace-debug] blockHandlerRegistry cleared", {
+          size: blockHandlerRegistry.size,
+        });
+      } finally {
+        Blockly.Events.enable();
+      }
+    } finally {
+      for (let i = 0; i < disabledDepth; i += 1) {
+        Blockly.Events.disable();
+      }
+    }
 
     // Load the validated JSON
     Blockly.serialization.workspaces.load(validatedJson, workspace);

--- a/main/files.js
+++ b/main/files.js
@@ -3,7 +3,10 @@ import { workspace } from "./blocklyinit.js";
 import { translate } from "./translation.js";
 import { getMetadata } from "meta-png";
 import { AUTOSAVE_KEY } from "../config.js";
-import { blockHandlerRegistry } from "../blocks/blocks.js";
+import {
+  blockHandlerRegistry,
+  rebuildBlockHandlerRegistryFromWorkspace,
+} from "../blocks/blocks.js";
 
 // Function to save the current workspace state
 export function saveWorkspace(workspace) {
@@ -334,6 +337,7 @@ export function loadWorkspaceAndExecute(json, workspace, executeCallback) {
 
     // Load the validated JSON
     Blockly.serialization.workspaces.load(validatedJson, workspace);
+    rebuildBlockHandlerRegistryFromWorkspace(workspace);
     console.log("[workspace-debug] workspace loaded", {
       workspaceId: workspace.id,
       topBlockCount: workspace.getTopBlocks(false).length,

--- a/main/files.js
+++ b/main/files.js
@@ -337,6 +337,10 @@ export function loadWorkspaceAndExecute(json, workspace, executeCallback) {
 
     // Load the validated JSON
     Blockly.serialization.workspaces.load(validatedJson, workspace);
+    console.error("[workspace-debug] about to rebuild block handler registry", {
+      workspaceId: workspace.id,
+      topBlockCount: workspace.getTopBlocks(false).length,
+    });
     const restoredHandlers =
       rebuildBlockHandlerRegistryFromWorkspace(workspace);
     console.log("[workspace-debug] workspace loaded", {
@@ -345,6 +349,24 @@ export function loadWorkspaceAndExecute(json, workspace, executeCallback) {
       restoredHandlers,
       handlerRegistrySize: blockHandlerRegistry.size,
     });
+    if (
+      workspace.getTopBlocks(false).length > 0 &&
+      restoredHandlers === 0 &&
+      blockHandlerRegistry.size === 0
+    ) {
+      const topBlockSample = workspace
+        .getTopBlocks(false)
+        .slice(0, 10)
+        .map((block) => ({ id: block.id, type: block.type }));
+      console.error(
+        "[workspace-debug] top blocks exist but handler registry remains empty after rebuild",
+        {
+          workspaceId: workspace.id,
+          topBlockCount: workspace.getTopBlocks(false).length,
+          topBlockSample,
+        },
+      );
+    }
 
     workspace.scroll(0, 0);
     executeCallback();

--- a/main/files.js
+++ b/main/files.js
@@ -337,10 +337,12 @@ export function loadWorkspaceAndExecute(json, workspace, executeCallback) {
 
     // Load the validated JSON
     Blockly.serialization.workspaces.load(validatedJson, workspace);
-    rebuildBlockHandlerRegistryFromWorkspace(workspace);
+    const restoredHandlers =
+      rebuildBlockHandlerRegistryFromWorkspace(workspace);
     console.log("[workspace-debug] workspace loaded", {
       workspaceId: workspace.id,
       topBlockCount: workspace.getTopBlocks(false).length,
+      restoredHandlers,
       handlerRegistrySize: blockHandlerRegistry.size,
     });
 

--- a/main/files.js
+++ b/main/files.js
@@ -327,10 +327,18 @@ export function loadWorkspaceAndExecute(json, workspace, executeCallback) {
     // Keep registry clearing isolated from workspace clear events.
     Blockly.Events.disable();
     blockHandlerRegistry.clear();
+    console.log("[workspace-debug] blockHandlerRegistry cleared", {
+      size: blockHandlerRegistry.size,
+    });
     if (eventsWereEnabled) Blockly.Events.enable();
 
     // Load the validated JSON
     Blockly.serialization.workspaces.load(validatedJson, workspace);
+    console.log("[workspace-debug] workspace loaded", {
+      workspaceId: workspace.id,
+      topBlockCount: workspace.getTopBlocks(false).length,
+      handlerRegistrySize: blockHandlerRegistry.size,
+    });
 
     workspace.scroll(0, 0);
     executeCallback();

--- a/main/files.js
+++ b/main/files.js
@@ -319,14 +319,17 @@ export function loadWorkspaceAndExecute(json, workspace, executeCallback) {
     // Validate JSON before loading into workspace
     const validatedJson = validateBlocklyJson(json);
 
-    // Clear workspace and handlers
+    // Clear workspace with events enabled so normal delete/trash semantics run.
     const eventsWereEnabled = Blockly.Events.isEnabled();
-    if (eventsWereEnabled) Blockly.Events.disable();
+    if (!eventsWereEnabled) Blockly.Events.enable();
     workspace.clear();
+
+    // Keep registry clearing isolated from workspace clear events.
+    Blockly.Events.disable();
     blockHandlerRegistry.clear();
     if (eventsWereEnabled) Blockly.Events.enable();
 
-     // Load the validated JSON
+    // Load the validated JSON
     Blockly.serialization.workspaces.load(validatedJson, workspace);
 
     workspace.scroll(0, 0);

--- a/ui/blockmesh.js
+++ b/ui/blockmesh.js
@@ -80,54 +80,49 @@ function isMainWorkspaceEvent(changeEvent, block) {
   const ws = block?.workspace;
 
   if (!ws) {
-    if (flock.meshDebug)
-      console.log("[isMainWorkspaceEvent] false: block has no workspace", {
-        blockId: block?.id,
-        eventType: changeEvent?.type,
-        eventWorkspaceId: changeEvent?.workspaceId,
-      });
+    console.log("[workspace-debug] isMainWorkspaceEvent=false:no-workspace", {
+      blockId: block?.id ?? null,
+      blockType: block?.type ?? null,
+      eventType: changeEvent?.type ?? null,
+      eventWorkspaceId: changeEvent?.workspaceId ?? null,
+      mainWorkspaceId: mainWs?.id ?? null,
+    });
     return false;
   }
 
   if (ws.isFlyout) {
-    if (flock.meshDebug)
-      console.log(
-        "[isMainWorkspaceEvent] false: block is in flyout workspace",
-        {
-          blockId: block?.id,
-          eventType: changeEvent?.type,
-          eventWorkspaceId: changeEvent?.workspaceId,
-          blockWorkspaceId: ws.id,
-          mainWorkspaceId: mainWs?.id,
-        },
-      );
+    console.log("[workspace-debug] isMainWorkspaceEvent=false:flyout", {
+      blockId: block?.id ?? null,
+      blockType: block?.type ?? null,
+      eventType: changeEvent?.type ?? null,
+      eventWorkspaceId: changeEvent?.workspaceId ?? null,
+      blockWorkspaceId: ws.id,
+      mainWorkspaceId: mainWs?.id ?? null,
+    });
     return false;
   }
 
   if (ws !== mainWs) {
-    if (flock.meshDebug)
-      console.log(
-        "[isMainWorkspaceEvent] false: block is in a non-main, non-flyout workspace",
-        {
-          blockId: block?.id,
-          eventType: changeEvent?.type,
-          eventWorkspaceId: changeEvent?.workspaceId,
-          blockWorkspaceId: ws.id,
-          mainWorkspaceId: mainWs?.id,
-        },
-      );
+    console.log("[workspace-debug] isMainWorkspaceEvent=false:non-main-block", {
+      blockId: block?.id ?? null,
+      blockType: block?.type ?? null,
+      eventType: changeEvent?.type ?? null,
+      eventWorkspaceId: changeEvent?.workspaceId ?? null,
+      blockWorkspaceId: ws.id,
+      mainWorkspaceId: mainWs?.id ?? null,
+    });
     return false;
   }
 
   if (changeEvent?.workspaceId && changeEvent.workspaceId !== ws.id) {
-    if (flock.meshDebug)
-      console.log("[isMainWorkspaceEvent] false: event workspaceId mismatch", {
-        blockId: block?.id,
-        eventType: changeEvent?.type,
-        eventWorkspaceId: changeEvent.workspaceId,
-        blockWorkspaceId: ws.id,
-        mainWorkspaceId: mainWs?.id,
-      });
+    console.log("[workspace-debug] isMainWorkspaceEvent=false:event-mismatch", {
+      blockId: block?.id ?? null,
+      blockType: block?.type ?? null,
+      eventType: changeEvent?.type ?? null,
+      eventWorkspaceId: changeEvent.workspaceId,
+      blockWorkspaceId: ws.id,
+      mainWorkspaceId: mainWs?.id ?? null,
+    });
     return false;
   }
 
@@ -452,14 +447,26 @@ export function setClearSkyToBlack() {
 
 // Add this function before updateMeshFromBlock
 export function updateOrCreateMeshFromBlock(block, changeEvent) {
-  if (flock.meshDebug)
-    console.log(
-      "Update or create mesh from block",
-      block.type,
-      changeEvent.type,
-    );
+  console.log("[workspace-debug] updateOrCreateMeshFromBlock:enter", {
+    blockId: block?.id ?? null,
+    blockType: block?.type ?? null,
+    blockWorkspaceId: block?.workspace?.id ?? null,
+    eventType: changeEvent?.type ?? null,
+    eventElement: changeEvent?.element ?? null,
+    eventName: changeEvent?.name ?? null,
+    eventWorkspaceId: changeEvent?.workspaceId ?? null,
+  });
 
-  if (!isMainWorkspaceEvent(changeEvent, block)) {
+  const isMain = isMainWorkspaceEvent(changeEvent, block);
+  if (!isMain) {
+    console.log("[workspace-debug] updateOrCreateMeshFromBlock:exit-not-main", {
+      blockId: block?.id ?? null,
+      blockType: block?.type ?? null,
+      blockWorkspaceId: block?.workspace?.id ?? null,
+      eventType: changeEvent?.type ?? null,
+      eventWorkspaceId: changeEvent?.workspaceId ?? null,
+      mainWorkspaceId: Blockly.getMainWorkspace()?.id ?? null,
+    });
     return;
   }
 

--- a/ui/blockmesh.js
+++ b/ui/blockmesh.js
@@ -1151,6 +1151,52 @@ function getXYZFromBlock(block) {
 }
 
 export function updateMeshFromBlock(meshesOrMesh, block, changeEvent) {
+  const mainWorkspace = Blockly.getMainWorkspace();
+  console.log("[color][workspace-debug] updateMeshFromBlock:enter", {
+    blockId: block?.id ?? null,
+    blockType: block?.type ?? null,
+    blockWorkspaceId: block?.workspace?.id ?? null,
+    eventType: changeEvent?.type ?? null,
+    eventElement: changeEvent?.element ?? null,
+    eventName: changeEvent?.name ?? null,
+    eventBlockId: changeEvent?.blockId ?? null,
+    eventWorkspaceId: changeEvent?.workspaceId ?? null,
+    mainWorkspaceId: mainWorkspace?.id ?? null,
+  });
+
+  if (
+    mainWorkspace &&
+    block?.workspace &&
+    block.workspace.id !== mainWorkspace.id
+  ) {
+    console.warn(
+      "[color][workspace-debug] Skipping updateMeshFromBlock for block in non-main workspace",
+      {
+        blockId: block.id,
+        blockType: block.type,
+        blockWorkspaceId: block.workspace.id,
+        mainWorkspaceId: mainWorkspace.id,
+      },
+    );
+    return;
+  }
+
+  if (
+    mainWorkspace &&
+    changeEvent?.workspaceId &&
+    changeEvent.workspaceId !== mainWorkspace.id
+  ) {
+    console.warn(
+      "[color][workspace-debug] Skipping updateMeshFromBlock for event in non-main workspace",
+      {
+        eventType: changeEvent.type,
+        eventWorkspaceId: changeEvent.workspaceId,
+        mainWorkspaceId: mainWorkspace.id,
+      },
+    );
+    return;
+  }
+
   if (flock.meshDebug) {
     console.log("=== UPDATE MESH FROM BLOCK ===");
     console.log("Block type:", block.type);
@@ -1186,8 +1232,18 @@ export function updateMeshFromBlock(meshesOrMesh, block, changeEvent) {
   }
 
   const changedBlock = changeEvent.blockId
-    ? Blockly.getMainWorkspace().getBlockById(changeEvent.blockId)
+    ? (block?.workspace || mainWorkspace)?.getBlockById(changeEvent.blockId)
     : null;
+  if (changeEvent.blockId && !changedBlock) {
+    console.warn(
+      "[color][workspace-debug] Changed block not found in resolved workspace",
+      {
+        eventBlockId: changeEvent.blockId,
+        blockWorkspaceId: block?.workspace?.id ?? null,
+        mainWorkspaceId: mainWorkspace?.id ?? null,
+      },
+    );
+  }
 
   const parent = changedBlock?.getParent() || changedBlock;
 

--- a/ui/blockmesh.js
+++ b/ui/blockmesh.js
@@ -2225,7 +2225,7 @@ export function updateBlockColorAndHighlight(mesh, selectedColor) {
   };
 
   const logColorResolutionDebug = (stage, details = {}) => {
-    console.debug("[color][workspace-debug]", {
+    console.log("[color][workspace-debug]", {
       stage,
       mainWorkspaceId: Blockly.getMainWorkspace()?.id ?? null,
       ...details,

--- a/ui/blockmesh.js
+++ b/ui/blockmesh.js
@@ -2224,6 +2224,20 @@ export function updateBlockColorAndHighlight(mesh, selectedColor) {
     TShirt: "TSHIRT_COLOR",
   };
 
+  const logColorResolutionDebug = (stage, details = {}) => {
+    console.debug("[color][workspace-debug]", {
+      stage,
+      mainWorkspaceId: Blockly.getMainWorkspace()?.id ?? null,
+      ...details,
+    });
+  };
+
+  const isBlockFromCurrentWorkspace = (candidateBlock) => {
+    const mainWorkspace = Blockly.getMainWorkspace();
+    if (!candidateBlock || !mainWorkspace) return true;
+    return candidateBlock.workspace?.id === mainWorkspace.id;
+  };
+
   // ---------- main ----------
   let block = null;
 
@@ -2240,6 +2254,11 @@ export function updateBlockColorAndHighlight(mesh, selectedColor) {
       wsBlocks.find((b) => b.type === "set_sky_color");
 
     block = backgroundBlock || skyBlock || meshMap?.["sky"];
+    logColorResolutionDebug("background-block-picked", {
+      selectedBlockId: block?.id ?? null,
+      selectedBlockType: block?.type ?? null,
+      selectedBlockWorkspaceId: block?.workspace?.id ?? null,
+    });
 
     if (!block) {
       // Create sky block
@@ -2253,6 +2272,19 @@ export function updateBlockColorAndHighlight(mesh, selectedColor) {
       const connection = startBlock.getInput("DO").connection;
       if (connection && block.previousConnection)
         connection.connect(block.previousConnection);
+    }
+
+    if (!isBlockFromCurrentWorkspace(block)) {
+      console.warn(
+        "[color] background/sky block belongs to a different workspace",
+        {
+          blockId: block.id,
+          blockType: block.type,
+          blockWorkspaceId: block.workspace?.id ?? null,
+          mainWorkspaceId: Blockly.getMainWorkspace()?.id ?? null,
+        },
+      );
+      return;
     }
 
     withUndoGroup(() => {
@@ -2275,6 +2307,12 @@ export function updateBlockColorAndHighlight(mesh, selectedColor) {
   // Mesh → block
   const root = getAttachedAwareRoot(mesh);
   const blockKey = root?.metadata?.blockKey;
+  logColorResolutionDebug("mesh-color-update-start", {
+    meshName: mesh?.name ?? null,
+    rootName: root?.name ?? null,
+    blockKey: blockKey ?? null,
+    meshMapHasBlockKey: Boolean(blockKey && meshMap?.[blockKey]),
+  });
 
   if (!blockKey || !meshMap?.[blockKey]) {
     const ws = Blockly.getMainWorkspace();
@@ -2301,6 +2339,25 @@ export function updateBlockColorAndHighlight(mesh, selectedColor) {
     return;
   }
   block = meshMap[blockKey];
+  logColorResolutionDebug("mesh-block-resolved", {
+    meshName: mesh?.name ?? null,
+    blockKey,
+    blockId: block?.id ?? null,
+    blockType: block?.type ?? null,
+    blockWorkspaceId: block?.workspace?.id ?? null,
+  });
+
+  if (!isBlockFromCurrentWorkspace(block)) {
+    console.warn("[color] Resolved block belongs to a different workspace", {
+      mesh: mesh?.name,
+      blockKey,
+      blockId: block?.id ?? null,
+      blockType: block?.type ?? null,
+      blockWorkspaceId: block?.workspace?.id ?? null,
+      mainWorkspaceId: Blockly.getMainWorkspace()?.id ?? null,
+    });
+    return;
+  }
 
   const materialName = mesh?.material?.name?.replace(/_clone$/, "");
   const colorIndex = mesh?.metadata?.materialIndex;

--- a/ui/blockmesh.js
+++ b/ui/blockmesh.js
@@ -1218,14 +1218,23 @@ export function updateMeshFromBlock(meshesOrMesh, block, changeEvent) {
       "create_map",
     ].includes(block.type)
   ) {
-    if (flock.meshDebug)
-      console.log("No mesh and not a special block type, returning");
+    console.log(
+      "[color][workspace-debug] updateMeshFromBlock:exit-no-mesh-for-block",
+      {
+        blockId: block?.id ?? null,
+        blockType: block?.type ?? null,
+      },
+    );
     return;
   }
 
   if (block.type === "change_color") {
-    if (flock.meshDebug)
-      console.log("Skipping live update for change_color block");
+    console.log(
+      "[color][workspace-debug] updateMeshFromBlock:exit-change_color_block",
+      {
+        blockId: block?.id ?? null,
+      },
+    );
     return;
   }
 
@@ -1250,8 +1259,13 @@ export function updateMeshFromBlock(meshesOrMesh, block, changeEvent) {
   let cursor = changedBlock;
   while (cursor) {
     if (cursor.type === "change_color") {
-      if (flock.meshDebug)
-        console.log("Skipping live update for change_color subtree");
+      console.log(
+        "[color][workspace-debug] updateMeshFromBlock:exit-change_color_subtree",
+        {
+          changedBlockId: changedBlock?.id ?? null,
+          changedBlockType: changedBlock?.type ?? null,
+        },
+      );
       return;
     }
     cursor = cursor.getParent?.();
@@ -1336,21 +1350,40 @@ export function updateMeshFromBlock(meshesOrMesh, block, changeEvent) {
       block.type === "create_map"
     ) {
       if (changeEvent.type === Blockly.Events.BLOCK_MOVE) {
-        if (flock.meshDebug)
-          console.log(
-            "Ignoring BLOCK_MOVE for scene block with no input change",
-          );
+        console.log(
+          "[color][workspace-debug] updateMeshFromBlock:exit-scene-block-move",
+          {
+            blockId: block?.id ?? null,
+            blockType: block?.type ?? null,
+            eventBlockId: changeEvent?.blockId ?? null,
+          },
+        );
         return;
       }
       changed = "COLOR";
     } else {
-      if (flock.meshDebug)
-        console.log("No relevant change detected, returning");
+      console.log(
+        "[color][workspace-debug] updateMeshFromBlock:exit-no-relevant-change",
+        {
+          blockId: block?.id ?? null,
+          blockType: block?.type ?? null,
+          eventBlockId: changeEvent?.blockId ?? null,
+          eventElement: changeEvent?.element ?? null,
+          eventName: changeEvent?.name ?? null,
+          changedBlockId: changedBlock?.id ?? null,
+          changedBlockType: changedBlock?.type ?? null,
+        },
+      );
       return;
     }
   }
 
-  if (flock.meshDebug) console.log(`Processing change type: ${changed}`);
+  console.log("[color][workspace-debug] updateMeshFromBlock:resolved-change", {
+    blockId: block?.id ?? null,
+    blockType: block?.type ?? null,
+    changed,
+    meshCount: meshes.length,
+  });
 
   if (
     (block.type === "load_object" ||

--- a/ui/blockmesh.js
+++ b/ui/blockmesh.js
@@ -2110,6 +2110,13 @@ function replaceMeshModel(currentMesh, block) {
 }
 
 export function updateBlockColorAndHighlight(mesh, selectedColor) {
+  console.log("[color][workspace-debug] updateBlockColorAndHighlight:enter", {
+    meshName: mesh?.name ?? null,
+    meshType: mesh?.type ?? null,
+    selectedColor: selectedColor ?? null,
+    mainWorkspaceId: Blockly.getMainWorkspace()?.id ?? null,
+  });
+
   // ---------- helpers
   const withUndoGroup = (fn) => {
     try {

--- a/ui/blockmesh.js
+++ b/ui/blockmesh.js
@@ -1170,7 +1170,7 @@ export function updateMeshFromBlock(meshesOrMesh, block, changeEvent) {
     block.workspace.id !== mainWorkspace.id
   ) {
     console.warn(
-      "[color][workspace-debug] Skipping updateMeshFromBlock for block in non-main workspace",
+      "[color][workspace-debug] Block is in non-main workspace; attempting best-effort update",
       {
         blockId: block.id,
         blockType: block.type,
@@ -1178,7 +1178,6 @@ export function updateMeshFromBlock(meshesOrMesh, block, changeEvent) {
         mainWorkspaceId: mainWorkspace.id,
       },
     );
-    return;
   }
 
   if (
@@ -1187,14 +1186,13 @@ export function updateMeshFromBlock(meshesOrMesh, block, changeEvent) {
     changeEvent.workspaceId !== mainWorkspace.id
   ) {
     console.warn(
-      "[color][workspace-debug] Skipping updateMeshFromBlock for event in non-main workspace",
+      "[color][workspace-debug] Event is from non-main workspace; attempting best-effort update",
       {
         eventType: changeEvent.type,
         eventWorkspaceId: changeEvent.workspaceId,
         mainWorkspaceId: mainWorkspace.id,
       },
     );
-    return;
   }
 
   if (flock.meshDebug) {
@@ -1232,7 +1230,9 @@ export function updateMeshFromBlock(meshesOrMesh, block, changeEvent) {
   }
 
   const changedBlock = changeEvent.blockId
-    ? (block?.workspace || mainWorkspace)?.getBlockById(changeEvent.blockId)
+    ? mainWorkspace?.getBlockById(changeEvent.blockId) ||
+      block?.workspace?.getBlockById(changeEvent.blockId) ||
+      null
     : null;
   if (changeEvent.blockId && !changedBlock) {
     console.warn(

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -242,6 +242,11 @@ function applyColorAtPosition(canvasX, canvasY) {
   );
 
   const pickedMesh = pickLeafFromRay(pickRay, scene);
+  console.log("[color][workspace-debug] applyColorAtPosition", {
+    pickedMeshName: pickedMesh?.name ?? null,
+    pickedMeshType: pickedMesh?.type ?? null,
+    selectedColor: window.selectedColor ?? null,
+  });
 
   if (pickedMesh) {
     updateBlockColorAndHighlight(pickedMesh, window.selectedColor);


### PR DESCRIPTION
### Motivation
- Ensure `workspace.clear()` is performed with Blockly events enabled so normal delete/trash semantics run during workspace load. 
- Prevent color-update logic from attempting to use blocks that belong to a different workspace which can cause incorrect behavior or errors. 
- Add diagnostic logging to help track block resolution and workspace association during color updates.

### Description
- Adjusted `loadWorkspaceAndExecute` in `main/files.js` to enable events for the `workspace.clear()` call, then temporarily disable events while clearing `blockHandlerRegistry`, and restore the original events state; added explanatory comments. 
- Added `logColorResolutionDebug` and `isBlockFromCurrentWorkspace` helpers in `ui/blockmesh.js` to surface debugging information and to verify that resolved blocks belong to the main workspace. 
- Inserted debug logs at background/sky selection, mesh resolution start, and mesh-to-block resolution points, and added early-return warnings when a resolved block belongs to a different workspace. 
- Kept existing color-target discovery and apply logic intact while improving resilience and observability.

### Testing
- Ran unit test suite with `yarn test`, which completed successfully. 
- Ran linter checks with `yarn lint`, which reported no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec4e187c28832684516da6578061c0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixes to workspace load/restore so block handlers are reliably rebuilt after loading, reducing lost interactions.
  * Prevents color/mesh updates from crossing between workspaces, avoiding unintended visual mutations.

* **Chores**
  * Expanded diagnostic and workspace-event logging to improve visibility into block/event behavior and help troubleshoot issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->