### PR TITLE
Fix block handler registry cleanup during workspace load

### DIFF
--- a/main/blockhandling.js
+++ b/main/blockhandling.js
@@ -527,12 +527,18 @@ export function initializeBlockHandling() {
     }
 
     // Purge deleted blocks from the registry, then dispatch to handlers.
+    // Guard: only remove if no live block with that ID exists. When
+    // workspaces.load() queues DELETE events during its internal clear()
+    // and flushes them after creating new blocks with the same IDs, the
+    // new handlers must not be evicted.
     if (
       event.type === Blockly.Events.BLOCK_DELETE &&
       Array.isArray(event.ids)
     ) {
       for (const id of event.ids) {
-        blockHandlerRegistry.delete(id);
+        if (!workspace.getBlockById(id)) {
+          blockHandlerRegistry.delete(id);
+        }
       }
     }
 

--- a/main/files.js
+++ b/main/files.js
@@ -3,7 +3,6 @@ import { workspace } from "./blocklyinit.js";
 import { translate } from "./translation.js";
 import { getMetadata } from "meta-png";
 import { AUTOSAVE_KEY } from "../config.js";
-import { blockHandlerRegistry } from "../blocks/blocks.js";
 
 // Function to save the current workspace state
 export function saveWorkspace(workspace) {
@@ -319,14 +318,7 @@ export function loadWorkspaceAndExecute(json, workspace, executeCallback) {
     // Validate JSON before loading into workspace
     const validatedJson = validateBlocklyJson(json);
 
-    // Clear workspace and handlers
-    const eventsWereEnabled = Blockly.Events.isEnabled();
-    if (eventsWereEnabled) Blockly.Events.disable();
-    workspace.clear();
-    blockHandlerRegistry.clear();
-    if (eventsWereEnabled) Blockly.Events.enable();
-
-     // Load the validated JSON
+    // Load the validated JSON
     Blockly.serialization.workspaces.load(validatedJson, workspace);
 
     workspace.scroll(0, 0);


### PR DESCRIPTION
## Summary
This PR fixes a race condition in the block handler registry cleanup that occurred when loading workspaces. The issue was that handlers for newly created blocks were being incorrectly removed during the load process.

## Key Changes
- **Removed manual workspace clearing logic** from `loadWorkspaceAndExecute()` in `files.js`:
  - Deleted explicit `workspace.clear()` and `blockHandlerRegistry.clear()` calls
  - Removed event enable/disable wrapping
  - Now relies on `Blockly.serialization.workspaces.load()` to handle workspace clearing internally

- **Added safety check for block deletion** in `blockhandling.js`:
  - Modified the `BLOCK_DELETE` event handler to only remove handlers for blocks that no longer exist
  - Added guard condition: `if (!workspace.getBlockById(id))` before deleting from registry
  - This prevents handlers from being evicted when `workspaces.load()` queues DELETE events during its internal clear phase, then creates new blocks with the same IDs before flushing those events

## Implementation Details
The root cause was a timing issue: `workspaces.load()` internally clears the workspace and queues DELETE events, but these events are flushed after new blocks with the same IDs have already been created and registered. By checking if a block still exists before removing its handler, we ensure that newly created blocks retain their handlers even if a DELETE event for the old block with the same ID is processed.

https://claude.ai/code/session_01E7VhufX5kQJmQmzgQr2HQp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved workspace loading to properly preserve block state and handler relationships during save and load cycles, preventing potential loss of functionality.

## Performance
* Optimized block registry management during workspace operations to eliminate redundant clearing and improve application responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->