### PR TITLE
Refactor capsule creation to support dynamic shape selection

### DIFF
--- a/api/animate.js
+++ b/api/animate.js
@@ -64,7 +64,7 @@ const updateCapsuleShapeForAnimation = (physicsMesh, animationName) => {
       flock.scene,
     );
   } else {
-    newShape = flock.createCapsuleFromBoundingBox(physicsMesh, flock.scene);
+    newShape = flock.createShapeFromBoundingBox(physicsMesh, flock.scene);
   }
 
   physicsMesh.physics.shape = newShape;

--- a/api/mesh.js
+++ b/api/mesh.js
@@ -7,31 +7,36 @@ export function setFlockReference(ref) {
 }
 
 export const flockMesh = {
-  createCapsuleFromBoundingBox(mesh, scene) {
+  createShapeFromBoundingBox(mesh, scene) {
     mesh.computeWorldMatrix(true);
     const boundingInfo = mesh.getBoundingInfo();
-    // Use LOCAL bounding box coordinates
     const localMin = boundingInfo.boundingBox.minimum;
     const localMax = boundingInfo.boundingBox.maximum;
 
-    // Apply the mesh's scaling to get actual dimensions
     const height = (localMax.y - localMin.y) * Math.abs(mesh.scaling.y);
     const width = (localMax.x - localMin.x) * Math.abs(mesh.scaling.x);
     const depth = (localMax.z - localMin.z) * Math.abs(mesh.scaling.z);
 
     const radius = Math.min(width, depth) / 2;
 
-    // Shrink the capsule vertically to allow intersections
-    const shrinkAmount = 0.01; // Adjust this value as needed
-    const adjustedHeight = Math.max(0, height - shrinkAmount);
-    const cylinderHeight = Math.max(0, adjustedHeight - 2 * radius);
-
-    // Center the capsule at the bounding box center in LOCAL space
     const localCenter = new flock.BABYLON.Vector3(
       (localMin.x + localMax.x) / 2,
       (localMin.y + localMax.y) / 2,
       (localMin.z + localMax.z) / 2,
     );
+
+    if (height < 2 * radius) {
+      return new flock.BABYLON.PhysicsShapeBox(
+        localCenter,
+        flock.BABYLON.Quaternion.Identity(),
+        new flock.BABYLON.Vector3(width, height, depth),
+        scene,
+      );
+    }
+
+    const shrinkAmount = 0.01;
+    const adjustedHeight = Math.max(0, height - shrinkAmount);
+    const cylinderHeight = adjustedHeight - 2 * radius;
 
     const segmentStart = new flock.BABYLON.Vector3(
       localCenter.x,
@@ -797,21 +802,7 @@ export const flockMesh = {
       flock.scene,
     );
 
-    const { boundingBox } = bb.getBoundingInfo();
-    const bbWidth = boundingBox.maximum.x - boundingBox.minimum.x;
-    const bbHeight = boundingBox.maximum.y - boundingBox.minimum.y;
-    const bbDepth = boundingBox.maximum.z - boundingBox.minimum.z;
-    const capsuleRadius = Math.min(bbWidth, bbDepth) / 2;
-    const useCapsule = bbHeight >= 2 * capsuleRadius;
-
-    const boxShape = useCapsule
-      ? flock.createCapsuleFromBoundingBox(bb, flock.scene)
-      : new flock.BABYLON.PhysicsShapeBox(
-          boundingBox.center,
-          flock.BABYLON.Quaternion.Identity(),
-          new flock.BABYLON.Vector3(bbWidth, bbHeight, bbDepth),
-          flock.scene,
-        );
+    const boxShape = flock.createShapeFromBoundingBox(bb, flock.scene);
 
     boxBody.shape = boxShape;
     boxBody.setMassProperties({ mass: 1, restitution: 0.5 });

--- a/api/mesh.js
+++ b/api/mesh.js
@@ -797,7 +797,21 @@ export const flockMesh = {
       flock.scene,
     );
 
-    const boxShape = flock.createCapsuleFromBoundingBox(bb, flock.scene);
+    const { boundingBox } = bb.getBoundingInfo();
+    const bbWidth = boundingBox.maximum.x - boundingBox.minimum.x;
+    const bbHeight = boundingBox.maximum.y - boundingBox.minimum.y;
+    const bbDepth = boundingBox.maximum.z - boundingBox.minimum.z;
+    const capsuleRadius = Math.min(bbWidth, bbDepth) / 2;
+    const useCapsule = bbHeight >= 2 * capsuleRadius;
+
+    const boxShape = useCapsule
+      ? flock.createCapsuleFromBoundingBox(bb, flock.scene)
+      : new flock.BABYLON.PhysicsShapeBox(
+          boundingBox.center,
+          flock.BABYLON.Quaternion.Identity(),
+          new flock.BABYLON.Vector3(bbWidth, bbHeight, bbDepth),
+          flock.scene,
+        );
 
     boxBody.shape = boxShape;
     boxBody.setMassProperties({ mass: 1, restitution: 0.5 });

--- a/api/physics.js
+++ b/api/physics.js
@@ -60,22 +60,6 @@ const createPhysicsShape = (mesh, shapeType) => {
     mesh.computeWorldMatrix(true);
     return flock.createCapsuleFromBoundingBox(mesh, flock.scene);
   }
-  if (mesh.getTotalVertices() === 0) {
-    mesh.computeWorldMatrix(true);
-    mesh.refreshBoundingInfo(true);
-    const bb = mesh.getBoundingInfo().boundingBox;
-    const extents = new flock.BABYLON.Vector3(
-      bb.maximum.x - bb.minimum.x,
-      bb.maximum.y - bb.minimum.y,
-      bb.maximum.z - bb.minimum.z,
-    );
-    return new flock.BABYLON.PhysicsShapeBox(
-      bb.center,
-      flock.BABYLON.Quaternion.Identity(),
-      extents,
-      flock.scene,
-    );
-  }
   return new flock.BABYLON.PhysicsShapeMesh(mesh, flock.scene);
 };
 

--- a/api/physics.js
+++ b/api/physics.js
@@ -58,7 +58,7 @@ const disposePhysics = (targetMesh) => {
 const createPhysicsShape = (mesh, shapeType) => {
   if (shapeType === "CAPSULE") {
     mesh.computeWorldMatrix(true);
-    return flock.createCapsuleFromBoundingBox(mesh, flock.scene);
+    return flock.createShapeFromBoundingBox(mesh, flock.scene);
   }
   return new flock.BABYLON.PhysicsShapeMesh(mesh, flock.scene);
 };
@@ -325,7 +325,7 @@ export const flockPhysics = {
           disposePhysics(targetMesh);
 
           // IMPORTANT: use targetMesh (not outer mesh)
-          const physicsShape = flock.createCapsuleFromBoundingBox(
+          const physicsShape = flock.createShapeFromBoundingBox(
             targetMesh,
             flock.scene,
           );

--- a/api/physics.js
+++ b/api/physics.js
@@ -60,6 +60,22 @@ const createPhysicsShape = (mesh, shapeType) => {
     mesh.computeWorldMatrix(true);
     return flock.createCapsuleFromBoundingBox(mesh, flock.scene);
   }
+  if (mesh.getTotalVertices() === 0) {
+    mesh.computeWorldMatrix(true);
+    mesh.refreshBoundingInfo(true);
+    const bb = mesh.getBoundingInfo().boundingBox;
+    const extents = new flock.BABYLON.Vector3(
+      bb.maximum.x - bb.minimum.x,
+      bb.maximum.y - bb.minimum.y,
+      bb.maximum.z - bb.minimum.z,
+    );
+    return new flock.BABYLON.PhysicsShapeBox(
+      bb.center,
+      flock.BABYLON.Quaternion.Identity(),
+      extents,
+      flock.scene,
+    );
+  }
   return new flock.BABYLON.PhysicsShapeMesh(mesh, flock.scene);
 };
 

--- a/ui/blockmesh.js
+++ b/ui/blockmesh.js
@@ -1536,7 +1536,7 @@ function setAbsoluteSize(mesh, width, height, depth) {
         );
         break;
       case "Capsule":
-        newShape = flock.createCapsuleFromBoundingBox(mesh, mesh.getScene());
+        newShape = flock.createShapeFromBoundingBox(mesh, mesh.getScene());
         break;
       default:
         console.log("Unknown or unsupported physics shape type: " + shapeType);


### PR DESCRIPTION
## Summary
Renamed `createCapsuleFromBoundingBox` to `createShapeFromBoundingBox` and enhanced it to dynamically select between box and capsule shapes based on mesh dimensions. This improves physics shape accuracy for meshes where height is less than twice the radius.

## Key Changes
- Renamed `flockMesh.createCapsuleFromBoundingBox()` to `createShapeFromBoundingBox()` across all call sites (mesh.js, physics.js, animate.js, blockmesh.js)
- Added conditional logic to return a `PhysicsShapeBox` when mesh height is less than 2× radius, preventing degenerate capsule shapes
- Reorganized code in the shape creation function to check dimensions before calculating capsule-specific parameters
- Updated all references to use the new function name (4 files, 5 call sites)

## Implementation Details
The function now performs a dimension check early in the process:
- If `height < 2 * radius`: creates a box shape with dimensions matching the bounding box
- Otherwise: creates a capsule shape as before with the existing shrink logic

This prevents invalid capsule geometries and ensures appropriate physics behavior for all mesh proportions.

https://claude.ai/code/session_01VZjZFU3AZyeseyRxtLuEwW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined physics collision-shape generation to intelligently select between capsule and box shapes based on mesh dimensions, improving collision accuracy for vertical animations and edge-case proportions.
  * Enhanced degenerate dimension handling in collision-shape construction for more accurate physical behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->