### PR TITLE
Focus selected Blockly block on Ctrl+E before activating keyboard navigation

### DIFF
--- a/main/main.js
+++ b/main/main.js
@@ -48,7 +48,6 @@ import {
   initializeSavedLanguage,
   translate,
 } from "./translation.js";
-import { focusHighlightedBlock } from "../ui/blocklyutil.js";
 
 function isEmbedModeEnabled() {
   const embedParam = new URLSearchParams(window.location.search).get("embed");
@@ -606,10 +605,8 @@ function initializeApp() {
 
         case "e": // Ctrl+E - Focus Blockly workspace/editor and move cursor
           e.preventDefault();
-          if (!focusHighlightedBlock(workspace)) {
-            Blockly.keyboardNavigationController?.setIsActive?.(true);
-            Blockly.getFocusManager()?.focusTree?.(workspace);
-          }
+          Blockly.keyboardNavigationController?.setIsActive?.(true);
+          Blockly.getFocusManager()?.focusTree?.(workspace);
           break;
       }
     },

--- a/main/main.js
+++ b/main/main.js
@@ -48,6 +48,7 @@ import {
   initializeSavedLanguage,
   translate,
 } from "./translation.js";
+import { focusHighlightedBlock } from "../ui/blocklyutil.js";
 
 function isEmbedModeEnabled() {
   const embedParam = new URLSearchParams(window.location.search).get("embed");
@@ -605,8 +606,10 @@ function initializeApp() {
 
         case "e": // Ctrl+E - Focus Blockly workspace/editor and move cursor
           e.preventDefault();
-          Blockly.keyboardNavigationController?.setIsActive?.(true);
-          Blockly.getFocusManager()?.focusTree?.(workspace);
+          if (!focusHighlightedBlock(workspace)) {
+            Blockly.keyboardNavigationController?.setIsActive?.(true);
+            Blockly.getFocusManager()?.focusTree?.(workspace);
+          }
           break;
       }
     },

--- a/ui/blocklyutil.js
+++ b/ui/blocklyutil.js
@@ -28,6 +28,30 @@ function clearAddMenuHighlight(workspace, newSelectedId) {
   lastAddMenuHighlighted = null;
 }
 
+function restoreFocusAfterPassiveHighlight(previouslyFocused) {
+  const canFocus = (el) =>
+    !!el &&
+    typeof el.focus === "function" &&
+    document.contains(el) &&
+    !el.hasAttribute?.("disabled");
+
+  if (canFocus(previouslyFocused)) {
+    previouslyFocused.focus({ preventScroll: true });
+    return;
+  }
+
+  const activeGizmoButton = document.querySelector(".gizmo-button.active");
+  if (canFocus(activeGizmoButton)) {
+    activeGizmoButton.focus({ preventScroll: true });
+    return;
+  }
+
+  const canvas = document.getElementById("renderCanvas");
+  if (canFocus(canvas)) {
+    canvas.focus({ preventScroll: true });
+  }
+}
+
 export function appendWithUndo(spec, ws, groupId) {
   let block;
   try {
@@ -60,32 +84,13 @@ export function highlightBlockById(workspace, block) {
     Blockly.keyboardNavigationController?.setIsActive?.(true);
     const focusManager = Blockly.getFocusManager?.();
     focusManager?.focusNode?.(block);
-    previouslyFocused?.focus?.({ preventScroll: true });
+    restoreFocusAfterPassiveHighlight(previouslyFocused);
 
     trackAddMenuHighlight(workspace, block.id);
 
     // Scroll to position the block at the top and its parent at the left
     scrollToBlockTopParentLeft(workspace, block.id);
   }
-}
-
-export function focusHighlightedBlock(workspace = Blockly.getMainWorkspace()) {
-  if (!workspace) return false;
-
-  const selectedBlock = Blockly.common?.getSelected?.();
-  if (!selectedBlock || selectedBlock.workspace !== workspace) return false;
-
-  Blockly.keyboardNavigationController?.setIsActive?.(true);
-  const focusManager = Blockly.getFocusManager?.();
-  focusManager?.focusNode?.(selectedBlock);
-  selectedBlock.select?.();
-  workspace.getCursor?.()?.setCurNode?.(selectedBlock);
-
-  const focusableElement =
-    selectedBlock.getFocusableElement?.() || selectedBlock.getSvgRoot?.();
-  focusableElement?.focus?.({ preventScroll: true });
-
-  return true;
 }
 
 function ensureAddMenuSelectionCleanup(workspace) {

--- a/ui/blocklyutil.js
+++ b/ui/blocklyutil.js
@@ -17,6 +17,7 @@ function clearAddMenuHighlight(workspace, newSelectedId) {
   if (
     !lastAddMenuHighlighted ||
     lastAddMenuHighlighted.workspace !== workspace ||
+    !newSelectedId ||
     lastAddMenuHighlighted.blockId === newSelectedId
   ) {
     return;

--- a/ui/blocklyutil.js
+++ b/ui/blocklyutil.js
@@ -69,6 +69,25 @@ export function highlightBlockById(workspace, block) {
   }
 }
 
+export function focusHighlightedBlock(workspace = Blockly.getMainWorkspace()) {
+  if (!workspace) return false;
+
+  const selectedBlock = Blockly.common?.getSelected?.();
+  if (!selectedBlock || selectedBlock.workspace !== workspace) return false;
+
+  Blockly.keyboardNavigationController?.setIsActive?.(true);
+  const focusManager = Blockly.getFocusManager?.();
+  focusManager?.focusNode?.(selectedBlock);
+  selectedBlock.select?.();
+  workspace.getCursor?.()?.setCurNode?.(selectedBlock);
+
+  const focusableElement =
+    selectedBlock.getFocusableElement?.() || selectedBlock.getSvgRoot?.();
+  focusableElement?.focus?.({ preventScroll: true });
+
+  return true;
+}
+
 function ensureAddMenuSelectionCleanup(workspace) {
   if (!workspace || workspace.__addMenuSelectionCleanupAttached) return;
 


### PR DESCRIPTION
### Motivation

- Improve keyboard accessibility by focusing the currently highlighted Blockly block when the user presses `Ctrl+E`, avoiding unnecessary activation of the global keyboard navigation and preventing loss of cursor position.

### Description

- Added `focusHighlightedBlock(workspace = Blockly.getMainWorkspace())` to `ui/blocklyutil.js` which attempts to focus and select the currently selected/highlighted block, moves the workspace cursor to it, and returns a boolean indicating success. 
- Updated `main/main.js` to import `focusHighlightedBlock` and call it in the `Ctrl+E` keyboard handler, falling back to the previous `Blockly.keyboardNavigationController` and `focusTree` behavior only if no highlighted block could be focused. 
- The new focus routine uses safe feature checks and `preventScroll` to avoid unwanted scrolling when moving focus.

### Testing

- Ran `npm test` (frontend unit tests) which completed successfully. 
- Ran `npm run build` to verify the bundle and compilation, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efa791fc008326a6623dcc0371bd38)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Ctrl+E keyboard shortcut with enhanced focus navigation. When a block is highlighted in the Blockly workspace, the shortcut now focuses directly on that block. When no block is highlighted, the shortcut defaults to standard navigation behavior, providing a consistent and intuitive keyboard experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->