### PR TITLE
Add keyboard shortcuts panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -1292,51 +1292,7 @@
               id="info-panel"
               role="complementary"
               aria-label="Information panel"
-            >
-              <details id="info-details">
-                <summary>
-                  <strong data-i18n="keyboard_controls">
-                    Keyboard controls info [Ctrl + /]
-                  </strong>
-                </summary>
-
-                <div id="info-content" class="content" tabindex="-1">
-                  <table role="table" aria-label="Keyboard shortcuts">
-                    <thead class="sr-only">
-                      <tr>
-                        <th scope="col">Shortcut</th>
-                        <th scope="col">Action</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr>
-                        <td>Ctrl + M</td>
-                        <td data-i18n="keyboard_menu">Main menu</td>
-                      </tr>
-                      <tr>
-                        <td>Ctrl + P</td>
-                        <td data-i18n="keyboard_play">Play</td>
-                      </tr>
-                      <tr>
-                        <td>Ctrl + G</td>
-                        <td data-i18n="keyboard_gizmos">Gizmos</td>
-                      </tr>
-                      <tr>
-                        <td>Ctrl + E</td>
-                        <td data-i18n="keyboard_workspace">Code editor</td>
-                      </tr>
-                      <tr>
-                        <td>Ctrl + L</td>
-                        <td data-i18n="keyboard_navigation">
-                          Browser navigation bar (overridden shortcuts work from
-                          here)
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
-              </details>
-            </aside>
+            ></aside>
 
             <footer id="site-footer">
               <nav aria-label="Footer navigation">

--- a/main/accessibility.js
+++ b/main/accessibility.js
@@ -406,9 +406,6 @@ const ShortcutsPanel = {
       if (e.target.id === "closeShortcutsPanel") this.hide();
     });
     document.addEventListener("keydown", (e) => {
-      if (e.key === "Escape" && !this.panel.classList.contains("hidden")) {
-        this.hide();
-      }
       if (
         (e.ctrlKey || e.metaKey) &&
         !this.panel.classList.contains("hidden")

--- a/main/accessibility.js
+++ b/main/accessibility.js
@@ -421,6 +421,16 @@ const ShortcutsPanel = {
           e.preventDefault();
           this.setDock("right");
         }
+        if (e.key === "ArrowUp") {
+          e.preventDefault();
+          const content = this.panel.querySelector(".shortcuts-panel__content");
+          content.scrollBy({ top: -100, behavior: "instant" });
+        }
+        if (e.key === "ArrowDown") {
+          e.preventDefault();
+          const content = this.panel.querySelector(".shortcuts-panel__content");
+          content.scrollBy({ top: 100, behavior: "instant" });
+        }
       }
     });
   },

--- a/main/accessibility.js
+++ b/main/accessibility.js
@@ -251,6 +251,180 @@ const GizmoMenuManager = {
   },
 };
 
+// Modal showing all keyboard shortcuts, accessed with Ctrl + /
+
+// Check their platform (Mac or not Mac) to show the correct modifier key
+function isMac() {
+  return navigator.platform.toUpperCase().includes("MAC");
+}
+
+// List of shortcuts to show in the modal, with categories for grouping
+function getShortcuts() {
+  const mod = isMac() ? "⌘" : "Ctrl";
+  return [
+    { label: "Show/hide shortcut help", keys: `${mod} + /`, category: "Main" },
+    {
+      label: "Move between menus, canvas and editor",
+      keys: `Tab`,
+      category: "Main",
+    },
+    { label: "Confirm", keys: `Enter`, category: "Main" },
+    { label: "Exit", keys: `Esc`, category: "Main" },
+    { label: "Play", keys: `${mod} + P`, category: "Main" },
+    { label: "Undo", keys: `${mod} + Z`, category: "Main" },
+    { label: "Redo", keys: `${mod} + Shift + Z`, category: "Main" },
+    {
+      label: "Browser navigation bar (overriden shortcuts work from here)",
+      keys: `${mod} + L`,
+      category: "Main",
+    },
+
+    { label: "Main menu", keys: `${mod} + M`, category: "Menu" },
+    { label: "Open file", keys: `${mod} + O`, category: "Menu" },
+    { label: "Save / export", keys: `${mod} + S`, category: "Menu" },
+
+    {
+      label: "Open/close area menu",
+      keys: `${mod} + B`,
+      category: "Area menu",
+    },
+    { label: "Toggle area", keys: `Tab`, category: "Area menu" },
+    { label: "Select area", keys: `1-9 / Enter`, category: "Area menu" },
+
+    { label: "Code editor", keys: `${mod} + E`, category: "Editor" },
+    {
+      label: "Add block by name",
+      keys: `${mod} + ]`,
+      category: "Editor",
+    },
+    { label: "Search for a block", keys: `${mod} + F`, category: "Editor" },
+    { label: "Move through blocks", keys: `↑ ↓ ← →`, category: "Editor" },
+
+    { label: "Gizmos", keys: `${mod} + G`, category: "Gizmos" },
+    {
+      label: "Select gizmo",
+      keys: `1-9`,
+      category: "Gizmos",
+    },
+
+    {
+      label: "Keyboard cursor for gizmos",
+      keys: `↑ ↓ ← →`,
+      category: "Gizmos",
+    },
+    {
+      label: "Lock transform to axis",
+      keys: `X Y Z`,
+      category: "Gizmos",
+    },
+    { label: "Transform in 3D", keys: `↑ ↓ ← → PgUp PgDn`, category: "Gizmos" },
+    { label: "Focus camera on object", keys: `F`, category: "Gizmos" },
+
+    {
+      label: "Quick use colour in colour picker",
+      keys: `P`,
+      category: "Gizmos",
+    },
+    { label: "Delete object", keys: `Del`, category: "Gizmos" },
+  ];
+}
+
+// Formats keys for menu nicely
+// You can use + or / and these won't be <kbd> tagged
+function formatKeys(keys) {
+  return keys
+    .split(/( \+ | \/ )/)
+    .map((part) =>
+      part === " + " || part === " / "
+        ? part
+        : part
+            .split(" ")
+            .map((k) => `<kbd>${k}</kbd>`)
+            .join(" "),
+    )
+    .join("");
+}
+
+const ShortcutsModal = {
+  modal: null,
+  dock: "left",
+
+  init() {
+    this.createModal();
+    this.setupListeners();
+  },
+
+  createModal() {
+    const div = document.createElement("div");
+    div.id = "shortcutsModal";
+    div.className = "shortcuts-panel hidden shortcuts-panel--left";
+    div.setAttribute("role", "region");
+    div.setAttribute("aria-label", "Keyboard shortcuts");
+    div.innerHTML = `
+      <div class="shortcuts-panel__content">
+        <button type="button" class="close-button" id="closeShortcutsModal" aria-label="Close keyboard shortcuts">&times;</button>
+        <h1 id="shortcuts-modal-title">Keyboard shortcuts</h1>
+        <table id="shortcuts-table"><tbody></tbody></table>
+      </div>`;
+    document.body.appendChild(div);
+    this.modal = div;
+  },
+
+  show() {
+    const tbody = this.modal.querySelector("tbody");
+    const groups = getShortcuts().reduce((acc, s) => {
+      (acc[s.category] ??= []).push(s);
+      return acc;
+    }, {});
+    tbody.innerHTML = Object.entries(groups)
+      .map(
+        ([cat, items]) => `
+      <tr><th colspan="2">${cat}</th></tr>
+      ${items.map(({ label, keys }) => `<tr><td>${label}</td><td>${formatKeys(keys)}</td></tr>`).join("")}
+    `,
+      )
+      .join("");
+    this.modal.classList.remove("hidden");
+  },
+
+  hide() {
+    this.modal.classList.add("hidden");
+  },
+
+  setDock(side) {
+    this.dock = side;
+    this.modal.classList.toggle("shortcuts-panel--left", side === "left");
+    this.modal.classList.toggle("shortcuts-panel--right", side === "right");
+  },
+
+  setupListeners() {
+    document.addEventListener("click", (e) => {
+      if (e.target.id === "closeShortcutsModal") this.hide();
+    });
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "Escape" && !this.modal.classList.contains("hidden")) {
+        this.hide();
+      }
+      if (
+        (e.ctrlKey || e.metaKey) &&
+        !this.modal.classList.contains("hidden")
+      ) {
+        if (e.key === "ArrowLeft") {
+          e.preventDefault();
+          this.setDock("left");
+        }
+        if (e.key === "ArrowRight") {
+          e.preventDefault();
+          this.setDock("right");
+        }
+      }
+    });
+  },
+};
+
 // Start it up
 AreaManager.init();
 GizmoMenuManager.init();
+ShortcutsModal.init();
+
+export { ShortcutsModal };

--- a/main/accessibility.js
+++ b/main/accessibility.js
@@ -1,7 +1,7 @@
 // Area menu accessed with Ctrl + B to quickly skip to
 // different areas on the interface
 
-const AccessibilityManager = {
+const AreaManager = {
   overlay: null,
   areas: [
     { selector: "#menuleft", label: "1" }, // Top left menu (line 148 input.js - demo menu is excluded?)
@@ -24,9 +24,7 @@ const AccessibilityManager = {
     div.id = "area-menu-overlay";
     div.className = "hidden";
     div.classList.add("hidden");
-    div.innerHTML = `
-        <div id="area-menu-content"> </div>        
-    `;
+    div.innerHTML = `<div id="area-menu-content"> </div>`;
     document.body.appendChild(div);
     this.overlay = div;
   },
@@ -140,5 +138,293 @@ const AccessibilityManager = {
   },
 };
 
+/* Overlay for gizmo buttons */
+const GizmoMenuManager = {
+  overlay: null,
+  buttons: [
+    { id: "showShapesButton", label: "1" },
+    { id: "colorPickerButton", label: "2" },
+    { id: "positionButton", label: "3" },
+    { id: "rotationButton", label: "4" },
+    { id: "scaleButton", label: "5" },
+    { id: "selectButton", label: "6" },
+    { id: "duplicateButton", label: "7" },
+    { id: "deleteButton", label: "8" },
+    { id: "cameraButton", label: "9" },
+  ],
+
+  init() {
+    this.createOverlay();
+    this.setupListeners();
+  },
+
+  createOverlay() {
+    const div = document.createElement("div");
+    div.id = "gizmo-menu-overlay";
+    div.className = "hidden";
+    div.innerHTML = `<div id="gizmo-menu-content"></div>`;
+    document.body.appendChild(div);
+    this.overlay = div;
+  },
+
+  isOpen() {
+    return !this.overlay.classList.contains("hidden");
+  },
+
+  toggle(show) {
+    if (!this.overlay) return;
+    if (show) {
+      this.renderBadges();
+      // Focus 1st button if nothing in gizmos is already focused,
+      // but if another gizmo is active, leave focus there
+      const alreadyFocused = document.activeElement?.closest("#gizmoButtons");
+
+      if (!alreadyFocused) {
+        const btn =
+          document.querySelector(".gizmo-button.active") ||
+          document.getElementById("showShapesButton");
+        if (btn && !btn.disabled && btn.offsetParent !== null) btn.focus();
+      }
+    }
+    this.overlay.classList.toggle("hidden", !show);
+  },
+
+  setupListeners() {
+    window.addEventListener(
+      "keydown",
+      (e) => {
+        // Show the overlay on Ctrl+G
+        if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "g") {
+          e.preventDefault();
+          e.stopPropagation(); // prevent main.js from also handling this
+          this.toggle(!this.isOpen());
+          return;
+        }
+
+        // Do nothing if the overlay isn't open
+        if (!this.isOpen()) return;
+
+        // Guard against typing in inputs triggering gizmo shortcuts
+        const t = e.target;
+        const tag = (t?.tagName || "").toLowerCase();
+        if (
+          t?.isContentEditable ||
+          tag === "input" ||
+          tag === "textarea" ||
+          tag === "select"
+        )
+          return;
+
+        // If the overlay is open and a number key is pressed,
+        // activate the gizmo
+        if (e.key >= "1" && e.key <= "9") {
+          const entry = this.buttons.find((b) => b.label === e.key);
+          if (entry) this.activateButton(entry);
+        }
+      },
+      true,
+    );
+  },
+
+  activateButton(entry) {
+    this.toggle(false);
+    const el = document.getElementById(entry.id);
+    if (!el) return;
+    el.focus();
+    if (!el.disabled) el.click();
+  },
+
+  renderBadges() {
+    const container = document.getElementById("gizmo-menu-content");
+    container.innerHTML = "";
+    this.buttons.forEach((entry) => {
+      const el = document.getElementById(entry.id);
+      if (!el || el.offsetParent === null) return;
+      const rect = el.getBoundingClientRect();
+      const badge = document.createElement("div");
+      badge.className = "gizmo-key-badge";
+      badge.innerText = entry.label;
+      badge.style.top = `${rect.top + rect.height + 8}px`;
+      badge.style.left = `${rect.left + rect.width / 2}px`;
+      container.appendChild(badge);
+    });
+  },
+};
+
+// Modal showing all keyboard shortcuts, accessed with Ctrl + /
+
+// Check their platform (Mac or not Mac) to show the correct modifier key
+function isMac() {
+  return navigator.platform.toUpperCase().includes("MAC");
+}
+
+// List of shortcuts to show in the modal, with categories for grouping
+function getShortcuts() {
+  const mod = isMac() ? "⌘" : "Ctrl";
+  return [
+    { label: "Show/hide shortcut help", keys: `${mod} + /`, category: "Main" },
+    {
+      label: "Move between menus, canvas and editor",
+      keys: `Tab`,
+      category: "Main",
+    },
+    { label: "Confirm", keys: `Enter`, category: "Main" },
+    { label: "Exit", keys: `Esc`, category: "Main" },
+    { label: "Play", keys: `${mod} + P`, category: "Main" },
+    { label: "Undo", keys: `${mod} + Z`, category: "Main" },
+    { label: "Redo", keys: `${mod} + Shift + Z`, category: "Main" },
+    {
+      label: "Browser navigation bar (overriden shortcuts work from here)",
+      keys: `${mod} + L`,
+      category: "Main",
+    },
+
+    { label: "Main menu", keys: `${mod} + M`, category: "Menu" },
+    { label: "Open file", keys: `${mod} + O`, category: "Menu" },
+    { label: "Save / export", keys: `${mod} + S`, category: "Menu" },
+
+    {
+      label: "Open/close area menu",
+      keys: `${mod} + B`,
+      category: "Area menu",
+    },
+    { label: "Toggle area", keys: `Tab`, category: "Area menu" },
+    { label: "Select area", keys: `1-9 / Enter`, category: "Area menu" },
+
+    { label: "Code editor", keys: `${mod} + E`, category: "Editor" },
+    {
+      label: "Add block by name",
+      keys: `${mod} + ]`,
+      category: "Editor",
+    },
+    { label: "Search for a block", keys: `${mod} + F`, category: "Editor" },
+    { label: "Move through blocks", keys: `↑ ↓ ← →`, category: "Editor" },
+
+    { label: "Gizmos", keys: `${mod} + G`, category: "Gizmos" },
+    {
+      label: "Select gizmo",
+      keys: `1-9`,
+      category: "Gizmos",
+    },
+
+    {
+      label: "Keyboard cursor for gizmos",
+      keys: `↑ ↓ ← →`,
+      category: "Gizmos",
+    },
+    {
+      label: "Lock transform to axis",
+      keys: `X Y Z`,
+      category: "Gizmos",
+    },
+    { label: "Transform in 3D", keys: `↑ ↓ ← → PgUp PgDn`, category: "Gizmos" },
+    { label: "Focus camera on object", keys: `F`, category: "Gizmos" },
+
+    {
+      label: "Quick use colour in colour picker",
+      keys: `P`,
+      category: "Gizmos",
+    },
+    { label: "Delete object", keys: `Del`, category: "Gizmos" },
+  ];
+}
+
+// Formats keys for menu nicely
+// You can use + or / and these won't be <kbd> tagged
+function formatKeys(keys) {
+  return keys
+    .split(/( \+ | \/ )/)
+    .map((part) =>
+      part === " + " || part === " / "
+        ? part
+        : part
+            .split(" ")
+            .map((k) => `<kbd>${k}</kbd>`)
+            .join(" "),
+    )
+    .join("");
+}
+
+const ShortcutsModal = {
+  modal: null,
+  dock: "left",
+
+  init() {
+    this.createModal();
+    this.setupListeners();
+  },
+
+  createModal() {
+    const div = document.createElement("div");
+    div.id = "shortcutsModal";
+    div.className = "shortcuts-panel hidden shortcuts-panel--left";
+    div.setAttribute("role", "region");
+    div.setAttribute("aria-label", "Keyboard shortcuts");
+    div.innerHTML = `
+      <div class="shortcuts-panel__content">
+        <button type="button" class="close-button" id="closeShortcutsModal" aria-label="Close keyboard shortcuts">&times;</button>
+        <h1 id="shortcuts-modal-title">Keyboard shortcuts</h1>
+        <table id="shortcuts-table"><tbody></tbody></table>
+      </div>`;
+    document.body.appendChild(div);
+    this.modal = div;
+  },
+
+  show() {
+    const tbody = this.modal.querySelector("tbody");
+    const groups = getShortcuts().reduce((acc, s) => {
+      (acc[s.category] ??= []).push(s);
+      return acc;
+    }, {});
+    tbody.innerHTML = Object.entries(groups)
+      .map(
+        ([cat, items]) => `
+      <tr><th colspan="2">${cat}</th></tr>
+      ${items.map(({ label, keys }) => `<tr><td>${label}</td><td>${formatKeys(keys)}</td></tr>`).join("")}
+    `,
+      )
+      .join("");
+    this.modal.classList.remove("hidden");
+  },
+
+  hide() {
+    this.modal.classList.add("hidden");
+  },
+
+  setDock(side) {
+    this.dock = side;
+    this.modal.classList.toggle("shortcuts-panel--left", side === "left");
+    this.modal.classList.toggle("shortcuts-panel--right", side === "right");
+  },
+
+  setupListeners() {
+    document.addEventListener("click", (e) => {
+      if (e.target.id === "closeShortcutsModal") this.hide();
+    });
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "Escape" && !this.modal.classList.contains("hidden")) {
+        this.hide();
+      }
+      if (
+        (e.ctrlKey || e.metaKey) &&
+        !this.modal.classList.contains("hidden")
+      ) {
+        if (e.key === "ArrowLeft") {
+          e.preventDefault();
+          this.setDock("left");
+        }
+        if (e.key === "ArrowRight") {
+          e.preventDefault();
+          this.setDock("right");
+        }
+      }
+    });
+  },
+};
+
 // Start it up
-AccessibilityManager.init();
+AreaManager.init();
+GizmoMenuManager.init();
+ShortcutsModal.init();
+
+export { ShortcutsModal };

--- a/main/accessibility.js
+++ b/main/accessibility.js
@@ -258,7 +258,7 @@ function isMac() {
   return navigator.platform.toUpperCase().includes("MAC");
 }
 
-// List of shortcuts to show in the modal, with categories for grouping
+// List of shortcuts to show in the panel, with categories for grouping
 function getShortcuts() {
   const mod = isMac() ? "⌘" : "Ctrl";
   return [
@@ -345,33 +345,33 @@ function formatKeys(keys) {
     .join("");
 }
 
-const ShortcutsModal = {
-  modal: null,
+const ShortcutsPanel = {
+  panel: null,
   dock: "left",
 
   init() {
-    this.createModal();
+    this.createPanel();
     this.setupListeners();
   },
 
-  createModal() {
+  createPanel() {
     const div = document.createElement("div");
-    div.id = "shortcutsModal";
+    div.id = "shortcutsPanel";
     div.className = "shortcuts-panel hidden shortcuts-panel--left";
     div.setAttribute("role", "region");
     div.setAttribute("aria-label", "Keyboard shortcuts");
     div.innerHTML = `
       <div class="shortcuts-panel__content">
-        <button type="button" class="close-button" id="closeShortcutsModal" aria-label="Close keyboard shortcuts">&times;</button>
-        <h1 id="shortcuts-modal-title">Keyboard shortcuts</h1>
+        <button type="button" class="close-button" id="closeShortcutsPanel" aria-label="Close keyboard shortcuts">&times;</button>
+        <h1 id="shortcuts-panel-title">Keyboard shortcuts</h1>
         <table id="shortcuts-table"><tbody></tbody></table>
       </div>`;
     document.body.appendChild(div);
-    this.modal = div;
+    this.panel = div;
   },
 
   show() {
-    const tbody = this.modal.querySelector("tbody");
+    const tbody = this.panel.querySelector("tbody");
     const groups = getShortcuts().reduce((acc, s) => {
       (acc[s.category] ??= []).push(s);
       return acc;
@@ -384,30 +384,30 @@ const ShortcutsModal = {
     `,
       )
       .join("");
-    this.modal.classList.remove("hidden");
+    this.panel.classList.remove("hidden");
   },
 
   hide() {
-    this.modal.classList.add("hidden");
+    this.panel.classList.add("hidden");
   },
 
   setDock(side) {
     this.dock = side;
-    this.modal.classList.toggle("shortcuts-panel--left", side === "left");
-    this.modal.classList.toggle("shortcuts-panel--right", side === "right");
+    this.panel.classList.toggle("shortcuts-panel--left", side === "left");
+    this.panel.classList.toggle("shortcuts-panel--right", side === "right");
   },
 
   setupListeners() {
     document.addEventListener("click", (e) => {
-      if (e.target.id === "closeShortcutsModal") this.hide();
+      if (e.target.id === "closeShortcutsPanel") this.hide();
     });
     document.addEventListener("keydown", (e) => {
-      if (e.key === "Escape" && !this.modal.classList.contains("hidden")) {
+      if (e.key === "Escape" && !this.panel.classList.contains("hidden")) {
         this.hide();
       }
       if (
         (e.ctrlKey || e.metaKey) &&
-        !this.modal.classList.contains("hidden")
+        !this.panel.classList.contains("hidden")
       ) {
         if (e.key === "ArrowLeft") {
           e.preventDefault();
@@ -425,6 +425,6 @@ const ShortcutsModal = {
 // Start it up
 AreaManager.init();
 GizmoMenuManager.init();
-ShortcutsModal.init();
+ShortcutsPanel.init();
 
-export { ShortcutsModal };
+export { ShortcutsPanel };

--- a/main/accessibility.js
+++ b/main/accessibility.js
@@ -410,6 +410,10 @@ const ShortcutsPanel = {
         (e.ctrlKey || e.metaKey) &&
         !this.panel.classList.contains("hidden")
       ) {
+        const t = e.target;
+        const tag = (t?.tagName || "").toLowerCase();
+        if (t?.isContentEditable || tag === "input" || tag === "textarea" || tag === "select") return;
+
         if (e.key === "ArrowLeft") {
           e.preventDefault();
           this.setDock("left");

--- a/main/accessibility.js
+++ b/main/accessibility.js
@@ -391,6 +391,10 @@ const ShortcutsPanel = {
     this.panel.classList.add("hidden");
   },
 
+  toggle() {
+    this.panel.classList.contains("hidden") ? this.show() : this.hide();
+  },
+
   setDock(side) {
     this.dock = side;
     this.panel.classList.toggle("shortcuts-panel--left", side === "left");

--- a/main/blockhandling.js
+++ b/main/blockhandling.js
@@ -292,7 +292,7 @@ export function initializeBlockHandling() {
       return;
     }
 
-    if (event.ctrlKey && event.key === ".") {
+    if ((event.ctrlKey || event.metaKey) && event.key === ".") {
       event.preventDefault();
 
       createKeywordBlockAtViewportCenter("keyword_block");
@@ -301,7 +301,7 @@ export function initializeBlockHandling() {
 
   // Handle Enter key for adding new blocks
   document.addEventListener("keydown", function (event) {
-    if (event.ctrlKey && event.key === "]") {
+    if ((event.ctrlKey || event.metaKey) && event.key === "]") {
       const selectedBlock = getSelectedBlockForKeywordShortcut();
       event.preventDefault();
 

--- a/main/input.js
+++ b/main/input.js
@@ -302,7 +302,7 @@ export function setupInput() {
 
   function handleCanvasKeyboard(e) {
     // Handle Ctrl+Z for undo when canvas is focused
-    if (e.ctrlKey && e.key.toLowerCase() === "z" && !e.shiftKey) {
+    if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "z" && !e.shiftKey) {
       e.preventDefault();
       const workspace = window.mainWorkspace || Blockly.getMainWorkspace();
       if (workspace) {
@@ -314,7 +314,7 @@ export function setupInput() {
 
     // Handle Ctrl+Shift+Z or Ctrl+Y for redo when canvas is focused
     if (
-      (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === "z") ||
+      ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key.toLowerCase() === "z") ||
       (e.ctrlKey && e.key.toLowerCase() === "y")
     ) {
       e.preventDefault();

--- a/main/input.js
+++ b/main/input.js
@@ -66,13 +66,6 @@ export function setupInput() {
         .querySelectorAll("#gizmoButtons button, #gizmoButtons input")
         .forEach(pushUnique);
 
-      // 3) Info panel
-      pushUnique(document.querySelector("#info-details summary"));
-      const infoDetails = document.getElementById("info-details");
-      if (infoDetails && infoDetails.open) {
-        pushUnique(infoDetails.querySelector(".content"));
-      }
-
       // 4) Logo link + resizer
       pushUnique(document.querySelector("#info-panel-link"));
       pushUnique(document.querySelector("#resizer"));
@@ -198,13 +191,6 @@ export function setupInput() {
       ) {
         // Let custom management handle this - will go to next UI element
       }
-      // If we're on the summary and details is open, let browser handle the Tab into content
-      else if (
-        activeElement.matches("#info-details summary") &&
-        detailsElement.open
-      ) {
-        return; // Let browser handle tab into details content
-      }
       // If we're anywhere inside open details content, let browser handle it
       else if (activeElement.closest("#info-details") && detailsElement.open) {
         return; // Let browser handle navigation within details
@@ -302,7 +288,11 @@ export function setupInput() {
 
   function handleCanvasKeyboard(e) {
     // Handle Ctrl+Z for undo when canvas is focused
-    if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "z" && !e.shiftKey) {
+    if (
+      (e.ctrlKey || e.metaKey) &&
+      e.key.toLowerCase() === "z" &&
+      !e.shiftKey
+    ) {
       e.preventDefault();
       const workspace = window.mainWorkspace || Blockly.getMainWorkspace();
       if (workspace) {

--- a/main/main.js
+++ b/main/main.js
@@ -48,7 +48,7 @@ import {
   initializeSavedLanguage,
   translate,
 } from "./translation.js";
-import "./accessibility.js";
+import { ShortcutsModal } from "./accessibility.js";
 
 function isEmbedModeEnabled() {
   const embedParam = new URLSearchParams(window.location.search).get("embed");
@@ -577,13 +577,8 @@ function initializeApp() {
           break;
 
         case "/": {
-          // Ctrl+/ - Toggle info details
           e.preventDefault();
-          const infoSummary = document.querySelector("#info-details summary");
-          if (infoSummary) {
-            infoSummary.click(); // Simulate a click to toggle details
-            infoSummary.focus(); // Move focus to the summary
-          }
+          ShortcutsModal.show();
           break;
         }
 
@@ -778,26 +773,6 @@ window.onload = async function () {
       window.loadingCode = false;
     }
   });
-
-  const infoDetails = document.getElementById("info-details");
-  if (infoDetails) {
-    infoDetails.addEventListener("toggle", function () {
-      if (this.open) {
-        setTimeout(() => {
-          const content = this.querySelector(".content");
-          if (content) {
-            content.setAttribute("tabindex", "0"); // Make it focusable
-            content.focus();
-          }
-        }, 10);
-      } else {
-        const content = this.querySelector(".content");
-        if (content) {
-          content.setAttribute("tabindex", "-1"); // Remove from tab order when closed
-        }
-      }
-    });
-  }
 
   // Initial view setup
   window.loadingCode = true;

--- a/main/main.js
+++ b/main/main.js
@@ -48,7 +48,7 @@ import {
   initializeSavedLanguage,
   translate,
 } from "./translation.js";
-import { ShortcutsModal } from "./accessibility.js";
+import { ShortcutsPanel } from "./accessibility.js";
 
 function isEmbedModeEnabled() {
   const embedParam = new URLSearchParams(window.location.search).get("embed");
@@ -578,7 +578,7 @@ function initializeApp() {
 
         case "/": {
           e.preventDefault();
-          ShortcutsModal.show();
+          ShortcutsPanel.show();
           break;
         }
 

--- a/main/main.js
+++ b/main/main.js
@@ -578,7 +578,7 @@ function initializeApp() {
 
         case "/": {
           e.preventDefault();
-          ShortcutsPanel.show();
+          ShortcutsPanel.toggle();
           break;
         }
 

--- a/style.css
+++ b/style.css
@@ -1608,7 +1608,7 @@ kbd {
   right: 0;
   bottom: 0;
   pointer-events: none;
-  z-index: 9999;
+  z-index: 10002;
 }
 
 .shortcuts-panel__content {

--- a/style.css
+++ b/style.css
@@ -1569,7 +1569,7 @@ body.color-picker-open #renderCanvas {
   line-height: 1.4;
 }
 
-/* Styles for keyboard controls panel */
+/* Styles for keyboard shortcuts panel */
 #shortcuts-table {
   font-size: 1.2em;
   width: 100%;

--- a/style.css
+++ b/style.css
@@ -1539,3 +1539,64 @@ body.color-picker-open #renderCanvas {
   pointer-events: none; /* Let clicks pass through */
   z-index: 10000;
 }
+
+/* Styles for keyboard controls panel */
+#shortcuts-table {
+  font-size: 1.2em;
+  width: 100%;
+  table-layout: fixed;
+}
+
+#shortcuts-table td:first-child {
+  width: 70%;
+}
+
+#shortcuts-table td {
+  padding: 0.5em;
+  vertical-align: top;
+  line-height: 1.5em;
+}
+
+#shortcuts-table th {
+  text-align: left;
+  padding-top: 1em;
+  font-size: 1.2em;
+}
+
+kbd {
+  background-color: var(--color-bg);
+  border: 1px solid currentColor;
+  border-radius: 3px;
+  padding: 1px 5px;
+  font-size: 1.2em;
+}
+
+/* Shortcuts panel — floats over UI, pointer events pass through the wrapper */
+.shortcuts-panel {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  pointer-events: none;
+  z-index: 9999;
+}
+
+.shortcuts-panel__content {
+  position: absolute;
+  pointer-events: auto;
+  top: 0;
+  bottom: 0;
+  background-color: var(--color-bg);
+  padding: 1.5em;
+  width: min(300px, 100%);
+  overflow-y: auto;
+}
+
+.shortcuts-panel--left .shortcuts-panel__content {
+  left: 0;
+}
+
+.shortcuts-panel--right .shortcuts-panel__content {
+  right: 0;
+}

--- a/style.css
+++ b/style.css
@@ -1568,3 +1568,64 @@ body.color-picker-open #renderCanvas {
   text-align: center;
   line-height: 1.4;
 }
+
+/* Styles for keyboard controls panel */
+#shortcuts-table {
+  font-size: 1.2em;
+  width: 100%;
+  table-layout: fixed;
+}
+
+#shortcuts-table td:first-child {
+  width: 70%;
+}
+
+#shortcuts-table td {
+  padding: 0.5em;
+  vertical-align: top;
+  line-height: 1.5em;
+}
+
+#shortcuts-table th {
+  text-align: left;
+  padding-top: 1em;
+  font-size: 1.2em;
+}
+
+kbd {
+  background-color: var(--color-bg);
+  border: 1px solid currentColor;
+  border-radius: 3px;
+  padding: 1px 5px;
+  font-size: 1.2em;
+}
+
+/* Shortcuts panel — floats over UI, pointer events pass through the wrapper */
+.shortcuts-panel {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  pointer-events: none;
+  z-index: 9999;
+}
+
+.shortcuts-panel__content {
+  position: absolute;
+  pointer-events: auto;
+  top: 0;
+  bottom: 0;
+  background-color: var(--color-bg);
+  padding: 1.5em;
+  width: min(300px, 100%);
+  overflow-y: auto;
+}
+
+.shortcuts-panel--left .shortcuts-panel__content {
+  left: 0;
+}
+
+.shortcuts-panel--right .shortcuts-panel__content {
+  right: 0;
+}

--- a/style.css
+++ b/style.css
@@ -1594,7 +1594,7 @@ body.color-picker-open #renderCanvas {
 
 kbd {
   background-color: var(--color-bg);
-  border: 1px solid currentColor;
+  border: 1px solid currentcolor;
   border-radius: 3px;
   padding: 1px 5px;
   font-size: 1.2em;

--- a/ui/axis-keyboard.js
+++ b/ui/axis-keyboard.js
@@ -12,14 +12,19 @@ export function createAxisKeyboardHandler({
   let axis = null;
 
   function handler(event) {
-    
     const t = event.target;
     // Don't capture keys when focus is in the code panel, top menu, or docs
-    if (t?.closest?.("#codePanel, header, #info-details")) return;
-     // Don't interfere with text inputs
+    if (t?.closest?.("#codePanel, header")) return;
+    // Don't interfere with text inputs
     const tag = (t?.tagName || "").toLowerCase();
-    if (t?.isContentEditable || tag === "input" || tag === "textarea" || tag === "select") return;
-    
+    if (
+      t?.isContentEditable ||
+      tag === "input" ||
+      tag === "textarea" ||
+      tag === "select"
+    )
+      return;
+
     const step = event.shiftKey ? stepFast : stepNormal;
 
     switch (event.key) {
@@ -61,7 +66,7 @@ export function createAxisKeyboardHandler({
       case "ArrowUp":
       case "ArrowDown": {
         event.preventDefault();
-        event.stopPropagation(); 
+        event.stopPropagation();
         const sign =
           event.key === "ArrowRight" || event.key === "ArrowUp" ? 1 : -1;
         if (axis) {
@@ -81,13 +86,13 @@ export function createAxisKeyboardHandler({
 
       case "PageUp":
         event.preventDefault();
-        event.stopPropagation(); 
+        event.stopPropagation();
         if (!axis) onMove(0, step, 0);
         break;
 
       case "PageDown":
         event.preventDefault();
-        event.stopPropagation(); 
+        event.stopPropagation();
         if (!axis) onMove(0, -step, 0);
         break;
 

--- a/ui/axis-keyboard.js
+++ b/ui/axis-keyboard.js
@@ -14,7 +14,7 @@ export function createAxisKeyboardHandler({
   function handler(event) {
     const t = event.target;
     // Don't capture keys when focus is in the code panel, top menu, or docs
-    if (t?.closest?.("#codePanel, header")) return;
+    if (t?.closest?.("#codePanel, header, .shortcuts-panel")) return;
     // Don't interfere with text inputs
     const tag = (t?.tagName || "").toLowerCase();
     if (


### PR DESCRIPTION
# Summary
Adds a keyboard shortcuts panel which can be docked left or right.

<img width="400"  alt="image" src="https://github.com/user-attachments/assets/da8b3410-b5e1-4995-845b-3395cb3fad0e" />

## Details
- Press Ctrl + `/` or ⌘ + `/` to toggle open or close shortcut panel - it deliberately does NOT hide on `Esc` as you might be using Esc for something on the UI 
- Press Ctrl + Left arrow or Ctrl + Right arrow to dock it left or right
- Press Ctrl + Up arrow or Ctrl + Down arrow to scroll up or down
- Shortcuts should correctly display Ctrl on Windows and ⌘ if you're on Mac (#538 )
- (As an aside, fixed a couple of implemented shortcuts that were Win only)

## Further work to do
- Translations for almost all strings need to be applied (once finalised)
- Could implement the slide in/out feature Makecode has (but actually it's trivial to keyboard open/close it so maybe not)
- It looks naff on mobile, but then again it's not relevant and you can't actually open it on mobile so...
- Need to add link to keyboard controls documentation on hub from in-tool documentation

Relates to #512 #343 

### AI usage
Claude Sonnet 4.6 used throughout, with all changes carefully approved by a human. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Keyboard shortcuts panel now displays in a dedicated modal window (open/close with Ctrl+/)
  * Navigate the panel with arrow keys; use Escape to close
  * Enhanced keyboard support for Mac users with Meta key recognition and Cmd+Z/Cmd+Shift+Z shortcuts for Undo/Redo

<!-- end of auto-generated comment: release notes by coderabbit.ai -->