### PR TITLE
Refactor mesh selection into shared handler and improve camera focus selection behavior

### DIFF
--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -411,7 +411,7 @@ function applyMeshSelection(pickedMesh, pickedPoint) {
     const block = meshMap[pickedMesh?.metadata?.blockKey];
     highlightBlockById(Blockly.getMainWorkspace(), block);
     gizmoManager.attachToMesh(pickedMesh);
-    pickedMesh.showBoundingBox = true;
+    enableBoundingBox(pickedMesh);
     return;
   }
 

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -380,6 +380,7 @@ function focusCameraOnMesh() {
     if (mesh && mesh.name === "ground") mesh = null;
   }
   if (!mesh) return;
+  applyMeshSelection(mesh);
 
   mesh.computeWorldMatrix(true);
   const { min, max } = mesh.getHierarchyBoundingVectors(true);
@@ -399,6 +400,36 @@ function focusCameraOnMesh() {
     newTarget.z - currentDistance,
   );
   camera.setTarget(newTarget);
+}
+
+function applyMeshSelection(pickedMesh, pickedPoint) {
+  if (pickedMesh && pickedMesh.name !== "ground") {
+    if (pickedMesh.parent) {
+      pickedMesh = getRootMesh(pickedMesh.parent);
+      pickedMesh.visibility = 0.001;
+    }
+    const block = meshMap[pickedMesh?.metadata?.blockKey];
+    highlightBlockById(Blockly.getMainWorkspace(), block);
+    gizmoManager.attachToMesh(pickedMesh);
+    pickedMesh.showBoundingBox = true;
+    return;
+  }
+
+  if (pickedMesh && pickedMesh.name === "ground") {
+    const roundedPosition = roundVectorToFixed(pickedPoint, 2);
+    flock.printText({
+      text: translate("position_readout").replace(
+        "{position}",
+        String(roundedPosition),
+      ),
+      duration: 30,
+      color: "black",
+    });
+  }
+  if (gizmoManager.attachedMesh) {
+    resetChildMeshesOfAttachedMesh();
+    gizmoManager.attachToMesh(null);
+  }
 }
 
 function viewMeshWithCamera() {
@@ -1774,34 +1805,8 @@ function handleSelectGizmo() {
         duration: 30,
         color: "black",
       });
-      if (flock.meshDebug) console.log(pickedMesh.parent);
-      if (pickedMesh.parent) {
-        pickedMesh = getRootMesh(pickedMesh.parent);
-        if (flock.meshDebug) console.log(pickedMesh.visibility);
-        pickedMesh.visibility = 0.001;
-        if (flock.meshDebug) console.log(pickedMesh.visibility);
-      }
-      const block = meshMap[pickedMesh?.metadata?.blockKey];
-      highlightBlockById(Blockly.getMainWorkspace(), block);
-      gizmoManager.attachToMesh(pickedMesh);
-      pickedMesh.showBoundingBox = true;
-    } else {
-      if (pickedMesh && pickedMesh.name === "ground") {
-        const roundedPosition = roundVectorToFixed(pickedPoint, 2);
-        flock.printText({
-          text: translate("position_readout").replace(
-            "{position}",
-            String(roundedPosition),
-          ),
-          duration: 30,
-          color: "black",
-        });
-      }
-      if (gizmoManager.attachedMesh) {
-        resetChildMeshesOfAttachedMesh();
-        gizmoManager.attachToMesh(null);
-      }
     }
+    applyMeshSelection(pickedMesh, pickedPoint);
     setTimeout(() => {
       if (!getCanvasCircle()) document.body.style.cursor = "crosshair";
     }, 0);


### PR DESCRIPTION
### Motivation
- Consolidate duplicate mesh-selection logic so selection behavior is consistent across camera focus and select gizmo paths.
- Ensure clicking a mesh (or its children) highlights the correct root mesh and associated Blockly block.
- Provide a clear readout when the ground is clicked and clean up attached gizmo state when deselecting.

### Description
- Introduces a new helper function `applyMeshSelection(pickedMesh, pickedPoint)` that centralizes selection behavior and ground click handling. 
- `focusCameraOnMesh()` now calls `applyMeshSelection` to apply the same highlighting and gizmo attachment when focusing a mesh. 
- `handleSelectGizmo()` was simplified to delegate to `applyMeshSelection`, removing duplicated code for parent/root mesh resolution, visibility adjustments, bounding-box display, block highlighting, and ground readout.
- When deselecting, the code now calls `resetChildMeshesOfAttachedMesh()` and detaches the gizmo via `gizmoManager.attachToMesh(null)` to restore child visibility consistently.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f869ac29d88326ae9f4d3c8cb7057c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Mesh selection interactions now consistently update block highlighting and gizmo attachment, providing unified visual feedback when focusing on or selecting objects in the viewport.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->