### PR TITLE
Disable automatic GLTF animation playback when loading models

### DIFF
--- a/api/models.js
+++ b/api/models.js
@@ -352,6 +352,16 @@ export const flockModels = {
         flock.modelPath,
         modelName,
         flock.scene,
+        undefined,
+        undefined,
+        flock.BABYLON_LOADER?.GLTFLoaderAnimationStartMode
+          ? {
+              gltf: {
+                animationStartMode:
+                  flock.BABYLON_LOADER.GLTFLoaderAnimationStartMode.NONE,
+              },
+            }
+          : undefined,
       );
       flock.modelsBeingLoaded[modelName] = loadPromise;
 


### PR DESCRIPTION
### Motivation
- Ensure glTF model animations do not start automatically when models are loaded via `SceneLoader.LoadAssetContainerAsync`, allowing the app to control animation start explicitly.

### Description
- Add extra parameters to `SceneLoader.LoadAssetContainerAsync` so that when `flock.BABYLON_LOADER?.GLTFLoaderAnimationStartMode` is present the call passes `{ gltf: { animationStartMode: flock.BABYLON_LOADER.GLTFLoaderAnimationStartMode.NONE } }` to disable automatic animation start.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f11784b1848326a7626f633be40fbb)