### PR TITLE
Clear file handle when importing a project file instead of keeping original handle

### DIFF
--- a/main/files.js
+++ b/main/files.js
@@ -1000,8 +1000,7 @@ export async function openFile(workspace, executeCallback) {
       window.loadingCode = true;
       document.getElementById("projectName").value =
         getSafeImportedFileBaseName(file.name);
-      currentFileHandle = fileHandle;
-      updateSaveButtonState();
+      clearFileHandle();
       loadWorkspaceAndExecute(json, workspace, executeCallback);
     } catch (e) {
       if (e.name === "AbortError") return;


### PR DESCRIPTION
### Motivation
- Prevent retaining the imported file's system handle as the current project handle so the app doesn't attempt to save back to an external file or rely on stale permissions.

### Description
- In `main/files.js` within `openFile`, replace the previous `currentFileHandle = fileHandle;` and `updateSaveButtonState();` calls with a single `clearFileHandle();` call so imported projects are treated as newly loaded content without an associated external handle.

### Testing
- Ran the automated test suite with `npm test` and the tests passed; a production build via `npm run build` also completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8db0987908326a2aa4d9476c26e2f)