### PR TITLE
Fix mesh picking and rotation gizmo configuration

### DIFF
--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -789,6 +789,7 @@ function pickMeshFromScene(onPicked, persistent = false) {
   activePick = { pointerObservable, pointerObserver };
 
   setTimeout(() => {
+    if (hasPicked) return;
     startCanvasKeyboardMode(
       (x, y) => {
         const pick = flock.scene.pick(x, y);
@@ -1379,7 +1380,7 @@ function handleScaleGizmo() {
 
 // Rotation: Allow the user to rotate the mesh by dragging it
 function handleRotationGizmo() {
-  configureRotationGizmo(gizmoManager, { updateToMatchAttachedMesh: true });
+  configureRotationGizmo(gizmoManager);
 
   // Show that rotation is active
   const rotationButton = document.getElementById("rotationButton");


### PR DESCRIPTION
## Summary
This PR addresses two issues in the gizmo interaction system: preventing duplicate mesh picking operations and correcting the rotation gizmo configuration.

## Key Changes
- **Mesh Picking**: Added an early return guard in `pickMeshFromScene()` to prevent starting keyboard mode if a mesh has already been picked, avoiding redundant picking operations
- **Rotation Gizmo**: Removed the `updateToMatchAttachedMesh: true` option from `configureRotationGizmo()` call to use the default configuration behavior

## Implementation Details
The mesh picking fix uses the existing `hasPicked` flag to short-circuit the keyboard mode initialization within the setTimeout callback, ensuring that only one picking operation occurs per user interaction. The rotation gizmo change simplifies the configuration by relying on default behavior rather than explicitly forcing mesh attachment updates.

https://claude.ai/code/session_01L3gkDE8aVzntgRGx76Ewwk