### PR TITLE
Improve area menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -1411,6 +1411,5 @@
       window.BABYLON_SKIP_FONT_LOADING = true;
     </script>
     <script type="module" src="/main/main.js"></script>
-    <script type="module" src="/main/accessibility.js"></script>
   </body>
 </html>

--- a/main/accessibility.js
+++ b/main/accessibility.js
@@ -33,7 +33,13 @@ const AccessibilityManager = {
 
   toggle(show) {
     if (this.overlay) {
-      if (show) this.renderHighlights();
+      if (show) {
+        this.renderHighlights();
+        setTimeout(
+          () => this.overlay.querySelector(".area-number-badge")?.focus(),
+          0,
+        );
+      }
       this.overlay.classList.toggle("hidden", !show);
     }
   },
@@ -57,23 +63,48 @@ const AccessibilityManager = {
           if (!this.overlay.classList.contains("hidden")) {
             // Find the area and set the focus
             const area = this.areas.find((a) => a.label === e.key);
-            if (area) {
-              e.preventDefault(); // Don't type the number!
-              this.toggle(false); // Close the menu
-
-              const el = document.querySelector(area.selector);
-              const focusable =
-                el?.querySelector(
-                  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
-                ) ?? el; // Focus the area itself if no suitable child
-
-              focusable?.focus();
-            }
+            if (area) this.activateArea(area);
           }
+        }
+        // Tab through badges when overlay is open
+        if (e.key === "Tab" && !this.overlay.classList.contains("hidden")) {
+          e.preventDefault();
+          const badges = [
+            ...this.overlay.querySelectorAll(".area-number-badge"),
+          ];
+          if (badges.length === 0) return;
+          const currentIndex = badges.indexOf(document.activeElement);
+          const nextIndex = e.shiftKey
+            ? (currentIndex - 1 + badges.length) % badges.length
+            : (currentIndex + 1) % badges.length;
+          badges[nextIndex].focus();
+        }
+        // Enter opens the area if a badge is focused
+        if (e.key === "Enter" && !this.overlay.classList.contains("hidden")) {
+          const focused = document.activeElement;
+          // Do nothing if a badge is not focused
+          if (!focused?.classList.contains("area-number-badge")) return;
+          e.preventDefault();
+
+          // Find the area and set the focus
+          const area = this.areas.find((a) => a.label === focused.innerText);
+          if (area) this.activateArea(area);
         }
       },
       true,
     ); // 'true' uses the capture phase to beat Blockly's listeners
+  },
+
+  // Set the focus to this area and close overlay
+  activateArea(area) {
+    this.toggle(false); // Close the menu
+    const el = document.querySelector(area.selector);
+    const focusable =
+      el?.querySelector(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      ) ?? el; // Focus the area itself if no suitable child
+
+    focusable?.focus();
   },
 
   renderHighlights() {
@@ -87,6 +118,7 @@ const AccessibilityManager = {
 
         const badge = document.createElement("div");
         badge.className = "area-number-badge";
+        badge.tabIndex = 0; // Make badges focusable
         badge.innerText = area.label;
 
         // Position the badge in the center of the area

--- a/main/main.js
+++ b/main/main.js
@@ -48,6 +48,7 @@ import {
   initializeSavedLanguage,
   translate,
 } from "./translation.js";
+import "./accessibility.js";
 
 function isEmbedModeEnabled() {
   const embedParam = new URLSearchParams(window.location.search).get("embed");

--- a/style.css
+++ b/style.css
@@ -1507,10 +1507,11 @@ body.color-picker-open #renderCanvas {
   color: var(--color-text-on-primary);
 }
 
+/* Colours hard coded to ensure visibility across all themes */
 .area-number-badge {
   position: absolute;
-  background: var(--color-text-primary);
-  color: var(--color-button-bg);
+  background: #000;
+  color: #fff;
   width: 40px;
   height: 40px;
   border-radius: 20%;
@@ -1521,12 +1522,19 @@ body.color-picker-open #renderCanvas {
   font-weight: bold;
   box-shadow: 0 0 15px var(--color-shadow);
   z-index: 10001;
-  border: 3px solid var(--color-button-bg);
+  border: 3px solid #fff;
 }
 
+/* Which area badge is currently focused */
+.area-number-badge:focus {
+  outline: 3px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
+/* Highlights the selectable areas */
 .area-outline {
   position: absolute;
-  outline: 5px solid var(--color-border);
+  outline: 5px solid #fff;
   background: rgba(128, 128, 128, 0.15);
   pointer-events: none; /* Let clicks pass through */
   z-index: 10000;


### PR DESCRIPTION
# Summary
You can now tab through the areas in the area menu and press enter to select an area, as well as using the number keys. 

- Moved the import inside `main.js` for consistency. 
- Hard coded the colours for the overlay buttons as these need to be consistent regardless of theme

### AI usage
Planned by me, mostly executed by me, with Claude Sonnet 4.6 to advise on a few fiddly bits. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added keyboard navigation support for area selection overlay (Tab/Shift+Tab to navigate, Enter to activate)

* **Style**
  * Enhanced visual focus indicators for keyboard users
  * Improved contrast and visibility of area badges across themes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->