### PR TITLE
Bug fixes - general UI keyboard controls

### DIFF
--- a/main/accessibility.js
+++ b/main/accessibility.js
@@ -231,11 +231,19 @@ const GizmoMenuManager = {
     );
 
     const gizmoButtons = document.getElementById("gizmoButtons");
+    const resizer = document.getElementById("resizer");
     if (gizmoButtons) {
       // Move the badges if the window is resized
       new ResizeObserver(() => {
         if (this.isOpen()) this.renderBadges();
       }).observe(gizmoButtons);
+    }
+    if (resizer) {
+      new MutationObserver(() => {
+        if (!resizer.classList.contains("resizing") && this.isOpen()) {
+          this.renderBadges();
+        }
+      }).observe(resizer, { attributes: true, attributeFilter: ["class"] });
     }
   },
 

--- a/main/accessibility.js
+++ b/main/accessibility.js
@@ -225,12 +225,17 @@ const GizmoMenuManager = {
       true,
     );
 
-    // Move the badges if the window is resized
     const gizmoButtons = document.getElementById("gizmoButtons");
     if (gizmoButtons) {
+      // Move the badges if the window is resized
       new ResizeObserver(() => {
         if (this.isOpen()) this.renderBadges();
       }).observe(gizmoButtons);
+
+      // Hide buttons if a gizmo is clicked
+      gizmoButtons.addEventListener("click", () => {
+        if (this.isOpen()) this.toggle(false);
+      });
     }
   },
 

--- a/main/accessibility.js
+++ b/main/accessibility.js
@@ -224,6 +224,14 @@ const GizmoMenuManager = {
       },
       true,
     );
+
+    // Move the badges if the window is resized
+    const gizmoButtons = document.getElementById("gizmoButtons");
+    if (gizmoButtons) {
+      new ResizeObserver(() => {
+        if (this.isOpen()) this.renderBadges();
+      }).observe(gizmoButtons);
+    }
   },
 
   activateButton(entry) {
@@ -412,7 +420,13 @@ const ShortcutsPanel = {
       ) {
         const t = e.target;
         const tag = (t?.tagName || "").toLowerCase();
-        if (t?.isContentEditable || tag === "input" || tag === "textarea" || tag === "select") return;
+        if (
+          t?.isContentEditable ||
+          tag === "input" ||
+          tag === "textarea" ||
+          tag === "select"
+        )
+          return;
 
         if (e.key === "ArrowLeft") {
           e.preventDefault();

--- a/main/accessibility.js
+++ b/main/accessibility.js
@@ -361,6 +361,7 @@ function formatKeys(keys) {
 const ShortcutsPanel = {
   panel: null,
   dock: "left",
+  previousFocus: null,
 
   init() {
     this.createPanel();
@@ -373,12 +374,12 @@ const ShortcutsPanel = {
     div.className = "shortcuts-panel hidden shortcuts-panel--left";
     div.setAttribute("role", "region");
     div.setAttribute("aria-label", "Keyboard shortcuts");
-    div.innerHTML = `
-      <div class="shortcuts-panel__content">
+    div.tabIndex = 0;
+    div.innerHTML = `      
         <button type="button" class="close-button" id="closeShortcutsPanel" aria-label="Close keyboard shortcuts">&times;</button>
         <h1 id="shortcuts-panel-title">Keyboard shortcuts</h1>
         <table id="shortcuts-table"><tbody></tbody></table>
-      </div>`;
+      `;
     document.body.appendChild(div);
     this.panel = div;
   },
@@ -397,11 +398,15 @@ const ShortcutsPanel = {
     `,
       )
       .join("");
+    this.previousFocus = document.activeElement;
     this.panel.classList.remove("hidden");
+    this.panel.focus();
   },
 
   hide() {
     this.panel.classList.add("hidden");
+    this.previousFocus?.focus();
+    this.previousFocus = null;
   },
 
   toggle() {
@@ -418,39 +423,26 @@ const ShortcutsPanel = {
     document.addEventListener("click", (e) => {
       if (e.target.id === "closeShortcutsPanel") this.hide();
     });
-    document.addEventListener("keydown", (e) => {
-      if (
-        (e.ctrlKey || e.metaKey) &&
-        !this.panel.classList.contains("hidden")
-      ) {
-        const t = e.target;
-        const tag = (t?.tagName || "").toLowerCase();
-        if (
-          t?.isContentEditable ||
-          tag === "input" ||
-          tag === "textarea" ||
-          tag === "select"
-        )
-          return;
-
-        if (e.key === "ArrowLeft") {
-          e.preventDefault();
-          this.setDock("left");
-        }
-        if (e.key === "ArrowRight") {
-          e.preventDefault();
-          this.setDock("right");
-        }
-        if (e.key === "ArrowUp") {
-          e.preventDefault();
-          const content = this.panel.querySelector(".shortcuts-panel__content");
-          content.scrollBy({ top: -100, behavior: "instant" });
-        }
-        if (e.key === "ArrowDown") {
-          e.preventDefault();
-          const content = this.panel.querySelector(".shortcuts-panel__content");
-          content.scrollBy({ top: 100, behavior: "instant" });
-        }
+    this.panel.addEventListener("keydown", (e) => {
+      if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        this.setDock("left");
+      }
+      if (e.key === "ArrowRight") {
+        e.preventDefault();
+        this.setDock("right");
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        this.panel.scrollBy({ top: -100, behavior: "instant" });
+      }
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        this.panel.scrollBy({ top: 100, behavior: "instant" });
+      }
+      if (e.key === "Tab") {
+        e.preventDefault();
+        this.hide();
       }
     });
   },

--- a/main/accessibility.js
+++ b/main/accessibility.js
@@ -32,6 +32,7 @@ const AreaManager = {
   toggle(show) {
     if (this.overlay) {
       if (show) {
+        GizmoMenuManager.toggle(false); // Close gizmo menu if open
         this.renderHighlights();
         setTimeout(
           () => this.overlay.querySelector(".area-number-badge")?.focus(),
@@ -220,6 +221,10 @@ const GizmoMenuManager = {
         if (e.key >= "1" && e.key <= "9") {
           const entry = this.buttons.find((b) => b.label === e.key);
           if (entry) this.activateButton(entry);
+        }
+        if (e.key === "Escape") {
+          e.preventDefault();
+          this.toggle(false);
         }
       },
       true,
@@ -440,7 +445,7 @@ const ShortcutsPanel = {
         e.preventDefault();
         this.panel.scrollBy({ top: 100, behavior: "instant" });
       }
-      if (e.key === "Tab") {
+      if (e.key === "Tab" || e.key === "Escape") {
         e.preventDefault();
         e.stopPropagation();
         this.hide();

--- a/main/accessibility.js
+++ b/main/accessibility.js
@@ -236,11 +236,6 @@ const GizmoMenuManager = {
       new ResizeObserver(() => {
         if (this.isOpen()) this.renderBadges();
       }).observe(gizmoButtons);
-
-      // Hide buttons if a gizmo is clicked
-      gizmoButtons.addEventListener("click", () => {
-        if (this.isOpen()) this.toggle(false);
-      });
     }
   },
 

--- a/main/accessibility.js
+++ b/main/accessibility.js
@@ -404,9 +404,9 @@ const ShortcutsPanel = {
   },
 
   hide() {
-    this.panel.classList.add("hidden");
     this.previousFocus?.focus();
     this.previousFocus = null;
+    this.panel.classList.add("hidden");
   },
 
   toggle() {
@@ -442,6 +442,7 @@ const ShortcutsPanel = {
       }
       if (e.key === "Tab") {
         e.preventDefault();
+        e.stopPropagation();
         this.hide();
       }
     });

--- a/style.css
+++ b/style.css
@@ -1604,28 +1604,24 @@ kbd {
 .shortcuts-panel {
   position: fixed;
   top: 0;
-  left: 0;
-  right: 0;
   bottom: 0;
-  pointer-events: none;
+  width: min(300px, 100%);
+  background-color: var(--color-bg);
+  padding: 1.5em;
+  overflow-y: auto;
   z-index: 10002;
 }
 
-.shortcuts-panel__content {
-  position: absolute;
-  pointer-events: auto;
-  top: 0;
-  bottom: 0;
-  background-color: var(--color-bg);
-  padding: 1.5em;
-  width: min(300px, 100%);
-  overflow-y: auto;
-}
-
-.shortcuts-panel--left .shortcuts-panel__content {
+.shortcuts-panel--left {
   left: 0;
 }
 
-.shortcuts-panel--right .shortcuts-panel__content {
+.shortcuts-panel--right {
   right: 0;
+  left: auto;
+}
+
+.shortcuts-panel:focus {
+  outline: 2px solid var(--color-focus);
+  outline-offset: -2px;
 }

--- a/ui/canvas-utils.js
+++ b/ui/canvas-utils.js
@@ -158,6 +158,7 @@ function ensureCircle() {
 // Deal with key down events for canvas keyboard mode
 function handleKeydown(event) {
   if (!keyboardCursorActive) return;
+  if (event.target?.closest?.(".shortcuts-panel")) return;
 
   // If a button was focused and they pressed enter/space, don't
   // move the circle, interact with the button
@@ -253,7 +254,7 @@ export function setCrosshairCursor() {
 // Restore default cursor
 export function setDefaultCursor() {
   document.body.style.cursor = "default";
- if (flock.scene) {
+  if (flock.scene) {
     flock.scene.hoverCursor = "pointer"; // Babylon.js default
     flock.scene.defaultCursor = ""; // Babylon.js default (inherits from body)
   }


### PR DESCRIPTION
# Summary
Bug fixes for gizmo menu and keyboard shortcut panel

- Gizmo number buttons now move correctly if the canvas is resized
- Keyboard shortcut panel is now focused on open and can be closed with Esc or Tab to move focus back to previous focus
- If the keyboard shortcut panel is focused, arrow keys control docking (L, R) and scrolling (U, D), focus is not stolen by the keyboard cursor

### AI usage
Claude Sonnet 4.6 used for advice, code added and directed by a human. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full keyboard navigation for the shortcuts panel (Arrow keys to navigate/scroll, Escape to close) with a visible close button and automatic focus save/restore.

* **Improvements**
  * Opening the shortcuts overlay now closes the Gizmo menu first; Gizmo overlay also supports Escape to dismiss and better alignment on resize.
  * Prevented unintended canvas keyboard movement while interacting with the shortcuts panel.

* **Style**
  * Added dedicated styling for a bottom-anchored, left/right shortcuts panel overlay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->