### PR TITLE
Area menu overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -1411,5 +1411,6 @@
       window.BABYLON_SKIP_FONT_LOADING = true;
     </script>
     <script type="module" src="/main/main.js"></script>
+    <script type="module" src="/main/accessibility.js"></script>
   </body>
 </html>

--- a/main/accessibility.js
+++ b/main/accessibility.js
@@ -4,11 +4,11 @@
 const AccessibilityManager = {
   overlay: null,
   areas: [
-    { selector: "#menuleft", label: "1" }, // Top left menu
+    { selector: "#menuleft", label: "1" }, // Top left menu (line 148 input.js - demo menu is excluded?)
     { selector: "#menuright", label: "2" }, // Top right
     { selector: "#renderCanvas", label: "3" }, // Main canvas
     { selector: "#gizmoButtons", label: "4" }, // Gizmos
-    { selector: "#resizer", label: "5" }, // Resizer
+    { selector: "#resizer", label: "5", pad: -3 }, // Resizer
     {
       selector: "#blockly-0",
       label: "6",
@@ -104,11 +104,12 @@ const AccessibilityManager = {
         container.appendChild(badge);
 
         const highlight = document.createElement("div");
+        const pad = area.pad ?? 1;
         highlight.className = "area-outline";
-        highlight.style.top = `${rect.top}px`;
-        highlight.style.left = `${rect.left}px`;
-        highlight.style.width = `${rect.width}px`;
-        highlight.style.height = `${rect.height}px`;
+        highlight.style.top = `${rect.top - pad}px`;
+        highlight.style.left = `${rect.left - pad}px`;
+        highlight.style.width = `${rect.width + pad * 2}px`;
+        highlight.style.height = `${rect.height + pad * 2}px`;
         container.appendChild(highlight);
       }
     });

--- a/main/accessibility.js
+++ b/main/accessibility.js
@@ -9,13 +9,7 @@ const AccessibilityManager = {
     { selector: "#renderCanvas", label: "3" }, // Main canvas
     { selector: "#gizmoButtons", label: "4" }, // Gizmos
     { selector: "#resizer", label: "5", pad: -3 }, // Resizer
-    {
-      selector: "#blockly-0",
-      label: "6",
-      onActivate() {
-        document.querySelector("#blocklyDiv")?.focus();
-      },
-    }, // Blockly toolbox
+    { selector: ".blocklyToolbox", label: "6" }, // Blockly toolbox
     { selector: "svg.blocklySvg", label: "7" }, // Block workspace
   ],
 
@@ -65,6 +59,7 @@ const AccessibilityManager = {
             const area = this.areas.find((a) => a.label === e.key);
             if (area) {
               e.preventDefault(); // Don't type the number!
+              this.toggle(false); // Close the menu
 
               const el = document.querySelector(area.selector);
               const focusable =
@@ -72,10 +67,7 @@ const AccessibilityManager = {
                   'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
                 ) ?? el; // Focus the area itself if no suitable child
 
-              if (focusable) {
-                this.toggle(false);
-                focusable.focus();
-              }
+              focusable?.focus();
             }
           }
         }

--- a/main/accessibility.js
+++ b/main/accessibility.js
@@ -1,6 +1,5 @@
 // Area menu accessed with Ctrl + B to quickly skip to
 // different areas on the interface
-let DEBUG = true;
 
 const AccessibilityManager = {
   overlay: null,
@@ -23,7 +22,6 @@ const AccessibilityManager = {
   init() {
     this.createOverlay();
     this.setupListeners();
-    if (DEBUG) console.log("🐟 Area overlay initialized");
   },
 
   createOverlay() {
@@ -37,8 +35,6 @@ const AccessibilityManager = {
     `;
     document.body.appendChild(div);
     this.overlay = div;
-
-    if (DEBUG) console.log("🐟 Overlay div", this.overlay);
   },
 
   toggle(show) {
@@ -54,13 +50,11 @@ const AccessibilityManager = {
       (e) => {
         // Open: Ctrl+B
         if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "b") {
-          if (DEBUG) console.log("🐟 Ctrl B pressed");
           e.preventDefault();
           this.toggle(true);
         }
         // Close: Escape
         if (e.key === "Escape") {
-          if (DEBUG) console.log("🐟 Escape pressed");
           this.toggle(false);
         }
         // Handle number keys

--- a/main/accessibility.js
+++ b/main/accessibility.js
@@ -15,18 +15,10 @@ const AccessibilityManager = {
     // Create the element dynamically so you don't have to edit index.html
     const div = document.createElement("div");
     div.id = "area-menu-overlay";
-    div.className = "area-menu-content";
+    div.className = "hidden";
     div.classList.add("hidden");
     div.innerHTML = `
-    
-        <h3>Jump to Area</h3>
-        <ul>
-            <li><kbd>1</kbd> 3D View</li>
-            <li><kbd>2</kbd> Blocks</li>
-            <li><kbd>3</kbd> Code Preview</li>
-        </ul>
-        <p>Press <kbd>Esc</kbd> to close</p>
-          
+        <div id="area-menu-content"> </div>        
     `;
     document.body.appendChild(div);
     this.overlay = div;
@@ -36,9 +28,8 @@ const AccessibilityManager = {
 
   toggle(show) {
     if (this.overlay) {
+      if (show) this.renderHighlights();
       this.overlay.classList.toggle("hidden", !show);
-      if (DEBUG)
-        console.log("🐟 Visibility", this.overlay.classList.contains("hidden"));
     }
   },
 
@@ -60,6 +51,47 @@ const AccessibilityManager = {
       },
       true,
     ); // 'true' uses the capture phase to beat Blockly's listeners
+  },
+
+  renderHighlights() {
+    const container = document.getElementById("area-menu-content");
+    container.innerHTML = ""; // Clear old numbers
+
+    const areas = [
+      { selector: "#menuleft", label: "1" }, // Top left menu
+      { selector: "#menuright", label: "2" }, // Top right
+      { selector: "#renderCanvas", label: "3" }, // Main canvas
+      { selector: "#gizmoButtons", label: "4" }, // Gizmos
+      { selector: "#resizer", label: "5" }, // Resizer
+      { selector: "#blockly-0", label: "6" }, // Block selector
+      //{ selector: "#.blocklyWorkspace", label: "7" }, // Block workspace
+    ];
+
+    areas.forEach((area) => {
+      const el = document.querySelector(area.selector);
+      if (el && el.offsetWidth > 0) {
+        const rect = el.getBoundingClientRect();
+
+        const badge = document.createElement("div");
+        badge.className = "area-number-badge";
+        badge.innerText = area.label;
+
+        // Position the badge exactly over the element
+        badge.style.top = `${rect.top + 20}px`;
+        badge.style.left = `${rect.left + 20}px`;
+
+        container.appendChild(badge);
+
+        // Optional: Add a dashed border highlight to the area itself
+        const highlight = document.createElement("div");
+        highlight.className = "area-outline";
+        highlight.style.top = `${rect.top}px`;
+        highlight.style.left = `${rect.left}px`;
+        highlight.style.width = `${rect.width}px`;
+        highlight.style.height = `${rect.height}px`;
+        container.appendChild(highlight);
+      }
+    });
   },
 };
 

--- a/main/accessibility.js
+++ b/main/accessibility.js
@@ -45,7 +45,7 @@ const AccessibilityManager = {
         // Open: Ctrl+B
         if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "b") {
           e.preventDefault();
-          this.toggle(true);
+          this.toggle(this.overlay.classList.contains("hidden"));
         }
         // Close: Escape
         if (e.key === "Escape") {

--- a/main/accessibility.js
+++ b/main/accessibility.js
@@ -4,6 +4,21 @@ let DEBUG = true;
 
 const AccessibilityManager = {
   overlay: null,
+  areas: [
+    { selector: "#menuleft", label: "1" }, // Top left menu
+    { selector: "#menuright", label: "2" }, // Top right
+    { selector: "#renderCanvas", label: "3" }, // Main canvas
+    { selector: "#gizmoButtons", label: "4" }, // Gizmos
+    { selector: "#resizer", label: "5" }, // Resizer
+    {
+      selector: "#blockly-0",
+      label: "6",
+      onActivate() {
+        document.querySelector("#blocklyDiv")?.focus();
+      },
+    }, // Blockly toolbox
+    { selector: "svg.blocklySvg", label: "7" }, // Block workspace
+  ],
 
   init() {
     this.createOverlay();
@@ -48,6 +63,28 @@ const AccessibilityManager = {
           if (DEBUG) console.log("🐟 Escape pressed");
           this.toggle(false);
         }
+        // Handle number keys
+        if (e.key >= "1" && e.key <= "9") {
+          // Only if the overlay is open (otherwise you can't type numbers)
+          if (!this.overlay.classList.contains("hidden")) {
+            // Find the area and set the focus
+            const area = this.areas.find((a) => a.label === e.key);
+            if (area) {
+              e.preventDefault(); // Don't type the number!
+
+              const el = document.querySelector(area.selector);
+              const focusable =
+                el?.querySelector(
+                  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+                ) ?? el; // Focus the area itself if no suitable child
+
+              if (focusable) {
+                this.toggle(false);
+                focusable.focus();
+              }
+            }
+          }
+        }
       },
       true,
     ); // 'true' uses the capture phase to beat Blockly's listeners
@@ -57,19 +94,9 @@ const AccessibilityManager = {
     const container = document.getElementById("area-menu-content");
     container.innerHTML = ""; // Clear old numbers
 
-    const areas = [
-      { selector: "#menuleft", label: "1" }, // Top left menu
-      { selector: "#menuright", label: "2" }, // Top right
-      { selector: "#renderCanvas", label: "3" }, // Main canvas
-      { selector: "#gizmoButtons", label: "4" }, // Gizmos
-      { selector: "#resizer", label: "5" }, // Resizer
-      { selector: "#blockly-0", label: "6" }, // Block selector
-      { selector: "#blocklyDiv", label: "7" }, // Block workspace
-    ];
-
-    areas.forEach((area) => {
+    this.areas.forEach((area) => {
       const el = document.querySelector(area.selector);
-      if (el && el.offsetWidth > 0) {
+      if (el && (el.offsetWidth > 0 || el.getBoundingClientRect().width > 0)) {
         const rect = el.getBoundingClientRect();
 
         const badge = document.createElement("div");

--- a/main/accessibility.js
+++ b/main/accessibility.js
@@ -64,7 +64,7 @@ const AccessibilityManager = {
       { selector: "#gizmoButtons", label: "4" }, // Gizmos
       { selector: "#resizer", label: "5" }, // Resizer
       { selector: "#blockly-0", label: "6" }, // Block selector
-      //{ selector: "#.blocklyWorkspace", label: "7" }, // Block workspace
+      { selector: "#blocklyDiv", label: "7" }, // Block workspace
     ];
 
     areas.forEach((area) => {
@@ -76,13 +76,12 @@ const AccessibilityManager = {
         badge.className = "area-number-badge";
         badge.innerText = area.label;
 
-        // Position the badge exactly over the element
-        badge.style.top = `${rect.top + 20}px`;
-        badge.style.left = `${rect.left + 20}px`;
+        // Position the badge in the center of the area
+        badge.style.top = `${rect.top + rect.height / 2 - 20}px`;
+        badge.style.left = `${rect.left + rect.width / 2 - 20}px`;
 
         container.appendChild(badge);
 
-        // Optional: Add a dashed border highlight to the area itself
         const highlight = document.createElement("div");
         highlight.className = "area-outline";
         highlight.style.top = `${rect.top}px`;

--- a/main/accessibility.js
+++ b/main/accessibility.js
@@ -1,0 +1,67 @@
+// Area menu accessed with Ctrl + B to quickly skip to
+// different areas on the interface
+let DEBUG = true;
+
+const AccessibilityManager = {
+  overlay: null,
+
+  init() {
+    this.createOverlay();
+    this.setupListeners();
+    if (DEBUG) console.log("🐟 Area overlay initialized");
+  },
+
+  createOverlay() {
+    // Create the element dynamically so you don't have to edit index.html
+    const div = document.createElement("div");
+    div.id = "area-menu-overlay";
+    div.className = "area-menu-content";
+    div.classList.add("hidden");
+    div.innerHTML = `
+    
+        <h3>Jump to Area</h3>
+        <ul>
+            <li><kbd>1</kbd> 3D View</li>
+            <li><kbd>2</kbd> Blocks</li>
+            <li><kbd>3</kbd> Code Preview</li>
+        </ul>
+        <p>Press <kbd>Esc</kbd> to close</p>
+          
+    `;
+    document.body.appendChild(div);
+    this.overlay = div;
+
+    if (DEBUG) console.log("🐟 Overlay div", this.overlay);
+  },
+
+  toggle(show) {
+    if (this.overlay) {
+      this.overlay.classList.toggle("hidden", !show);
+      if (DEBUG)
+        console.log("🐟 Visibility", this.overlay.classList.contains("hidden"));
+    }
+  },
+
+  setupListeners() {
+    window.addEventListener(
+      "keydown",
+      (e) => {
+        // Open: Ctrl+B
+        if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "b") {
+          if (DEBUG) console.log("🐟 Ctrl B pressed");
+          e.preventDefault();
+          this.toggle(true);
+        }
+        // Close: Escape
+        if (e.key === "Escape") {
+          if (DEBUG) console.log("🐟 Escape pressed");
+          this.toggle(false);
+        }
+      },
+      true,
+    ); // 'true' uses the capture phase to beat Blockly's listeners
+  },
+};
+
+// Start it up
+AccessibilityManager.init();

--- a/style.css
+++ b/style.css
@@ -1526,8 +1526,8 @@ body.color-picker-open #renderCanvas {
 
 .area-outline {
   position: absolute;
-  border: 5px solid var(--color-border);
+  outline: 5px solid var(--color-border);
+  background: rgba(128, 128, 128, 0.15);
   pointer-events: none; /* Let clicks pass through */
   z-index: 10000;
-  box-sizing: border-box;
 }

--- a/style.css
+++ b/style.css
@@ -1492,18 +1492,7 @@ body.color-picker-open #renderCanvas {
   animation: circle-invalid-flash 0.25s ease-out;
 }
 
-kbd {
-  background: #eee;
-  border: 1px solid #b4b4b4;
-  border-radius: 3px;
-  padding: 1px 4px;
-  color: #333;
-}
-
-.area-menu-content {
-  border: 10px solid --color-border;
-  background: var(--color-bg-overlay);
-}
+/* Area Menu Styles */
 
 #area-menu-overlay {
   position: fixed;
@@ -1511,11 +1500,34 @@ kbd {
   left: 0;
   width: 100vw;
   height: 100vh;
-  background: --color-bg-overlay;
+  background: var(--color-bg-overlay);
   display: flex;
   flex-direction: column;
+  z-index: 10000; /* Ensure it stays on top of Babylon canvas */
+  color: var(--color-text-on-primary);
+}
+
+.area-number-badge {
+  position: absolute;
+  background: var(--color-text-primary);
+  color: var(--color-button-bg);
+  width: 40px;
+  height: 40px;
+  border-radius: 20%;
+  display: flex;
   justify-content: center;
   align-items: center;
-  z-index: 10000; /* Ensure it stays on top of Babylon canvas */
-  color: white;
+  font-size: 30px;
+  font-weight: bold;
+  box-shadow: 0 0 15px var(--color-shadow);
+  z-index: 10001;
+  border: 3px solid var(--color-button-bg);
+}
+
+.area-outline {
+  position: absolute;
+  border: 5px solid var(--color-border);
+  pointer-events: none; /* Let clicks pass through */
+  z-index: 10000;
+  box-sizing: border-box;
 }

--- a/style.css
+++ b/style.css
@@ -1051,7 +1051,7 @@ button {
 }
 
 .hidden {
-  display: none;
+  display: none !important;
 }
 
 .close-button {
@@ -1179,9 +1179,9 @@ body.embed-mode #canvasArea {
 body.embed-mode #embedShell {
   background: #ffffff;
   border: 2px solid #511d91;
-  border-radius: 12px;   /* adjust as needed */
+  border-radius: 12px; /* adjust as needed */
   box-sizing: border-box;
-  overflow: hidden;      /* important: clips inner content to rounded corners */
+  overflow: hidden; /* important: clips inner content to rounded corners */
 }
 
 body.embed-mode #embedBottomBar a,
@@ -1490,4 +1490,32 @@ body.color-picker-open #renderCanvas {
 
 .canvas-selector-circle--invalid-press {
   animation: circle-invalid-flash 0.25s ease-out;
+}
+
+kbd {
+  background: #eee;
+  border: 1px solid #b4b4b4;
+  border-radius: 3px;
+  padding: 1px 4px;
+  color: #333;
+}
+
+.area-menu-content {
+  border: 10px solid --color-border;
+  background: var(--color-bg-overlay);
+}
+
+#area-menu-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: --color-bg-overlay;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  z-index: 10000; /* Ensure it stays on top of Babylon canvas */
+  color: white;
 }


### PR DESCRIPTION
# Summary
Press Ctrl + B (or presumably also ⌘+B but I don't have a Mac to test) to bring up an area menu overlay

<img width="2109" height="1323" alt="image" src="https://github.com/user-attachments/assets/745cd75d-57fd-4291-95e4-60ab925d5e3e" />

Press the number key to set the focus to the first element in that area. Press Esc to exit the overlay menu.

## Might be an issue
- The demo menu appears to have been deliberately excluded from the tab order in `input.js` which feels a bit weird when you select area 1 and can't get to that menu. I haven't changed it because I didn't know what the rationale behind that was. 

### AI usage
I built the overlay up from initially just being able to be toggled on and off to being able to focus the areas, having looked at the Makecode implementation. Google AI mode helped with initial code. Later Claude Sonnet 4.6 helped with a few issues with the blockly toolbox. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* **Accessibility keyboard navigation**: Introduced keyboard shortcut (Ctrl/⌘+B) to open an overlay displaying numbered areas within the application. Users can press number keys to navigate directly to specific regions, with visual highlights indicating selectable areas. Press Escape to close the overlay without changing focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->