### PR TITLE
Clear stored file handle when autosave is denied

### DIFF
--- a/main/files.js
+++ b/main/files.js
@@ -511,6 +511,19 @@ export function clearFileHandle() {
   updateSaveButtonState();
 }
 
+function isFileAutosavePermissionError(error) {
+  const name = error?.name || "";
+  if (name === "AbortError" || name === "NotAllowedError") return true;
+
+  const message = String(error?.message || "").toLowerCase();
+  return (
+    message.includes("permission") ||
+    message.includes("denied") ||
+    message.includes("aborted") ||
+    message.includes("cancel")
+  );
+}
+
 // Function to export project code
 export async function exportCode(workspace) {
   try {
@@ -592,6 +605,9 @@ export async function autoSaveToFile(workspace) {
     await writable.write(jsonString);
     await writable.close();
   } catch (e) {
+    if (isFileAutosavePermissionError(e)) {
+      clearFileHandle();
+    }
     console.error("Error during file autosave:", e);
   }
 }


### PR DESCRIPTION
### Motivation
- Prevent repeated autosave failures when the File System Access API permission is revoked or user cancels the save operation.
- Ensure the UI state is consistent by dropping the stored `FileSystemFileHandle` after a permission-related autosave error.

### Description
- Added a helper `isFileAutosavePermissionError(error)` that detects permission/abort/denied/cancel errors from the File System Access API.
- Updated `autoSaveToFile` error handling to call `clearFileHandle()` when a permission-related error is detected so autosave will stop targeting an invalid handle.

### Testing
- Ran the automated test suite with `npm test` and linting with `npm run lint`, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f372dffdc083268d042e66d7402cb7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced autosave functionality to better handle file permission and access errors, preventing repeated failed save attempts and improving reliability when files become inaccessible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->