### PR TITLE
Check and handle file write permission before autosave

### DIFF
--- a/main/files.js
+++ b/main/files.js
@@ -593,6 +593,18 @@ export async function exportCode(workspace) {
 export async function autoSaveToFile(workspace) {
   if (!currentFileHandle) return;
   try {
+    if (typeof currentFileHandle.queryPermission === "function") {
+      const permission = await currentFileHandle.queryPermission({
+        mode: "readwrite",
+      });
+      if (permission !== "granted") {
+        if (permission === "denied") {
+          clearFileHandle();
+        }
+        return;
+      }
+    }
+
     const ws =
       workspace && workspace.getAllBlocks
         ? workspace


### PR DESCRIPTION
### Motivation

- Prevent autosave from throwing when the previously-selected file handle no longer grants write access and ensure stale handles are cleared.

### Description

- In `autoSaveToFile` add a safe check for `currentFileHandle.queryPermission` before attempting autosave by testing `typeof currentFileHandle.queryPermission === "function"`.
- Call `currentFileHandle.queryPermission({ mode: "readwrite" })` and return early if permission is not `granted`.
- If permission is `denied`, call `clearFileHandle()` to drop the stale handle so future autosaves use the picker flow.
- Preserve existing serialization and write logic and existing error handling via `isFileAutosavePermissionError`.

### Testing

- Ran the project test suite with `npm test`, which completed successfully.
- Ran the linter with `npm run lint`, which passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8d505e9848326aba3464a4c6e4058)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced autosave functionality to properly handle file system write permissions. The app now verifies write access before attempting to save workspace changes automatically. If write permission is denied, the stored file reference is cleared and autosave is skipped to prevent errors. This improves reliability and prevents permission-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->