### PR TITLE
Handle mesh creation when blocks are moved to enabled chains

### DIFF
--- a/ui/blockmesh.js
+++ b/ui/blockmesh.js
@@ -486,6 +486,10 @@ export function updateOrCreateMeshFromBlock(block, changeEvent) {
     changeEvent?.type === Blockly.Events.BLOCK_CREATE &&
     isConnectedToEnabledChain &&
     meshes.length === 0;
+  const isConnectedMove =
+    changeEvent?.type === Blockly.Events.BLOCK_MOVE &&
+    isConnectedToEnabledChain &&
+    meshes.length === 0;
 
   if (!isConnectedToEnabledChain) {
     if (meshes.length) {
@@ -496,7 +500,7 @@ export function updateOrCreateMeshFromBlock(block, changeEvent) {
   if ((window.loadingCode && !changeEvent?.recordUndo) || block.disposed)
     return;
   const alreadyCreatingMesh = meshMap[block.id] !== undefined;
-  if (!alreadyCreatingMesh && (isEnabledEvent || isImmediateEnabledCreate)) {
+  if (!alreadyCreatingMesh && (isEnabledEvent || isImmediateEnabledCreate || isConnectedMove)) {
     if (sceneControllerTypes.includes(block.type)) {
       updateMeshFromBlock(meshes, block, changeEvent);
     } else {


### PR DESCRIPTION
## Summary
This change extends the mesh creation logic to handle block move events in addition to block creation events. Previously, meshes were only created when a block was first created and connected to an enabled chain. Now, meshes are also created when a block is moved into an enabled chain.

## Key Changes
- Added `isConnectedMove` condition to detect when a block is moved (`BLOCK_MOVE` event) to an enabled chain with no existing meshes
- Updated the mesh creation condition to trigger on `isConnectedMove` in addition to existing `isEnabledEvent` and `isImmediateEnabledCreate` conditions

## Implementation Details
The new logic mirrors the existing `isImmediateEnabledCreate` pattern, checking for:
- A `BLOCK_MOVE` change event type
- The block being connected to an enabled chain
- No existing meshes for the block

This ensures that when users move blocks into an enabled chain, the corresponding 3D mesh is created immediately, providing consistent behavior whether blocks are created in-place or moved into position.

https://claude.ai/code/session_018FzuL691PTMx5puGLJd4i1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved mesh creation and updates when moving blocks connected to the enabled chain, ensuring proper handling of block movement interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->