### PR TITLE
Stop animation groups when loading 3D models

### DIFF
--- a/api/models.js
+++ b/api/models.js
@@ -359,6 +359,7 @@ export const flockModels = {
 
       loadPromise.then((container) => {
         container.addAllToScene();
+        container.animationGroups.forEach((ag) => ag.stop());
 
         container.meshes.forEach((m) => {
           m.metadata = m.metadata || {};


### PR DESCRIPTION
## Summary
Added logic to stop all animation groups immediately after loading 3D model containers into the scene.

## Key Changes
- Stop all animation groups on the loaded container before processing meshes
- This prevents animations from auto-playing when models are loaded

## Implementation Details
The `container.animationGroups.forEach((ag) => ag.stop())` call is executed right after `container.addAllToScene()`, ensuring that any animations defined in the loaded model are halted before the mesh metadata processing begins. This gives callers control over when and how animations should be played.

https://claude.ai/code/session_01PhP6TQpjYMuBT8rLXgxAhr