### PR TITLE
Fix cylinder physics shape to use height instead of adjustedHeight

### DIFF
--- a/api/mesh.js
+++ b/api/mesh.js
@@ -222,12 +222,12 @@ export const flockMesh = {
     if (cylinderLength <= 0) {
       const cylinderStart = new flock.BABYLON.Vector3(
         localCenter.x,
-        localCenter.y - adjustedHeight / 2,
+        localCenter.y - height / 2,
         localCenter.z,
       );
       const cylinderEnd = new flock.BABYLON.Vector3(
         localCenter.x,
-        localCenter.y + adjustedHeight / 2,
+        localCenter.y + height / 2,
         localCenter.z,
       );
       shape = new flock.BABYLON.PhysicsShapeCylinder(
@@ -241,7 +241,7 @@ export const flockMesh = {
         {
           meshName: mesh.name,
           meshId: mesh.id,
-          adjustedHeight,
+          height,
           radius,
         },
       );*/


### PR DESCRIPTION
## Summary
Fixed a bug in the cylinder physics shape calculation where `adjustedHeight` was being used instead of the correct `height` variable.

## Key Changes
- Replaced `adjustedHeight` with `height` in cylinder start position calculation (line 225)
- Replaced `adjustedHeight` with `height` in cylinder end position calculation (line 230)
- Updated the shape metadata to reference `height` instead of `adjustedHeight` (line 244)

## Details
The cylinder physics shape was incorrectly using an `adjustedHeight` variable that doesn't appear to be defined in this scope. This has been corrected to use the `height` variable which is the appropriate parameter for calculating the cylinder's vertical extent. This ensures the physics shape dimensions match the intended geometry.

https://claude.ai/code/session_015gvXhZsqsduR6wukd4mbvW