### PR TITLE
Update duplicate placement to track and switch source mesh and highlight chained duplicates

### DIFF
--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -59,6 +59,8 @@ let cameraMode = "play";
 let activePick = null; // [Select mesh?]
 let activeDuplicatePickHandler = null; // [Clone mesh?]
 let stopAxisKeyboard = null; // Axis keyboard active?
+let duplicateModeActive = false;
+let duplicateRafId = null;
 
 // Keep track of things to clean up
 const cleanupFns = [];
@@ -554,6 +556,12 @@ function getScaledSize(mesh) {
 
 // Clean up gizmo state if aborted
 export function exitGizmoState() {
+  duplicateModeActive = false;
+  if (duplicateRafId !== null) {
+    cancelAnimationFrame(duplicateRafId);
+    duplicateRafId = null;
+  }
+
   cleanupScenePick(); // Stop picking
 
   // Properly clean up if duplicating
@@ -980,6 +988,7 @@ function startDuplicatePlacement() {
   meshToClone.showBoundingBox = true;
 
   blockId = meshBlockIdMap[blockKey];
+  duplicateModeActive = true;
 
   setCrosshairCursor();
 
@@ -996,29 +1005,38 @@ function startDuplicatePlacement() {
     const maxAttempts = 20;
 
     const resolveSourceMesh = () => {
+      duplicateRafId = null;
+      if (!duplicateModeActive) return;
+
       const newBlockKey = getBlockKeyFromBlock(newBlock);
       let nextSource = (newBlockKey ? getMeshFromBlockKey(newBlockKey) : null) ||
         getMeshFromBlock(newBlock);
 
       if (!nextSource && attempt < maxAttempts) {
         attempt += 1;
-        requestAnimationFrame(resolveSourceMesh);
+        duplicateRafId = requestAnimationFrame(resolveSourceMesh);
         return;
       }
 
       if (!nextSource) return;
       if (nextSource.parent) nextSource = getRootMesh(nextSource.parent);
 
-      if (meshToClone && meshToClone !== nextSource) {
-        meshToClone.showBoundingBox = false;
+      if (duplicateModeActive) {
+        if (meshToClone && meshToClone !== nextSource) {
+          meshToClone.showBoundingBox = false;
+        }
+        meshToClone = nextSource;
+        gizmoManager.attachToMesh(meshToClone);
+        meshToClone.visibility = 0.001;
+        meshToClone.showBoundingBox = true;
       }
-      meshToClone = nextSource;
-      gizmoManager.attachToMesh(meshToClone);
-      meshToClone.visibility = 0.001;
-      meshToClone.showBoundingBox = true;
     };
 
-    requestAnimationFrame(resolveSourceMesh);
+    if (duplicateRafId !== null) {
+      cancelAnimationFrame(duplicateRafId);
+      duplicateRafId = null;
+    }
+    duplicateRafId = requestAnimationFrame(resolveSourceMesh);
   };
 
   onPickMesh = function (event) {

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -1024,6 +1024,7 @@ function startDuplicatePlacement() {
       if (duplicateModeActive) {
         if (meshToClone && meshToClone !== nextSource) {
           meshToClone.showBoundingBox = false;
+          resetBoundingBoxVisibilityIfManuallyChanged(meshToClone);
         }
         meshToClone = nextSource;
         gizmoManager.attachToMesh(meshToClone);

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -975,7 +975,7 @@ function startDuplicatePlacement() {
 
   // Make sure that if there is already a selected mesh
   // its bounding box is visible so the user knows what they are duplicating
-  const meshToClone = gizmoManager.attachedMesh;
+  let meshToClone = gizmoManager.attachedMesh;
   meshToClone.visibility = 0.001;
   meshToClone.showBoundingBox = true;
 
@@ -984,6 +984,40 @@ function startDuplicatePlacement() {
   setCrosshairCursor();
 
   canvas = flock.scene.getEngine().getRenderingCanvas(); // Get the flock.BABYLON.js canvas
+
+  const updateDuplicateChainSource = (newBlock, workspace) => {
+    if (!newBlock) return;
+
+    highlightBlockById(workspace, newBlock);
+    blockId = newBlock.id;
+    setCrosshairCursor();
+
+    let attempt = 0;
+    const maxAttempts = 20;
+
+    const resolveSourceMesh = () => {
+      const newBlockKey = getBlockKeyFromBlock(newBlock) || newBlock.id;
+      let nextSource = getMeshFromBlockKey(newBlockKey) || getMeshFromBlock(newBlock);
+
+      if (!nextSource && attempt < maxAttempts) {
+        attempt += 1;
+        requestAnimationFrame(resolveSourceMesh);
+        return;
+      }
+
+      if (!nextSource) return;
+      if (nextSource.parent) nextSource = getRootMesh(nextSource.parent);
+
+      if (meshToClone && meshToClone !== nextSource) {
+        meshToClone.showBoundingBox = false;
+      }
+      meshToClone = nextSource;
+      meshToClone.visibility = 0.001;
+      meshToClone.showBoundingBox = true;
+    };
+
+    requestAnimationFrame(resolveSourceMesh);
+  };
 
   onPickMesh = function (event) {
     const canvasRect = canvas.getBoundingClientRect();
@@ -1025,9 +1059,7 @@ function startDuplicatePlacement() {
         workspace,
         pickedPosition,
       );
-      if (newBlock) {
-        highlightBlockById(workspace, newBlock);
-      }
+      updateDuplicateChainSource(newBlock, workspace);
     }
   };
 
@@ -1059,9 +1091,7 @@ function startDuplicatePlacement() {
             workspace,
             pickResult.pickedPoint,
           );
-          if (newBlock) {
-            highlightBlockById(workspace, newBlock);
-          }
+          updateDuplicateChainSource(newBlock, workspace);
         }
       },
       false,

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -1012,6 +1012,7 @@ function startDuplicatePlacement() {
         meshToClone.showBoundingBox = false;
       }
       meshToClone = nextSource;
+      gizmoManager.attachToMesh(meshToClone);
       meshToClone.visibility = 0.001;
       meshToClone.showBoundingBox = true;
     };

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -996,8 +996,9 @@ function startDuplicatePlacement() {
     const maxAttempts = 20;
 
     const resolveSourceMesh = () => {
-      const newBlockKey = getBlockKeyFromBlock(newBlock) || newBlock.id;
-      let nextSource = getMeshFromBlockKey(newBlockKey) || getMeshFromBlock(newBlock);
+      const newBlockKey = getBlockKeyFromBlock(newBlock);
+      let nextSource = (newBlockKey ? getMeshFromBlockKey(newBlockKey) : null) ||
+        getMeshFromBlock(newBlock);
 
       if (!nextSource && attempt < maxAttempts) {
         attempt += 1;


### PR DESCRIPTION
### Motivation

- Allow users to continue duplicating newly created blocks by updating the source mesh and visual cues when chaining duplicates in the scene.

### Description

- Change `meshToClone` from `const` to `let` so it can be updated when the duplicate chain source changes. 
- Add `updateDuplicateChainSource` which highlights the new block, updates `blockId`, sets the crosshair cursor, resolves the new source mesh (with an animation-frame retry loop), and updates `meshToClone` visibility and bounding box. 
- Replace direct `highlightBlockById` calls after `duplicateBlockAndInsert` with `updateDuplicateChainSource(newBlock, workspace)` in both click and keyboard placement paths. 
- Ensure the previous source mesh bounding box is hidden when switching to a new source, and handle cases where the source mesh is not immediately available by retrying up to a limit.

### Testing

- Ran unit and integration tests via `npm test`, which completed successfully. 
- Ran linting via `npm run lint`, which passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef8849a05c8326b17df6134bd21cb8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate element workflow to properly synchronize visual highlighting and element visibility across duplicate chains, ensuring correct visual feedback when placing duplicates through click or keyboard methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->