### PR TITLE
Add isValidProjectFileJson helper and centralize project file validation

### DIFF
--- a/main/files.js
+++ b/main/files.js
@@ -726,6 +726,23 @@ function appendSnippetBlocksAtViewport(workspace, blocksJson) {
   });
 }
 
+function isValidProjectFileJson(json) {
+  if (!json || typeof json !== "object") {
+    return false;
+  }
+
+  if (Object.keys(json).length === 0) {
+    return true;
+  }
+
+  return (
+    !!json.blocks &&
+    typeof json.blocks === "object" &&
+    !!json.blocks.blocks &&
+    Array.isArray(json.blocks.blocks)
+  );
+}
+
 // Private helper: process a project file (used by file input and drag-and-drop)
 function processProjectFileDrop(file, workspace, executeCallback) {
   const maxSize = 5 * 1024 * 1024;
@@ -752,13 +769,7 @@ function processProjectFileDrop(file, workspace, executeCallback) {
         throw new Error("File content is too large");
       }
       const json = JSON.parse(text);
-      if (
-        !json ||
-        typeof json !== "object" ||
-        !json.blocks ||
-        typeof json.blocks !== "object" ||
-        !json.blocks.blocks
-      ) {
+      if (!isValidProjectFileJson(json)) {
         throw new Error("Invalid Blockly project file structure");
       }
 
@@ -902,13 +913,7 @@ export function setupFileInput(workspace, executeCallback) {
           throw new Error("File content is too large");
         }
         const json = JSON.parse(text);
-        if (
-          !json ||
-          typeof json !== "object" ||
-          !json.blocks ||
-          typeof json.blocks !== "object" ||
-          !json.blocks.blocks
-        ) {
+        if (!isValidProjectFileJson(json)) {
           throw new Error("Invalid Blockly project file structure");
         }
 
@@ -961,13 +966,7 @@ export async function openFile(workspace, executeCallback) {
         throw new Error("File content is too large");
       }
       const json = JSON.parse(text);
-      if (
-        !json ||
-        typeof json !== "object" ||
-        !json.blocks ||
-        typeof json.blocks !== "object" ||
-        !json.blocks.blocks
-      ) {
+      if (!isValidProjectFileJson(json)) {
         throw new Error("Invalid Blockly project file structure");
       }
       window.loadingCode = true;


### PR DESCRIPTION
### Motivation
- Consolidate repeated JSON structure validation logic for project files to make checks clearer and reduce duplication.
- Improve maintainability when validating imported `.json`/`.flock` project files across different import paths.

### Description
- Introduce a new helper function `isValidProjectFileJson(json)` that validates whether an object is a valid (possibly empty) project payload and that `blocks.blocks` is an array when present.
- Replace three inline validation blocks with calls to `isValidProjectFileJson` in `processProjectFileDrop`, the file input handler in `setupFileInput`, and `openFile`.
- Preserve existing size/type checks and error handling while consolidating the structure validation into a single place.

### Testing
- No new automated tests were added for this refactor. 
- Ran the existing linting and automated test suite; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edbd5cbd7c8326ba29b8b21887ea55)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal file validation mechanisms for improved code organization and consistency across project file-loading operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->