### PR TITLE
Crosshair cursor for colour placement

### DIFF
--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -218,13 +218,11 @@ function pickMeshFromCanvas() {
 
     const [canvasX, canvasY] = getCanvasXAndCanvasYValues(event, canvasRect);
     applyColorAtPosition(canvasX, canvasY);
-    document.body.style.cursor = "crosshair";
-    canvas.style.cursor = "crosshair";
   };
 
   startCanvasKeyboardMode((x, y) => applyColorAtPosition(x, y));
-  document.body.style.cursor = "crosshair";
-  canvas.style.cursor = "crosshair";
+  document.body.style.cursor = "crosshair"; // works
+  flock.scene.defaultCursor = "crosshair";
 
   setTimeout(() => {
     window.addEventListener("click", onPickMesh);


### PR DESCRIPTION
The cursor should be a crosshair when you are filling with the colour picker. It isn't, but I think this fixes it. I haven't fully tested whether this has any knock on effects. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cursor display consistency when selecting objects on the canvas. Users will now experience more reliable and consistent cursor behavior during object picking interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->