### PR TITLE
Update CI to also run on Windows and add Node.js 24.x

### DIFF
--- a/.github/workflows/run-mocha-tests.yml
+++ b/.github/workflows/run-mocha-tests.yml
@@ -17,12 +17,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-2022]
         node-version: [20.x, 22.x, 24.x]
-
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-2022]
-        node-version: [20.x, 22.x, 24.x]
-      # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.github/workflows/run-mocha-tests.yml
+++ b/.github/workflows/run-mocha-tests.yml
@@ -11,7 +11,12 @@ on:
 
 jobs:
   build:
-    runs-on: ["ubuntu-latest", "windows-2022"]
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-2022]
+        node-version: [20.x, 22.x, 24.x]
 
     strategy:
       matrix:

--- a/.github/workflows/run-mocha-tests.yml
+++ b/.github/workflows/run-mocha-tests.yml
@@ -20,7 +20,9 @@ jobs:
 
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-2022]
         node-version: [20.x, 22.x, 24.x]
+      # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.github/workflows/run-mocha-tests.yml
+++ b/.github/workflows/run-mocha-tests.yml
@@ -11,11 +11,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ["ubuntu-latest", "windows-2022"]
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
Updating the test runner so the smoke tests are run on Microsoft Windows. Also updated the set of Node versions as these had dropped behind Node's release schedule https://nodejs.org/en/about/previous-releases 

This Pull Request will trigger the tests to run on Microsoft Windows. We may need to revise the configuration to run the tests on Windows. This was initiated in response to changes in #611 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Test workflow now runs on both Ubuntu and Windows runners.
  * Node.js testing matrix expanded to include 20.x, 22.x, and 24.x.
  * Cross-platform API test job maintained to ensure consistent test execution across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->