### PR TITLE
Fix capsule shape bottom Y calculation using physics shape geometry

### DIFF
--- a/api/animate.js
+++ b/api/animate.js
@@ -35,11 +35,33 @@ const updateCapsuleShapeForAnimation = (physicsMesh, animationName) => {
     return;
   }
 
-  // Capture pre-switch bottom Y (world)
-  physicsMesh.computeWorldMatrix?.(true);
-  physicsMesh.refreshBoundingInfo?.(true);
-  const preMinY =
-    physicsMesh.getBoundingInfo?.()?.boundingBox?.minimumWorld?.y ?? null;
+  // Read the local-space bottom Y of a capsule or cylinder shape directly from
+  // its geometry. The bounding-box approach gave preMinY ≈ postMinY for
+  // characters (mesh geometry is unchanged by capsule orientation), so the
+  // correction was always zero. Using the shape's own pointA/pointB/radius
+  // gives the actual capsule bottom regardless of orientation.
+  const getShapeLocalBottomY = (shape) => {
+    if (
+      flock?.BABYLON?.PhysicsShapeCapsule &&
+      shape instanceof flock.BABYLON.PhysicsShapeCapsule &&
+      shape.pointA &&
+      shape.pointB &&
+      shape.radius !== undefined
+    ) {
+      return Math.min(shape.pointA.y, shape.pointB.y) - shape.radius;
+    }
+    if (
+      flock?.BABYLON?.PhysicsShapeCylinder &&
+      shape instanceof flock.BABYLON.PhysicsShapeCylinder &&
+      shape.pointA &&
+      shape.pointB
+    ) {
+      return Math.min(shape.pointA.y, shape.pointB.y);
+    }
+    return null;
+  };
+
+  const preBottomLocalY = getShapeLocalBottomY(physicsMesh.physics.shape);
 
   const motionType = physicsMesh.physics.getMotionType();
   const massProps = physicsMesh.physics.getMassProperties();
@@ -72,14 +94,11 @@ const updateCapsuleShapeForAnimation = (physicsMesh, animationName) => {
   physicsMesh.physics.setMassProperties(massProps);
   physicsMesh.physics.disablePreStep = disablePreStep;
 
-  // Correct transform so bottom Y stays unchanged after shape swap
-  physicsMesh.computeWorldMatrix?.(true);
-  physicsMesh.refreshBoundingInfo?.(true);
-  const postMinY =
-    physicsMesh.getBoundingInfo?.()?.boundingBox?.minimumWorld?.y ?? null;
-
-  if (Number.isFinite(preMinY) && Number.isFinite(postMinY)) {
-    const deltaY = preMinY - postMinY;
+  // Keep the capsule bottom at the same world Y after the shape swap so the
+  // mesh does not teleport into or away from the terrain when orientation changes.
+  const postBottomLocalY = getShapeLocalBottomY(newShape);
+  if (Number.isFinite(preBottomLocalY) && Number.isFinite(postBottomLocalY)) {
+    const deltaY = preBottomLocalY - postBottomLocalY;
     if (Math.abs(deltaY) > 1e-5) {
       physicsMesh.position.y += deltaY;
       physicsMesh.computeWorldMatrix?.(true);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Flock",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "Flock",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "dependencies": {
         "@babylonjs/addons": "^8.56.0",
         "@babylonjs/core": "^8.56.0",
@@ -18,9 +18,11 @@
         "@babylonjs/serializers": "^8.56.0",
         "@blockly/block-dynamic-connection": "^0.8.8",
         "@blockly/block-plus-minus": "^9.0.9",
+        "@blockly/block-shareable-procedures": "^6.0.10",
         "@blockly/field-colour": "^6.0.11",
         "@blockly/field-grid-dropdown": "^6.0.9",
         "@blockly/keyboard-navigation": "^3.0.3",
+        "@blockly/plugin-cross-tab-copy-paste": "^8.0.7",
         "@blockly/plugin-scroll-options": "^7.0.8",
         "@blockly/plugin-workspace-search": "^10.1.7",
         "@blockly/toolbox-search": "^3.1.8",
@@ -33,7 +35,6 @@
         "babylonjs-serializers": "^8.56.0",
         "blockly": "^12.3.1",
         "earcut": "^3.0.2",
-        "Flock": "file:",
         "manifold-3d": "^3.4.0",
         "opentype.js": "^1.3.4",
         "ses": "^1.15.0",
@@ -5514,10 +5515,6 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/Flock": {
-      "resolved": "",
-      "link": true
     },
     "node_modules/for-each": {
       "version": "0.3.5",


### PR DESCRIPTION
## Summary
Fixed an issue where character meshes would teleport when their capsule physics shape orientation changed during animations. The previous implementation used bounding box calculations which failed to detect actual capsule position changes, resulting in zero correction.

## Key Changes
- Replaced bounding box-based bottom Y detection with direct physics shape geometry inspection
- Added `getShapeLocalBottomY()` helper function that reads capsule/cylinder shape properties (`pointA`, `pointB`, `radius`) to calculate the actual local-space bottom Y coordinate
- Updated the pre/post shape swap comparison to use local-space shape geometry instead of world-space bounding boxes
- Improved code comments to explain why the shape geometry approach is necessary

## Implementation Details
The new approach directly accesses the physics shape's geometric properties:
- For `PhysicsShapeCapsule`: calculates bottom as `min(pointA.y, pointB.y) - radius`
- For `PhysicsShapeCylinder`: calculates bottom as `min(pointA.y, pointB.y)`
- This gives the actual capsule bottom regardless of mesh orientation, whereas the bounding box approach was unchanged by capsule orientation since the mesh geometry itself doesn't rotate

The position correction now properly maintains the capsule's world-space bottom Y coordinate across shape swaps, preventing unwanted mesh teleportation.

https://claude.ai/code/session_016MZQHro8AWTT3iqvNUf5Mj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added animation management controls: play, pause, and stop animations by group or model
  * Enhanced capsule shape positioning during animation transitions for improved visual alignment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->