### PR TITLE
Fix rotation gizmo to sync quaternion with Euler angles

### DIFF
--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -1371,7 +1371,7 @@ function handleScaleGizmo() {
 
 // Rotation: Allow the user to rotate the mesh by dragging it
 function handleRotationGizmo() {
-  configureRotationGizmo(gizmoManager);
+  configureRotationGizmo(gizmoManager, { updateToMatchAttachedMesh: true });
 
   // Show that rotation is active
   const rotationButton = document.getElementById("rotationButton");
@@ -1451,6 +1451,11 @@ function handleRotationGizmo() {
       // Is there any physics to restore?
       if (mesh?.physics && mesh.savedMotionType != null) {
         mesh.physics.setMotionType(mesh.savedMotionType);
+      }
+
+      if (mesh?.rotationQuaternion) {
+        mesh.rotation = mesh.rotationQuaternion.toEulerAngles();
+        mesh.rotationQuaternion = null;
       }
 
       updateRotationBlock(mesh); // Update blockly block


### PR DESCRIPTION
## Summary
Fixed the rotation gizmo to properly synchronize mesh rotation state by converting quaternion-based rotations back to Euler angles after interaction.

## Key Changes
- Updated `configureRotationGizmo()` call to pass `{ updateToMatchAttachedMesh: true }` option, ensuring the gizmo stays synchronized with the mesh's current rotation state
- Added quaternion-to-Euler conversion logic after rotation gizmo interaction completes:
  - Converts `mesh.rotationQuaternion` to Euler angles and assigns to `mesh.rotation`
  - Clears the quaternion to prevent dual rotation representations

## Implementation Details
The fix addresses a rotation state inconsistency where meshes using quaternion-based rotation could end up with misaligned rotation representations. By converting quaternions back to Euler angles after gizmo interaction and clearing the quaternion property, we ensure a single source of truth for the mesh's rotation state, which is then properly reflected in the Blockly rotation block update.

https://claude.ai/code/session_015w2ie2ZbMdLcLRi7Kk4Rhm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rotation gizmo synchronization to ensure mesh rotation states are properly matched when attached and correctly normalized after rotation interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->