### PR TITLE
Fix delete gizmo mesh picking with async timeout

### DIFF
--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -1704,11 +1704,13 @@ function handleDeleteGizmo() {
 
   function applyDelete(pickedMesh) {
     if (!pickedMesh || pickedMesh.name === "ground") {
-      if (
-        document.getElementById("deleteButton")?.classList.contains("active")
-      ) {
-        pickMeshFromScene(applyDelete, false);
-      }
+      setTimeout(() => {
+        if (
+          document.getElementById("deleteButton")?.classList.contains("active")
+        ) {
+          pickMeshFromScene(applyDelete, false);
+        }
+      }, 0);
       return;
     }
     const blockKey = findParentWithBlockId(pickedMesh)?.metadata?.blockKey;


### PR DESCRIPTION
## Summary
Wrapped the recursive mesh picking call in `applyDelete` with a `setTimeout` to defer execution and prevent synchronous recursion issues when the delete button remains active.

## Key Changes
- Wrapped the `pickMeshFromScene(applyDelete, false)` call in a `setTimeout` with 0ms delay
- This defers the recursive mesh picking to the next event loop iteration
- Prevents potential stack overflow or synchronous recursion issues when the delete button state persists

## Implementation Details
The change ensures that when `applyDelete` is called with an invalid mesh (null or ground), and the delete button is still active, the subsequent call to `pickMeshFromScene` is scheduled asynchronously rather than executed immediately. This breaks the synchronous call chain and allows the current execution context to complete before attempting to pick another mesh.

https://claude.ai/code/session_01YNQ2JdTh9dgs7YdG7s2aEZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed mesh deletion interaction to improve reliability of the delete function when no valid mesh is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->