### PR TITLE
Translations for kb shortcut panel

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,5 +1,8 @@
 import { getDropdownOption, translate } from "./main/translation.js";
 
+export const SHORTCUTS_HELP_URL =
+  "https://hub.flockxr.com/knowledge-base/keyboard-controls/";
+
 export const themeNames = [
   "theme-bright.mp3",
   "theme-calm.mp3",
@@ -428,7 +431,6 @@ export const attachNames = [
   "RightLeg",
   "RightFoot",
 ];
-
 
 export const attachBlockMapping = {
   LeftHand: "Hold",

--- a/locale/de.js
+++ b/locale/de.js
@@ -1208,4 +1208,44 @@ export default {
   RightUpLeg_option: "Rechter Oberschenkel",
   RightLeg_option: "Rechtes Schienbein",
   RightFoot_option: "Rechter Fuß",
+
+  // Keyboard shortcuts panel — title and close button
+  shortcut_panel_title: "Tastaturkürzel",
+  shortcut_panel_close: "Tastaturkürzel schließen",
+
+  // Keyboard shortcuts panel — labels
+  shortcut_show_hide_help: "Tastaturkürzel ein-/ausblenden",
+  shortcut_move_between_areas: "Zwischen Menüs, Canvas und Editor wechseln",
+  shortcut_confirm: "Bestätigen",
+  shortcut_exit: "Beenden",
+  shortcut_play: "Abspielen",
+  shortcut_undo: "Rückgängig",
+  shortcut_redo: "Wiederholen",
+  shortcut_browser_nav:
+    "Browser-Adressleiste (überschriebene Tastaturkürzel funktionieren von hier)",
+  shortcut_main_menu: "Hauptmenü",
+  shortcut_open_file: "Datei öffnen",
+  shortcut_save_export: "Speichern / Exportieren",
+  shortcut_open_close_area_menu: "Bereichsmenü öffnen/schließen",
+  shortcut_toggle_area: "Bereich umschalten",
+  shortcut_select_area: "Bereich auswählen",
+  shortcut_code_editor: "Code-Editor",
+  shortcut_add_block_by_name: "Block nach Name hinzufügen",
+  shortcut_search_block: "Nach einem Block suchen",
+  shortcut_move_through_blocks: "Durch Blöcke navigieren",
+  shortcut_open_gizmos: "Gizmos",
+  shortcut_select_gizmo: "Gizmo auswählen",
+  shortcut_keyboard_cursor_gizmos: "Tastaturcursor für Gizmos",
+  shortcut_lock_transform: "Transformation auf Achse einschränken",
+  shortcut_transform_3d: "In 3D transformieren",
+  shortcut_focus_camera: "Kamera auf Objekt ausrichten",
+  shortcut_quick_colour: "Schnellfarbauswahl im Farbwähler",
+  shortcut_delete_object: "Objekt löschen",
+
+  // Keyboard shortcuts panel — category names
+  shortcut_category_main: "Allgemein",
+  shortcut_category_menu: "Menü",
+  shortcut_category_area_menu: "Bereichsmenü",
+  shortcut_category_editor: "Editor",
+  shortcut_category_gizmos: "Gizmos",
 };

--- a/locale/en.js
+++ b/locale/en.js
@@ -150,8 +150,7 @@ export default {
     "glide %1 to x: %2 y: %3 z: %4 in %5 seconds \n%6 return? %7 loop? %8 %9",
   glide_to_object:
     "glide %1 to %2 in %6 seconds \noffset x: %3 y: %4 z: %5\n%7 return? %8 loop? %9 %10",
-  glide_to_axis:
-    "glide %1 %2 %3 in %4 seconds\n%5 return? %6 loop? %7 %8",
+  glide_to_axis: "glide %1 %2 %3 in %4 seconds\n%5 return? %6 loop? %7 %8",
   rotate_to_object: "rotate %1 %2 %3 in %4 seconds\n%5 reverse? %6 loop? %7 %8",
   rotate_anim:
     "rotate %1 to x: %2 y: %3 z: %4 in %5 ms\n%6 reverse? %7 loop? %8  %9",
@@ -1272,7 +1271,8 @@ export default {
   shortcut_play: "Play",
   shortcut_undo: "Undo",
   shortcut_redo: "Redo",
-  shortcut_browser_nav: "Browser navigation bar (overriden shortcuts work from here)",
+  shortcut_browser_nav:
+    "Browser navigation bar (overridden shortcuts work from here)",
   shortcut_main_menu: "Main menu",
   shortcut_open_file: "Open file",
   shortcut_save_export: "Save / export",

--- a/locale/en.js
+++ b/locale/en.js
@@ -1259,4 +1259,43 @@ export default {
   // Service worker update notification
   update_available_ui: "A new version of Flock is available.",
   reload_button_ui: "Reload",
+
+  // Keyboard shortcuts panel — title and close button
+  shortcut_panel_title: "Keyboard shortcuts",
+  shortcut_panel_close: "Close keyboard shortcuts",
+
+  // Keyboard shortcuts panel — labels
+  shortcut_show_hide_help: "Show/hide shortcut help",
+  shortcut_move_between_areas: "Move between menus, canvas and editor",
+  shortcut_confirm: "Confirm",
+  shortcut_exit: "Exit",
+  shortcut_play: "Play",
+  shortcut_undo: "Undo",
+  shortcut_redo: "Redo",
+  shortcut_browser_nav: "Browser navigation bar (overriden shortcuts work from here)",
+  shortcut_main_menu: "Main menu",
+  shortcut_open_file: "Open file",
+  shortcut_save_export: "Save / export",
+  shortcut_open_close_area_menu: "Open/close area menu",
+  shortcut_toggle_area: "Toggle area",
+  shortcut_select_area: "Select area",
+  shortcut_code_editor: "Code editor",
+  shortcut_add_block_by_name: "Add block by name",
+  shortcut_search_block: "Search for a block",
+  shortcut_move_through_blocks: "Move through blocks",
+  shortcut_open_gizmos: "Gizmos",
+  shortcut_select_gizmo: "Select gizmo",
+  shortcut_keyboard_cursor_gizmos: "Keyboard cursor for gizmos",
+  shortcut_lock_transform: "Lock transform to axis",
+  shortcut_transform_3d: "Transform in 3D",
+  shortcut_focus_camera: "Focus camera on object",
+  shortcut_quick_colour: "Quick use colour in colour picker",
+  shortcut_delete_object: "Delete object",
+
+  // Keyboard shortcuts panel — category names
+  shortcut_category_main: "Main",
+  shortcut_category_menu: "Menu",
+  shortcut_category_area_menu: "Area menu",
+  shortcut_category_editor: "Editor",
+  shortcut_category_gizmos: "Gizmos",
 };

--- a/locale/es.js
+++ b/locale/es.js
@@ -1221,4 +1221,44 @@ export default {
   RightUpLeg_option: "Muslo derecho", // human
   RightLeg_option: "Espinilla derecha", // human
   RightFoot_option: "Pie derecho", // human
+
+  // Keyboard shortcuts panel — title and close button
+  shortcut_panel_title: "Atajos de teclado",
+  shortcut_panel_close: "Cerrar atajos de teclado",
+
+  // Keyboard shortcuts panel — labels
+  shortcut_show_hide_help: "Mostrar/ocultar atajos de teclado",
+  shortcut_move_between_areas: "Moverse entre menús, canvas y editor",
+  shortcut_confirm: "Confirmar",
+  shortcut_exit: "Salir",
+  shortcut_play: "Reproducir",
+  shortcut_undo: "Deshacer",
+  shortcut_redo: "Rehacer",
+  shortcut_browser_nav:
+    "Barra de navegación del navegador (los atajos bloqueados funcionan desde aquí)",
+  shortcut_main_menu: "Menú principal",
+  shortcut_open_file: "Abrir archivo",
+  shortcut_save_export: "Guardar / exportar",
+  shortcut_open_close_area_menu: "Abrir/cerrar menú de áreas",
+  shortcut_toggle_area: "Cambiar área",
+  shortcut_select_area: "Seleccionar área",
+  shortcut_code_editor: "Editor de código",
+  shortcut_add_block_by_name: "Añadir bloque por nombre",
+  shortcut_search_block: "Buscar un bloque",
+  shortcut_move_through_blocks: "Navegar por los bloques",
+  shortcut_open_gizmos: "Gizmos",
+  shortcut_select_gizmo: "Seleccionar gizmo",
+  shortcut_keyboard_cursor_gizmos: "Cursor de teclado para gizmos",
+  shortcut_lock_transform: "Bloquear transformación en eje",
+  shortcut_transform_3d: "Transformar en 3D",
+  shortcut_focus_camera: "Enfocar cámara en objeto",
+  shortcut_quick_colour: "Usar color rápido en el selector de color",
+  shortcut_delete_object: "Eliminar objeto",
+
+  // Keyboard shortcuts panel — category names
+  shortcut_category_main: "General",
+  shortcut_category_menu: "Menú",
+  shortcut_category_area_menu: "Menú de áreas",
+  shortcut_category_editor: "Editor",
+  shortcut_category_gizmos: "Gizmos",
 };

--- a/locale/fr.js
+++ b/locale/fr.js
@@ -147,8 +147,7 @@ export default {
     "glisser %1 vers x %2 y %3 z %4 en %5 secondes \n%6 retour? %7 boucle? %8 %9",
   glide_to_object:
     "glisser %1 vers %2 en %6 secondes\ndécalage x: %3 y: %4 z: %5\n%7 retour? %8 boucle? %9 %10",
-  glide_to_axis:
-    "glisser %1 %2 %3 en %4 secondes\n%5 retour? %6 boucle? %7 %8",
+  glide_to_axis: "glisser %1 %2 %3 en %4 secondes\n%5 retour? %6 boucle? %7 %8",
   rotate_anim:
     "tourner %1 vers x %2 y %3 z %4 en %5 ms\n%6 inverse? %7 boucle? %8 %9",
   rotate_anim_seconds:
@@ -1220,4 +1219,44 @@ export default {
   RightUpLeg_option: "Cuisse droite",
   RightLeg_option: "Tibia droit",
   RightFoot_option: "Pied droit",
+
+  // Keyboard shortcuts panel — title and close button
+  shortcut_panel_title: "Raccourcis clavier",
+  shortcut_panel_close: "Fermer les raccourcis clavier",
+
+  // Keyboard shortcuts panel — labels
+  shortcut_show_hide_help: "Afficher/masquer les raccourcis clavier",
+  shortcut_move_between_areas: "Se déplacer entre les menus, le canvas et l'éditeur",
+  shortcut_confirm: "Confirmer",
+  shortcut_exit: "Quitter",
+  shortcut_play: "Lancer",
+  shortcut_undo: "Annuler",
+  shortcut_redo: "Rétablir",
+  shortcut_browser_nav:
+    "Barre d'adresse du navigateur (les raccourcis bloqués fonctionnent depuis ici)",
+  shortcut_main_menu: "Menu principal",
+  shortcut_open_file: "Ouvrir un fichier",
+  shortcut_save_export: "Enregistrer / exporter",
+  shortcut_open_close_area_menu: "Ouvrir/fermer le menu des zones",
+  shortcut_toggle_area: "Changer de zone",
+  shortcut_select_area: "Sélectionner une zone",
+  shortcut_code_editor: "Éditeur de code",
+  shortcut_add_block_by_name: "Ajouter un bloc par nom",
+  shortcut_search_block: "Rechercher un bloc",
+  shortcut_move_through_blocks: "Naviguer dans les blocs",
+  shortcut_open_gizmos: "Gizmos",
+  shortcut_select_gizmo: "Sélectionner un gizmo",
+  shortcut_keyboard_cursor_gizmos: "Curseur clavier pour les gizmos",
+  shortcut_lock_transform: "Verrouiller la transformation sur un axe",
+  shortcut_transform_3d: "Transformer en 3D",
+  shortcut_focus_camera: "Centrer la caméra sur l'objet",
+  shortcut_quick_colour: "Utiliser rapidement une couleur dans le sélecteur",
+  shortcut_delete_object: "Supprimer l'objet",
+
+  // Keyboard shortcuts panel — category names
+  shortcut_category_main: "Général",
+  shortcut_category_menu: "Menu",
+  shortcut_category_area_menu: "Menu des zones",
+  shortcut_category_editor: "Éditeur",
+  shortcut_category_gizmos: "Gizmos",
 };

--- a/locale/it.js
+++ b/locale/it.js
@@ -152,8 +152,7 @@ export default {
     "scivola %1 a x %2 y %3 z %4 in %5 secondi \n%6 ritorna? %7 ripeti? %8 %9",
   glide_to_object:
     "scivola %1 verso %2 in %6 secondi\noffset x: %3 y: %4 z: %5\n%7 ritorna? %8 ripeti? %9 %10",
-  glide_to_axis:
-    "scivola %1 %2 %3 in %4 secondi\n%5 ritorna? %6 ripeti? %7 %8",
+  glide_to_axis: "scivola %1 %2 %3 in %4 secondi\n%5 ritorna? %6 ripeti? %7 %8",
   rotate_anim:
     "ruota %1 a x %2 y %3 z %4 in %5 ms\n%6 inverti? %7 ripeti? %8  %9",
   rotate_anim_seconds:
@@ -1211,4 +1210,44 @@ export default {
   RightUpLeg_option: "Coscia destra",
   RightLeg_option: "Stinco destro",
   RightFoot_option: "Piede destro",
+
+  // Keyboard shortcuts panel — title and close button
+  shortcut_panel_title: "Scorciatoie da tastiera",
+  shortcut_panel_close: "Chiudi le scorciatoie da tastiera",
+
+  // Keyboard shortcuts panel — labels
+  shortcut_show_hide_help: "Mostra/nascondi scorciatoie da tastiera",
+  shortcut_move_between_areas: "Spostarsi tra menu, canvas ed editor",
+  shortcut_confirm: "Conferma",
+  shortcut_exit: "Esci",
+  shortcut_play: "Avvia",
+  shortcut_undo: "Annulla",
+  shortcut_redo: "Ripristina",
+  shortcut_browser_nav:
+    "Barra degli indirizzi del browser (le scorciatoie bloccate funzionano da qui)",
+  shortcut_main_menu: "Menu principale",
+  shortcut_open_file: "Apri file",
+  shortcut_save_export: "Salva / esporta",
+  shortcut_open_close_area_menu: "Apri/chiudi menu delle aree",
+  shortcut_toggle_area: "Cambia area",
+  shortcut_select_area: "Seleziona area",
+  shortcut_code_editor: "Editor di codice",
+  shortcut_add_block_by_name: "Aggiungi blocco per nome",
+  shortcut_search_block: "Cerca un blocco",
+  shortcut_move_through_blocks: "Navigare tra i blocchi",
+  shortcut_open_gizmos: "Gizmos",
+  shortcut_select_gizmo: "Seleziona gizmo",
+  shortcut_keyboard_cursor_gizmos: "Cursore da tastiera per i gizmos",
+  shortcut_lock_transform: "Blocca trasformazione sull'asse",
+  shortcut_transform_3d: "Trasforma in 3D",
+  shortcut_focus_camera: "Centra la telecamera sull'oggetto",
+  shortcut_quick_colour: "Uso rapido del colore nel selettore colori",
+  shortcut_delete_object: "Elimina oggetto",
+
+  // Keyboard shortcuts panel — category names
+  shortcut_category_main: "Generale",
+  shortcut_category_menu: "Menu",
+  shortcut_category_area_menu: "Menu delle aree",
+  shortcut_category_editor: "Editor",
+  shortcut_category_gizmos: "Gizmos",
 };

--- a/locale/pl.js
+++ b/locale/pl.js
@@ -1215,4 +1215,44 @@ export default {
   RightUpLeg_option: "Prawe udo",
   RightLeg_option: "Prawe podudzie",
   RightFoot_option: "Prawa stopa",
+
+  // Keyboard shortcuts panel — title and close button
+  shortcut_panel_title: "Skróty klawiaturowe",
+  shortcut_panel_close: "Zamknij skróty klawiaturowe",
+
+  // Keyboard shortcuts panel — labels
+  shortcut_show_hide_help: "Pokaż/ukryj skróty klawiaturowe",
+  shortcut_move_between_areas: "Przechodzenie między menu, płótnem i edytorem",
+  shortcut_confirm: "Potwierdź",
+  shortcut_exit: "Wyjdź",
+  shortcut_play: "Uruchom",
+  shortcut_undo: "Cofnij",
+  shortcut_redo: "Ponów",
+  shortcut_browser_nav:
+    "Pasek adresu przeglądarki (zablokowane skróty działają stąd)",
+  shortcut_main_menu: "Menu główne",
+  shortcut_open_file: "Otwórz plik",
+  shortcut_save_export: "Zapisz / eksportuj",
+  shortcut_open_close_area_menu: "Otwórz/zamknij menu obszarów",
+  shortcut_toggle_area: "Przełącz obszar",
+  shortcut_select_area: "Wybierz obszar",
+  shortcut_code_editor: "Edytor kodu",
+  shortcut_add_block_by_name: "Dodaj blok według nazwy",
+  shortcut_search_block: "Szukaj bloku",
+  shortcut_move_through_blocks: "Nawiguj między blokami",
+  shortcut_open_gizmos: "Gizmos",
+  shortcut_select_gizmo: "Wybierz gizmo",
+  shortcut_keyboard_cursor_gizmos: "Kursor klawiatury dla gizmos",
+  shortcut_lock_transform: "Zablokuj transformację na osi",
+  shortcut_transform_3d: "Transformuj w 3D",
+  shortcut_focus_camera: "Skieruj kamerę na obiekt",
+  shortcut_quick_colour: "Szybkie użycie koloru w selektorze kolorów",
+  shortcut_delete_object: "Usuń obiekt",
+
+  // Keyboard shortcuts panel — category names
+  shortcut_category_main: "Ogólne",
+  shortcut_category_menu: "Menu",
+  shortcut_category_area_menu: "Menu obszarów",
+  shortcut_category_editor: "Edytor",
+  shortcut_category_gizmos: "Gizmos",
 };

--- a/locale/pt.js
+++ b/locale/pt.js
@@ -1207,4 +1207,44 @@ export default {
   RightUpLeg_option: "Coxa direita",
   RightLeg_option: "Canela direita",
   RightFoot_option: "Pé direito",
+
+  // Keyboard shortcuts panel — title and close button
+  shortcut_panel_title: "Atalhos de teclado",
+  shortcut_panel_close: "Fechar atalhos de teclado",
+
+  // Keyboard shortcuts panel — labels
+  shortcut_show_hide_help: "Mostrar/ocultar atalhos de teclado",
+  shortcut_move_between_areas: "Mover entre menus, canvas e editor",
+  shortcut_confirm: "Confirmar",
+  shortcut_exit: "Sair",
+  shortcut_play: "Executar",
+  shortcut_undo: "Desfazer",
+  shortcut_redo: "Refazer",
+  shortcut_browser_nav:
+    "Barra de endereço do navegador (atalhos bloqueados funcionam daqui)",
+  shortcut_main_menu: "Menu principal",
+  shortcut_open_file: "Abrir ficheiro",
+  shortcut_save_export: "Guardar / exportar",
+  shortcut_open_close_area_menu: "Abrir/fechar menu de áreas",
+  shortcut_toggle_area: "Alternar área",
+  shortcut_select_area: "Selecionar área",
+  shortcut_code_editor: "Editor de código",
+  shortcut_add_block_by_name: "Adicionar bloco por nome",
+  shortcut_search_block: "Procurar um bloco",
+  shortcut_move_through_blocks: "Navegar pelos blocos",
+  shortcut_open_gizmos: "Gizmos",
+  shortcut_select_gizmo: "Selecionar gizmo",
+  shortcut_keyboard_cursor_gizmos: "Cursor de teclado para gizmos",
+  shortcut_lock_transform: "Bloquear transformação no eixo",
+  shortcut_transform_3d: "Transformar em 3D",
+  shortcut_focus_camera: "Focar câmara no objeto",
+  shortcut_quick_colour: "Uso rápido de cor no seletor de cores",
+  shortcut_delete_object: "Eliminar objeto",
+
+  // Keyboard shortcuts panel — category names
+  shortcut_category_main: "Geral",
+  shortcut_category_menu: "Menu",
+  shortcut_category_area_menu: "Menu de áreas",
+  shortcut_category_editor: "Editor",
+  shortcut_category_gizmos: "Gizmos",
 };

--- a/locale/sv.js
+++ b/locale/sv.js
@@ -147,8 +147,7 @@ export default {
     "glid %1 till x %2 y %3 z %4 på %5 sekunder\n%6 återvända? %7 loop? %8 %9",
   glide_to_object:
     "glid %1 till %2 på %6 sekunder\nförskjutning x: %3 y: %4 z: %5\n%7 återvända? %8 loop? %9 %10",
-  glide_to_axis:
-    "glid %1 %2 %3 på %4 sekunder\n%5 återvända? %6 loop? %7 %8",
+  glide_to_axis: "glid %1 %2 %3 på %4 sekunder\n%5 återvända? %6 loop? %7 %8",
   rotate_anim:
     "rotera %1 till x %2 y %3 z %4 på %5 ms\n%6 omvänd? %7 loop? %8  %9",
   rotate_anim_seconds:
@@ -1198,4 +1197,44 @@ export default {
   RightUpLeg_option: "Höger lår",
   RightLeg_option: "Höger smalben",
   RightFoot_option: "Höger fot",
+
+  // Keyboard shortcuts panel — title and close button
+  shortcut_panel_title: "Tangentbordsgenvägar",
+  shortcut_panel_close: "Stäng tangentbordsgenvägar",
+
+  // Keyboard shortcuts panel — labels
+  shortcut_show_hide_help: "Visa/dölj tangentbordsgenvägar",
+  shortcut_move_between_areas: "Flytta mellan menyer, canvas och editor",
+  shortcut_confirm: "Bekräfta",
+  shortcut_exit: "Avsluta",
+  shortcut_play: "Kör",
+  shortcut_undo: "Ångra",
+  shortcut_redo: "Gör om",
+  shortcut_browser_nav:
+    "Webbläsarens adressfält (blockerade genvägar fungerar härifrån)",
+  shortcut_main_menu: "Huvudmeny",
+  shortcut_open_file: "Öppna fil",
+  shortcut_save_export: "Spara / exportera",
+  shortcut_open_close_area_menu: "Öppna/stäng områdesmeny",
+  shortcut_toggle_area: "Växla område",
+  shortcut_select_area: "Välj område",
+  shortcut_code_editor: "Kodeditor",
+  shortcut_add_block_by_name: "Lägg till block efter namn",
+  shortcut_search_block: "Sök efter ett block",
+  shortcut_move_through_blocks: "Navigera bland block",
+  shortcut_open_gizmos: "Gizmos",
+  shortcut_select_gizmo: "Välj gizmo",
+  shortcut_keyboard_cursor_gizmos: "Tangentbordskursor för gizmos",
+  shortcut_lock_transform: "Lås transformering till axel",
+  shortcut_transform_3d: "Transformera i 3D",
+  shortcut_focus_camera: "Rikta kameran mot objekt",
+  shortcut_quick_colour: "Snabb färganvändning i färgväljaren",
+  shortcut_delete_object: "Ta bort objekt",
+
+  // Keyboard shortcuts panel — category names
+  shortcut_category_main: "Allmänt",
+  shortcut_category_menu: "Meny",
+  shortcut_category_area_menu: "Områdesmeny",
+  shortcut_category_editor: "Editor",
+  shortcut_category_gizmos: "Gizmos",
 };

--- a/main/accessibility.js
+++ b/main/accessibility.js
@@ -1,6 +1,7 @@
 import { InputManager } from "./inputmanager.js";
 import { ContextManager } from "./context.js";
 import { translate } from "./translation.js";
+import { SHORTCUTS_HELP_URL } from "../config.js";
 
 // Area menu accessed with Ctrl + B to quickly skip to
 // different areas on the interface
@@ -342,6 +343,7 @@ const ShortcutsPanel = {
     div.tabIndex = 0;
     div.innerHTML = `
         <button type="button" class="close-button" id="closeShortcutsPanel" aria-label="${translate("shortcut_panel_close")}">&times;</button>
+        <a href="${SHORTCUTS_HELP_URL}" target="_blank" rel="noopener noreferrer" class="help-link-button" aria-label="Open keyboard shortcuts help page"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="16" height="16" aria-hidden="true"><!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.--><path d="M320 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l82.7 0L201.4 265.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L448 109.3l0 82.7c0 17.7 14.3 32 32 32s32-14.3 32-32l0-160c0-17.7-14.3-32-32-32L320 0zM80 32C35.8 32 0 67.8 0 112L0 432c0 44.2 35.8 80 80 80l320 0c44.2 0 80-35.8 80-80l0-112c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 112c0 8.8-7.2 16-16 16L80 448c-8.8 0-16-7.2-16-16l0-320c0-8.8 7.2-16 16-16l112 0c17.7 0 32-14.3 32-32s-14.3-32-32-32L80 32z"/></svg></a>
         <h1 id="shortcuts-panel-title">${translate("shortcut_panel_title")}</h1>
         <table id="shortcuts-table"><tbody></tbody></table>
       `;

--- a/main/accessibility.js
+++ b/main/accessibility.js
@@ -48,54 +48,47 @@ const AreaManager = {
   },
 
   setupListeners() {
-    window.addEventListener(
-      "keydown",
-      (e) => {
-        // Open: Ctrl+B
-        if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "b") {
-          e.preventDefault();
-          this.toggle(this.overlay.classList.contains("hidden"));
-        }
-        // Close: Escape
-        if (e.key === "Escape") {
-          this.toggle(false);
-        }
-        // Handle number keys
-        if (e.key >= "1" && e.key <= "9") {
-          // Only if the overlay is open (otherwise you can't type numbers)
-          if (!this.overlay.classList.contains("hidden")) {
-            // Find the area and set the focus
-            const area = this.areas.find((a) => a.label === e.key);
-            if (area) this.activateArea(area);
-          }
-        }
-        // Tab through badges when overlay is open
-        if (e.key === "Tab" && !this.overlay.classList.contains("hidden")) {
-          e.preventDefault();
-          const badges = [
-            ...this.overlay.querySelectorAll(".area-number-badge"),
-          ];
-          if (badges.length === 0) return;
-          const currentIndex = badges.indexOf(document.activeElement);
-          const nextIndex = e.shiftKey
-            ? (currentIndex - 1 + badges.length) % badges.length
-            : (currentIndex + 1) % badges.length;
-          badges[nextIndex].focus();
-        }
-        // Enter opens the area if a badge is focused
-        if (e.key === "Enter" && !this.overlay.classList.contains("hidden")) {
-          const focused = document.activeElement;
-          // Do nothing if a badge is not focused
-          if (!focused?.classList.contains("area-number-badge")) return;
-          e.preventDefault();
+    InputManager.on("*", "Mod+KeyB", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      this.toggle(this.overlay.classList.contains("hidden"));
+    });
 
-          // Find the area and set the focus
-          const area = this.areas.find((a) => a.label === focused.innerText);
-          if (area) this.activateArea(area);
-        }
-      },
-      true,
-    ); // 'true' uses the capture phase to beat Blockly's listeners
+    InputManager.on("OVERLAY", "Escape", () => this.toggle(false));
+
+    for (let i = 1; i <= 9; i++) {
+      InputManager.on("OVERLAY", `Digit${i}`, () => {
+        const area = this.areas.find((a) => a.label === String(i));
+        if (area) this.activateArea(area);
+      });
+    }
+
+    const cycleBadges = (reverse) => {
+      const badges = [...this.overlay.querySelectorAll(".area-number-badge")];
+      if (badges.length === 0) return;
+      const currentIndex = badges.indexOf(document.activeElement);
+      const nextIndex = reverse
+        ? (currentIndex - 1 + badges.length) % badges.length
+        : (currentIndex + 1) % badges.length;
+      badges[nextIndex].focus();
+    };
+
+    InputManager.on("OVERLAY", "Tab", (e) => {
+      e.preventDefault();
+      cycleBadges(false);
+    });
+    InputManager.on("OVERLAY", "Shift+Tab", (e) => {
+      e.preventDefault();
+      cycleBadges(true);
+    });
+
+    InputManager.on("OVERLAY", "Enter", (e) => {
+      const focused = document.activeElement;
+      if (!focused?.classList.contains("area-number-badge")) return;
+      e.preventDefault();
+      const area = this.areas.find((a) => a.label === focused.innerText);
+      if (area) this.activateArea(area);
+    });
   },
 
   // Set the focus to this area and close overlay
@@ -184,7 +177,7 @@ const GizmoMenuManager = {
     if (show) {
       this.renderBadges();
 
-      // Check if the overlay should exit
+      // Check if the Gizmo number shortcut overlay should exit
       this._watcher = () => {
         const ctx = ContextManager.getCurrentContext();
         if (ctx !== "GIZMO" && ctx !== "NAVIGATION") this.toggle(false);
@@ -209,35 +202,25 @@ const GizmoMenuManager = {
   },
 
   setupListeners() {
-    window.addEventListener(
-      "keydown",
-      (e) => {
-        // Ctrl+G: toggle overlay from any context
-        if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "g") {
-          e.preventDefault();
-          e.stopPropagation();
-          this.toggle(!this.isOpen());
-          return;
-        }
+    // Toggle gizmo menu with Ctrl + G
+    InputManager.on("*", "Mod+KeyG", (e) => {
+      const ctx = ContextManager.getCurrentContext();
+      if (ctx === "TYPING" || ctx === "OVERLAY") return;
+      e.preventDefault();
+      e.stopPropagation();
+      this.toggle(!this.isOpen());
+    });
 
+    // Activate gizmo buttons with number keys
+    for (let i = 1; i <= 9; i++) {
+      InputManager.on("*", `Digit${i}`, () => {
         if (!this.isOpen()) return;
+        const entry = this.buttons.find((b) => b.label === String(i));
+        if (entry) this.activateButton(entry);
+      });
+    }
 
-        // Respect TYPING and OVERLAY contexts
-        const ctx = ContextManager.getCurrentContext();
-        if (ctx === "TYPING" || ctx === "OVERLAY") return;
-
-        if (e.key >= "1" && e.key <= "9") {
-          const entry = this.buttons.find((b) => b.label === e.key);
-          if (entry) {
-            this.activateButton(entry);
-            e.stopPropagation();
-          }
-        }
-      },
-      true,
-    );
-
-    // Move the badges if the window is resized
+    // Move the gizmo buttons if the window is resized
     const gizmoButtons = document.getElementById("gizmoButtons");
     const resizer = document.getElementById("resizer");
     if (gizmoButtons) {
@@ -434,6 +417,8 @@ const ShortcutsPanel = {
   },
 
   setupListeners() {
+    // Not handled by InputManager as they are set specifically
+    // to listen when the panel has focus, not globally
     document.addEventListener("click", (e) => {
       if (e.target.id === "closeShortcutsPanel") this.hide();
     });

--- a/main/accessibility.js
+++ b/main/accessibility.js
@@ -71,7 +71,9 @@ const AreaManager = {
       if (badges.length === 0) return;
       const currentIndex = badges.indexOf(document.activeElement);
       const nextIndex = reverse
-        ? currentIndex === -1 ? badges.length - 1 : (currentIndex - 1 + badges.length) % badges.length
+        ? currentIndex === -1
+          ? badges.length - 1
+          : (currentIndex - 1 + badges.length) % badges.length
         : (currentIndex + 1) % badges.length;
       badges[nextIndex].focus();
     };
@@ -268,43 +270,149 @@ const GizmoMenuManager = {
 
 // Check their platform (Mac or not Mac) to show the correct modifier key
 function isMac() {
-  return (navigator.userAgentData?.platform ?? navigator.platform).toUpperCase().includes("MAC");
+  return (navigator.userAgentData?.platform ?? navigator.platform)
+    .toUpperCase()
+    .includes("MAC");
 }
 
 // List of shortcuts to show in the panel, with categories for grouping
 function getShortcuts() {
   const mod = isMac() ? "⌘" : "Ctrl";
   return [
-    { label: translate("shortcut_show_hide_help"), keys: `${mod} + /`, category: translate("shortcut_category_main") },
-    { label: translate("shortcut_move_between_areas"), keys: `Tab`, category: translate("shortcut_category_main") },
-    { label: translate("shortcut_confirm"), keys: `Enter`, category: translate("shortcut_category_main") },
-    { label: translate("shortcut_exit"), keys: `Esc`, category: translate("shortcut_category_main") },
-    { label: translate("shortcut_play"), keys: `${mod} + P`, category: translate("shortcut_category_main") },
-    { label: translate("shortcut_undo"), keys: `${mod} + Z`, category: translate("shortcut_category_main") },
-    { label: translate("shortcut_redo"), keys: `${mod} + Shift + Z`, category: translate("shortcut_category_main") },
-    { label: translate("shortcut_browser_nav"), keys: `${mod} + L`, category: translate("shortcut_category_main") },
+    {
+      label: translate("shortcut_show_hide_help"),
+      keys: `${mod} + /`,
+      category: translate("shortcut_category_main"),
+    },
+    {
+      label: translate("shortcut_move_between_areas"),
+      keys: `Tab`,
+      category: translate("shortcut_category_main"),
+    },
+    {
+      label: translate("shortcut_confirm"),
+      keys: `Enter`,
+      category: translate("shortcut_category_main"),
+    },
+    {
+      label: translate("shortcut_exit"),
+      keys: `Esc`,
+      category: translate("shortcut_category_main"),
+    },
+    {
+      label: translate("shortcut_play"),
+      keys: `${mod} + P`,
+      category: translate("shortcut_category_main"),
+    },
+    {
+      label: translate("shortcut_undo"),
+      keys: `${mod} + Z`,
+      category: translate("shortcut_category_main"),
+    },
+    {
+      label: translate("shortcut_redo"),
+      keys: `${mod} + Shift + Z`,
+      category: translate("shortcut_category_main"),
+    },
+    {
+      label: translate("shortcut_browser_nav"),
+      keys: `${mod} + L`,
+      category: translate("shortcut_category_main"),
+    },
 
-    { label: translate("shortcut_main_menu"), keys: `${mod} + M`, category: translate("shortcut_category_menu") },
-    { label: translate("shortcut_open_file"), keys: `${mod} + O`, category: translate("shortcut_category_menu") },
-    { label: translate("shortcut_save_export"), keys: `${mod} + S`, category: translate("shortcut_category_menu") },
+    {
+      label: translate("shortcut_main_menu"),
+      keys: `${mod} + M`,
+      category: translate("shortcut_category_menu"),
+    },
+    {
+      label: translate("shortcut_open_file"),
+      keys: `${mod} + O`,
+      category: translate("shortcut_category_menu"),
+    },
+    {
+      label: translate("shortcut_save_export"),
+      keys: `${mod} + S`,
+      category: translate("shortcut_category_menu"),
+    },
 
-    { label: translate("shortcut_open_close_area_menu"), keys: `${mod} + B`, category: translate("shortcut_category_area_menu") },
-    { label: translate("shortcut_toggle_area"), keys: `Tab`, category: translate("shortcut_category_area_menu") },
-    { label: translate("shortcut_select_area"), keys: `1-9 / Enter`, category: translate("shortcut_category_area_menu") },
+    {
+      label: translate("shortcut_open_close_area_menu"),
+      keys: `${mod} + B`,
+      category: translate("shortcut_category_area_menu"),
+    },
+    {
+      label: translate("shortcut_toggle_area"),
+      keys: `Tab`,
+      category: translate("shortcut_category_area_menu"),
+    },
+    {
+      label: translate("shortcut_select_area"),
+      keys: `1-9 / Enter`,
+      category: translate("shortcut_category_area_menu"),
+    },
 
-    { label: translate("shortcut_code_editor"), keys: `${mod} + E`, category: translate("shortcut_category_editor") },
-    { label: translate("shortcut_add_block_by_name"), keys: `${mod} + ]`, category: translate("shortcut_category_editor") },
-    { label: translate("shortcut_search_block"), keys: `${mod} + F`, category: translate("shortcut_category_editor") },
-    { label: translate("shortcut_move_through_blocks"), keys: `↑ ↓ ← →`, category: translate("shortcut_category_editor") },
+    {
+      label: translate("shortcut_code_editor"),
+      keys: `${mod} + E`,
+      category: translate("shortcut_category_editor"),
+    },
+    {
+      label: translate("shortcut_add_block_by_name"),
+      keys: `${mod} + ]`,
+      category: translate("shortcut_category_editor"),
+    },
+    {
+      label: translate("shortcut_search_block"),
+      keys: `${mod} + F`,
+      category: translate("shortcut_category_editor"),
+    },
+    {
+      label: translate("shortcut_move_through_blocks"),
+      keys: `↑ ↓ ← →`,
+      category: translate("shortcut_category_editor"),
+    },
 
-    { label: translate("shortcut_open_gizmos"), keys: `${mod} + G`, category: translate("shortcut_category_gizmos") },
-    { label: translate("shortcut_select_gizmo"), keys: `1-9`, category: translate("shortcut_category_gizmos") },
-    { label: translate("shortcut_keyboard_cursor_gizmos"), keys: `↑ ↓ ← →`, category: translate("shortcut_category_gizmos") },
-    { label: translate("shortcut_lock_transform"), keys: `X Y Z`, category: translate("shortcut_category_gizmos") },
-    { label: translate("shortcut_transform_3d"), keys: `↑ ↓ ← → PgUp PgDn`, category: translate("shortcut_category_gizmos") },
-    { label: translate("shortcut_focus_camera"), keys: `F`, category: translate("shortcut_category_gizmos") },
-    { label: translate("shortcut_quick_colour"), keys: `P`, category: translate("shortcut_category_gizmos") },
-    { label: translate("shortcut_delete_object"), keys: `Del`, category: translate("shortcut_category_gizmos") },
+    {
+      label: translate("shortcut_open_gizmos"),
+      keys: `${mod} + G`,
+      category: translate("shortcut_category_gizmos"),
+    },
+    {
+      label: translate("shortcut_select_gizmo"),
+      keys: `1-9`,
+      category: translate("shortcut_category_gizmos"),
+    },
+    {
+      label: translate("shortcut_keyboard_cursor_gizmos"),
+      keys: `↑ ↓ ← →`,
+      category: translate("shortcut_category_gizmos"),
+    },
+    {
+      label: translate("shortcut_lock_transform"),
+      keys: `X Y Z`,
+      category: translate("shortcut_category_gizmos"),
+    },
+    {
+      label: translate("shortcut_transform_3d"),
+      keys: `↑ ↓ ← → PgUp PgDn`,
+      category: translate("shortcut_category_gizmos"),
+    },
+    {
+      label: translate("shortcut_focus_camera"),
+      keys: `F`,
+      category: translate("shortcut_category_gizmos"),
+    },
+    {
+      label: translate("shortcut_quick_colour"),
+      keys: `P`,
+      category: translate("shortcut_category_gizmos"),
+    },
+    {
+      label: translate("shortcut_delete_object"),
+      keys: `Del`,
+      category: translate("shortcut_category_gizmos"),
+    },
   ];
 }
 
@@ -353,8 +461,12 @@ const ShortcutsPanel = {
 
   show() {
     this.panel.setAttribute("aria-label", translate("shortcut_panel_title"));
-    this.panel.querySelector("#shortcuts-panel-title").textContent = translate("shortcut_panel_title");
-    this.panel.querySelector("#closeShortcutsPanel").setAttribute("aria-label", translate("shortcut_panel_close"));
+    this.panel.querySelector("#shortcuts-panel-title").textContent = translate(
+      "shortcut_panel_title",
+    );
+    this.panel
+      .querySelector("#closeShortcutsPanel")
+      .setAttribute("aria-label", translate("shortcut_panel_close"));
     const tbody = this.panel.querySelector("tbody");
     const groups = getShortcuts().reduce((acc, s) => {
       (acc[s.category] ??= []).push(s);

--- a/main/accessibility.js
+++ b/main/accessibility.js
@@ -208,7 +208,7 @@ const GizmoMenuManager = {
       if (ctx === "TYPING" || ctx === "OVERLAY") return;
       e.preventDefault();
       e.stopPropagation();
-      this.toggle(!this.isOpen());
+      this.toggle(true);
     });
 
     // Activate gizmo buttons with number keys

--- a/main/accessibility.js
+++ b/main/accessibility.js
@@ -71,7 +71,7 @@ const AreaManager = {
       if (badges.length === 0) return;
       const currentIndex = badges.indexOf(document.activeElement);
       const nextIndex = reverse
-        ? (currentIndex - 1 + badges.length) % badges.length
+        ? currentIndex === -1 ? badges.length - 1 : (currentIndex - 1 + badges.length) % badges.length
         : (currentIndex + 1) % badges.length;
       badges[nextIndex].focus();
     };

--- a/main/accessibility.js
+++ b/main/accessibility.js
@@ -57,7 +57,8 @@ const AreaManager = {
     InputManager.on("OVERLAY", "Escape", () => this.toggle(false));
 
     for (let i = 1; i <= 9; i++) {
-      InputManager.on("OVERLAY", `Digit${i}`, () => {
+      InputManager.on("OVERLAY", `Digit${i}`, (e) => {
+        e.preventDefault();
         const area = this.areas.find((a) => a.label === String(i));
         if (area) this.activateArea(area);
       });

--- a/main/accessibility.js
+++ b/main/accessibility.js
@@ -267,7 +267,7 @@ const GizmoMenuManager = {
 
 // Check their platform (Mac or not Mac) to show the correct modifier key
 function isMac() {
-  return navigator.platform.toUpperCase().includes("MAC");
+  return (navigator.userAgentData?.platform ?? navigator.platform).toUpperCase().includes("MAC");
 }
 
 // List of shortcuts to show in the panel, with categories for grouping

--- a/main/accessibility.js
+++ b/main/accessibility.js
@@ -1,5 +1,6 @@
 import { InputManager } from "./inputmanager.js";
 import { ContextManager } from "./context.js";
+import { translate } from "./translation.js";
 
 // Area menu accessed with Ctrl + B to quickly skip to
 // different areas on the interface
@@ -273,70 +274,36 @@ function isMac() {
 function getShortcuts() {
   const mod = isMac() ? "⌘" : "Ctrl";
   return [
-    { label: "Show/hide shortcut help", keys: `${mod} + /`, category: "Main" },
-    {
-      label: "Move between menus, canvas and editor",
-      keys: `Tab`,
-      category: "Main",
-    },
-    { label: "Confirm", keys: `Enter`, category: "Main" },
-    { label: "Exit", keys: `Esc`, category: "Main" },
-    { label: "Play", keys: `${mod} + P`, category: "Main" },
-    { label: "Undo", keys: `${mod} + Z`, category: "Main" },
-    { label: "Redo", keys: `${mod} + Shift + Z`, category: "Main" },
-    {
-      label: "Browser navigation bar (overriden shortcuts work from here)",
-      keys: `${mod} + L`,
-      category: "Main",
-    },
+    { label: translate("shortcut_show_hide_help"), keys: `${mod} + /`, category: translate("shortcut_category_main") },
+    { label: translate("shortcut_move_between_areas"), keys: `Tab`, category: translate("shortcut_category_main") },
+    { label: translate("shortcut_confirm"), keys: `Enter`, category: translate("shortcut_category_main") },
+    { label: translate("shortcut_exit"), keys: `Esc`, category: translate("shortcut_category_main") },
+    { label: translate("shortcut_play"), keys: `${mod} + P`, category: translate("shortcut_category_main") },
+    { label: translate("shortcut_undo"), keys: `${mod} + Z`, category: translate("shortcut_category_main") },
+    { label: translate("shortcut_redo"), keys: `${mod} + Shift + Z`, category: translate("shortcut_category_main") },
+    { label: translate("shortcut_browser_nav"), keys: `${mod} + L`, category: translate("shortcut_category_main") },
 
-    { label: "Main menu", keys: `${mod} + M`, category: "Menu" },
-    { label: "Open file", keys: `${mod} + O`, category: "Menu" },
-    { label: "Save / export", keys: `${mod} + S`, category: "Menu" },
+    { label: translate("shortcut_main_menu"), keys: `${mod} + M`, category: translate("shortcut_category_menu") },
+    { label: translate("shortcut_open_file"), keys: `${mod} + O`, category: translate("shortcut_category_menu") },
+    { label: translate("shortcut_save_export"), keys: `${mod} + S`, category: translate("shortcut_category_menu") },
 
-    {
-      label: "Open/close area menu",
-      keys: `${mod} + B`,
-      category: "Area menu",
-    },
-    { label: "Toggle area", keys: `Tab`, category: "Area menu" },
-    { label: "Select area", keys: `1-9 / Enter`, category: "Area menu" },
+    { label: translate("shortcut_open_close_area_menu"), keys: `${mod} + B`, category: translate("shortcut_category_area_menu") },
+    { label: translate("shortcut_toggle_area"), keys: `Tab`, category: translate("shortcut_category_area_menu") },
+    { label: translate("shortcut_select_area"), keys: `1-9 / Enter`, category: translate("shortcut_category_area_menu") },
 
-    { label: "Code editor", keys: `${mod} + E`, category: "Editor" },
-    {
-      label: "Add block by name",
-      keys: `${mod} + ]`,
-      category: "Editor",
-    },
-    { label: "Search for a block", keys: `${mod} + F`, category: "Editor" },
-    { label: "Move through blocks", keys: `↑ ↓ ← →`, category: "Editor" },
+    { label: translate("shortcut_code_editor"), keys: `${mod} + E`, category: translate("shortcut_category_editor") },
+    { label: translate("shortcut_add_block_by_name"), keys: `${mod} + ]`, category: translate("shortcut_category_editor") },
+    { label: translate("shortcut_search_block"), keys: `${mod} + F`, category: translate("shortcut_category_editor") },
+    { label: translate("shortcut_move_through_blocks"), keys: `↑ ↓ ← →`, category: translate("shortcut_category_editor") },
 
-    { label: "Gizmos", keys: `${mod} + G`, category: "Gizmos" },
-    {
-      label: "Select gizmo",
-      keys: `1-9`,
-      category: "Gizmos",
-    },
-
-    {
-      label: "Keyboard cursor for gizmos",
-      keys: `↑ ↓ ← →`,
-      category: "Gizmos",
-    },
-    {
-      label: "Lock transform to axis",
-      keys: `X Y Z`,
-      category: "Gizmos",
-    },
-    { label: "Transform in 3D", keys: `↑ ↓ ← → PgUp PgDn`, category: "Gizmos" },
-    { label: "Focus camera on object", keys: `F`, category: "Gizmos" },
-
-    {
-      label: "Quick use colour in colour picker",
-      keys: `P`,
-      category: "Gizmos",
-    },
-    { label: "Delete object", keys: `Del`, category: "Gizmos" },
+    { label: translate("shortcut_open_gizmos"), keys: `${mod} + G`, category: translate("shortcut_category_gizmos") },
+    { label: translate("shortcut_select_gizmo"), keys: `1-9`, category: translate("shortcut_category_gizmos") },
+    { label: translate("shortcut_keyboard_cursor_gizmos"), keys: `↑ ↓ ← →`, category: translate("shortcut_category_gizmos") },
+    { label: translate("shortcut_lock_transform"), keys: `X Y Z`, category: translate("shortcut_category_gizmos") },
+    { label: translate("shortcut_transform_3d"), keys: `↑ ↓ ← → PgUp PgDn`, category: translate("shortcut_category_gizmos") },
+    { label: translate("shortcut_focus_camera"), keys: `F`, category: translate("shortcut_category_gizmos") },
+    { label: translate("shortcut_quick_colour"), keys: `P`, category: translate("shortcut_category_gizmos") },
+    { label: translate("shortcut_delete_object"), keys: `Del`, category: translate("shortcut_category_gizmos") },
   ];
 }
 
@@ -371,11 +338,11 @@ const ShortcutsPanel = {
     div.id = "shortcutsPanel";
     div.className = "shortcuts-panel hidden shortcuts-panel--left";
     div.setAttribute("role", "region");
-    div.setAttribute("aria-label", "Keyboard shortcuts");
+    div.setAttribute("aria-label", translate("shortcut_panel_title"));
     div.tabIndex = 0;
-    div.innerHTML = `      
-        <button type="button" class="close-button" id="closeShortcutsPanel" aria-label="Close keyboard shortcuts">&times;</button>
-        <h1 id="shortcuts-panel-title">Keyboard shortcuts</h1>
+    div.innerHTML = `
+        <button type="button" class="close-button" id="closeShortcutsPanel" aria-label="${translate("shortcut_panel_close")}">&times;</button>
+        <h1 id="shortcuts-panel-title">${translate("shortcut_panel_title")}</h1>
         <table id="shortcuts-table"><tbody></tbody></table>
       `;
     document.body.appendChild(div);
@@ -383,6 +350,9 @@ const ShortcutsPanel = {
   },
 
   show() {
+    this.panel.setAttribute("aria-label", translate("shortcut_panel_title"));
+    this.panel.querySelector("#shortcuts-panel-title").textContent = translate("shortcut_panel_title");
+    this.panel.querySelector("#closeShortcutsPanel").setAttribute("aria-label", translate("shortcut_panel_close"));
     const tbody = this.panel.querySelector("tbody");
     const groups = getShortcuts().reduce((acc, s) => {
       (acc[s.category] ??= []).push(s);

--- a/main/accessibility.js
+++ b/main/accessibility.js
@@ -108,6 +108,7 @@ const AreaManager = {
       ) ?? el; // Focus the area itself if no suitable child
 
     focusable?.focus();
+    if (area.selector === "#gizmoButtons") GizmoMenuManager.toggle(true);
   },
 
   renderHighlights() {
@@ -183,6 +184,16 @@ const GizmoMenuManager = {
     if (show) {
       this.renderBadges();
 
+      // Check if the overlay should exit
+      this._watcher = () => {
+        const ctx = ContextManager.getCurrentContext();
+        if (ctx !== "GIZMO" && ctx !== "NAVIGATION") this.toggle(false);
+      };
+      document.addEventListener("focusin", this._watcher);
+      document.addEventListener("pointerdown", this._watcher, {
+        capture: true,
+      });
+
       // Focus 1st button if nothing in gizmos is already focused,
       // but if another gizmo is active, leave focus there
       const alreadyFocused = document.activeElement?.closest("#gizmoButtons");
@@ -221,9 +232,6 @@ const GizmoMenuManager = {
             this.activateButton(entry);
             e.stopPropagation();
           }
-        }
-        if (e.key === "Escape") {
-          this.toggle(false);
         }
       },
       true,

--- a/main/accessibility.js
+++ b/main/accessibility.js
@@ -1,3 +1,6 @@
+import { InputManager } from "./inputmanager.js";
+import { ContextManager } from "./context.js";
+
 // Area menu accessed with Ctrl + B to quickly skip to
 // different areas on the interface
 
@@ -179,6 +182,7 @@ const GizmoMenuManager = {
     if (!this.overlay) return;
     if (show) {
       this.renderBadges();
+
       // Focus 1st button if nothing in gizmos is already focused,
       // but if another gizmo is active, leave focus there
       const alreadyFocused = document.activeElement?.closest("#gizmoButtons");
@@ -197,46 +201,38 @@ const GizmoMenuManager = {
     window.addEventListener(
       "keydown",
       (e) => {
-        // Show the overlay on Ctrl+G
+        // Ctrl+G: toggle overlay from any context
         if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "g") {
           e.preventDefault();
-          e.stopPropagation(); // prevent main.js from also handling this
+          e.stopPropagation();
           this.toggle(!this.isOpen());
           return;
         }
 
-        // Do nothing if the overlay isn't open
         if (!this.isOpen()) return;
 
-        // Guard against typing in inputs triggering gizmo shortcuts
-        const t = e.target;
-        const tag = (t?.tagName || "").toLowerCase();
-        if (
-          t?.isContentEditable ||
-          tag === "input" ||
-          tag === "textarea" ||
-          tag === "select"
-        )
-          return;
+        // Respect TYPING and OVERLAY contexts
+        const ctx = ContextManager.getCurrentContext();
+        if (ctx === "TYPING" || ctx === "OVERLAY") return;
 
-        // If the overlay is open and a number key is pressed,
-        // activate the gizmo
         if (e.key >= "1" && e.key <= "9") {
           const entry = this.buttons.find((b) => b.label === e.key);
-          if (entry) this.activateButton(entry);
+          if (entry) {
+            this.activateButton(entry);
+            e.stopPropagation();
+          }
         }
         if (e.key === "Escape") {
-          e.preventDefault();
           this.toggle(false);
         }
       },
       true,
     );
 
+    // Move the badges if the window is resized
     const gizmoButtons = document.getElementById("gizmoButtons");
     const resizer = document.getElementById("resizer");
     if (gizmoButtons) {
-      // Move the badges if the window is resized
       new ResizeObserver(() => {
         if (this.isOpen()) this.renderBadges();
       }).observe(gizmoButtons);

--- a/main/context.js
+++ b/main/context.js
@@ -54,8 +54,14 @@ export const ContextManager = {
     }
 
     // GIZMO: Is a gizmo currently active?
+    // Yield to EDITOR if the user is actively working in Blockly
     if (document.querySelector(".gizmo-button.active")) {
-      return "GIZMO";
+      const currentGesture = window.Blockly?.Gesture?.getCurrentGesture?.();
+      const isBlocklyActive =
+        currentGesture?.isDragging?.() ||
+        activeEl?.closest(".blocklySvg") ||
+        activeEl?.closest(".blocklyToolbox");
+      if (!isBlocklyActive) return "GIZMO";
     }
 
     // RESIZER: Are they changing the canvas size?

--- a/main/inputmanager.js
+++ b/main/inputmanager.js
@@ -8,8 +8,7 @@ import { ContextManager } from "./context.js";
 // Work out what key combo was pressed (e.g. Ctrl+Shift+KeyA)
 function _keyCombo(event) {
   const mods = [
-    event.ctrlKey && "Ctrl",
-    event.metaKey && "Meta",
+    (event.ctrlKey || event.metaKey) && "Mod",
     event.altKey && "Alt",
     event.shiftKey && "Shift",
   ].filter(Boolean);
@@ -47,13 +46,13 @@ const InputManager = {
         return;
       }
     }
+    const combo = _keyCombo(event);
     const handler =
+      this._registry[`${context}:${combo}`] ||
+      this._registry[`*:${combo}`] ||
       this._registry[`${context}:${event.code}`] ||
-      this._registry[`*:${event.code}`];
-    _debugShow(
-      _keyCombo(event),
-      handler ? `${context}:${event.code}` : "external",
-    );
+      this._registry[`*:${event.code}`]; // Wildcard context *
+    _debugShow(combo, handler ? `${context}:${combo}` : "external");
     if (handler) handler(event);
   },
 };

--- a/main/main.js
+++ b/main/main.js
@@ -49,6 +49,7 @@ import {
   translate,
 } from "./translation.js";
 import { ShortcutsPanel } from "./accessibility.js";
+import { InputManager } from "./inputmanager.js";
 import "./context.js";
 
 function isEmbedModeEnabled() {
@@ -603,67 +604,19 @@ function initializeApp() {
   // Enable the file input after initialization
   fileInput.removeAttribute("disabled");
 
-  // keydown event listener (capture phase to ensure shortcuts
-  // are handled before any other handler can stop propagation)
-  document.addEventListener(
-    "keydown",
-    function (e) {
-      // Check for modifier key (Ctrl on Windows/Linux, Cmd on Mac)
-      if (!(e.ctrlKey || e.metaKey)) return;
-
-      let key = e.key.toLowerCase();
-      if (e.code === "KeyM" && key !== "m") key = "m";
-      if (e.code === "KeyE" && key !== "e") key = "e";
-
-      switch (key) {
-        case "o": // Ctrl+O - Open file
-          e.preventDefault();
-          openFile(workspace, executeCode);
-          break;
-
-        case "s": // Ctrl+S - Save/Export
-          e.preventDefault();
-          exportCode(workspace); // Or saveWorkspace(workspace) for autosave
-          break;
-
-        case "p": // Ctrl+P - Execute code
-          e.preventDefault();
-          const canvas = document.getElementById("renderCanvas");
-          canvas.focus({ preventScroll: true });
-          break;
-
-        case "/": {
-          e.preventDefault();
-          ShortcutsPanel.toggle();
-          break;
-        }
-
-        case "m": {
-          // Ctrl+M - Move focus to main menu button
-          e.preventDefault();
-          if (menuButton) menuButton.focus();
-          break;
-        }
-
-        case "g": {
-          // Ctrl+G - Focus shapes button
-          e.preventDefault();
-          const btn = document.getElementById("showShapesButton");
-          if (btn && !btn.disabled && btn.offsetParent !== null) {
-            btn.focus();
-          }
-          break;
-        }
-
-        case "e": // Ctrl+E - Focus Blockly workspace/editor and move cursor
-          e.preventDefault();
-          Blockly.keyboardNavigationController?.setIsActive?.(true);
-          Blockly.getFocusManager()?.focusTree?.(workspace);
-          break;
-      }
-    },
-    true,
-  );
+  InputManager.on("*", "Mod+KeyO", (e) => { e.preventDefault(); openFile(workspace, executeCode); });
+  InputManager.on("*", "Mod+KeyS", (e) => { e.preventDefault(); exportCode(workspace); });
+  InputManager.on("*", "Mod+KeyP", (e) => {
+    e.preventDefault();
+    document.getElementById("renderCanvas")?.focus({ preventScroll: true });
+  });
+  InputManager.on("*", "Mod+Slash", (e) => { e.preventDefault(); ShortcutsPanel.toggle(); });
+  InputManager.on("*", "Mod+KeyM", (e) => { e.preventDefault(); if (menuButton) menuButton.focus(); });
+  InputManager.on("*", "Mod+KeyE", (e) => {
+    e.preventDefault();
+    Blockly.keyboardNavigationController?.setIsActive?.(true);
+    Blockly.getFocusManager()?.focusTree?.(workspace);
+  });
   if (toggleDesignButton) {
     toggleDesignButton.addEventListener("click", toggleDesignMode);
   }

--- a/main/main.js
+++ b/main/main.js
@@ -604,14 +604,26 @@ function initializeApp() {
   // Enable the file input after initialization
   fileInput.removeAttribute("disabled");
 
-  InputManager.on("*", "Mod+KeyO", (e) => { e.preventDefault(); openFile(workspace, executeCode); });
-  InputManager.on("*", "Mod+KeyS", (e) => { e.preventDefault(); exportCode(workspace); });
+  InputManager.on("*", "Mod+KeyO", (e) => {
+    e.preventDefault();
+    openFile(workspace, executeCode);
+  });
+  InputManager.on("*", "Mod+KeyS", (e) => {
+    e.preventDefault();
+    exportCode(workspace);
+  });
   InputManager.on("*", "Mod+KeyP", (e) => {
     e.preventDefault();
     document.getElementById("renderCanvas")?.focus({ preventScroll: true });
   });
-  InputManager.on("*", "Mod+Slash", (e) => { e.preventDefault(); ShortcutsPanel.toggle(); });
-  InputManager.on("*", "Mod+KeyM", (e) => { e.preventDefault(); if (menuButton) menuButton.focus(); });
+  InputManager.on("*", "Mod+Slash", (e) => {
+    e.preventDefault();
+    ShortcutsPanel.toggle();
+  });
+  InputManager.on("*", "Mod+KeyM", (e) => {
+    e.preventDefault();
+    if (menuButton) menuButton.focus();
+  });
   InputManager.on("*", "Mod+KeyE", (e) => {
     e.preventDefault();
     Blockly.keyboardNavigationController?.setIsActive?.(true);

--- a/main/main.js
+++ b/main/main.js
@@ -585,7 +585,7 @@ function initializeApp() {
   }
   runCodeButton.addEventListener("click", executeCode);
   stopCodeButton.addEventListener("click", stopCode);
-  exportCodeButton.addEventListener("click", exportCode);
+  exportCodeButton.addEventListener("click", () => exportCode(workspace));
 
   // Make open button work with keyboard
   if (openButton) {
@@ -680,7 +680,7 @@ function initializeApp() {
   if (projectSave) {
     projectSave.addEventListener("click", function (e) {
       e.preventDefault();
-      exportCode();
+      exportCode(workspace);
       document.getElementById("menuDropdown")?.classList.add("hidden");
     });
   }

--- a/ui/addmenu.js
+++ b/ui/addmenu.js
@@ -20,6 +20,7 @@ import {
   setCrosshairCursor,
   setDefaultCursor,
 } from "./canvas-utils.js";
+import { GizmoMenuManager } from "../main/accessibility.js";
 
 const colorFields = {
   HAIR_COLOR: "#000000", // Hair: black
@@ -828,6 +829,7 @@ function handleShapeMenuKeydown(event) {
 function startPlacementKeyboardMode() {
   const canvas = flock.scene?.getEngine?.().getRenderingCanvas?.();
   if (!flock.scene || !canvas) return;
+  GizmoMenuManager.toggle(true);
   const isValidHit = (x, y) =>
     !!flock.scene.pick(x, y, (mesh) => mesh.isPickable)?.hit;
 

--- a/ui/canvas-utils.js
+++ b/ui/canvas-utils.js
@@ -232,7 +232,6 @@ function handleKeydown(event) {
 
     case "Escape":
       event.preventDefault();
-      event.stopPropagation();
       stopCanvasKeyboardMode();
       break;
 

--- a/ui/colourpicker.js
+++ b/ui/colourpicker.js
@@ -1867,6 +1867,7 @@ class CustomColorPicker {
     // Add P shortcut to pick current colour
     InputManager.on("*", "KeyP", (e) => {
       if (ContextManager.getCurrentContext() === "TYPING") return;
+      if (e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) return;
       e.preventDefault();
       this.container.querySelector(".color-picker-use")?.click();
     });

--- a/ui/colourpicker.js
+++ b/ui/colourpicker.js
@@ -1,5 +1,7 @@
 import { translate } from "../main/translation.js";
 import { exitGizmoState } from "./gizmos.js";
+import { InputManager } from "../main/inputmanager.js";
+import { ContextManager } from "../main/context.js";
 
 const COLOR_PALETTES = {
   Bright: [
@@ -1863,18 +1865,11 @@ class CustomColorPicker {
     document.getElementById("colorPickerButton")?.classList.add("active");
 
     // Add P shortcut to pick current colour
-    if (document._colorPickerShortcut) {
-      document.removeEventListener("keydown", document._colorPickerShortcut);
-    }
-    document._colorPickerShortcut = (e) => {
-      if (e.key !== "p" && e.key !== "P") return;
-      const tag = (e.target?.tagName || "").toLowerCase();
-      if (tag === "input" || tag === "textarea" || e.target?.isContentEditable)
-        return;
+    InputManager.on("*", "KeyP", (e) => {
+      if (ContextManager.getCurrentContext() === "TYPING") return;
       e.preventDefault();
       this.container.querySelector(".color-picker-use")?.click();
-    };
-    document.addEventListener("keydown", document._colorPickerShortcut);
+    });
 
     // --- Positioning (unchanged) ---
     const colorButton = document.getElementById("colorPickerButton");
@@ -2086,8 +2081,7 @@ class CustomColorPicker {
     document.getElementById("colorPickerButton")?.classList.remove("active");
     document.removeEventListener("click", this.outsideClickHandler, true);
     window.removeEventListener("keydown", this.globalEscapeHandler, true);
-    document.removeEventListener("keydown", document._colorPickerShortcut);
-    document._colorPickerShortcut = null;
+    InputManager.off("*", "KeyP");
   }
 
   confirmColor() {

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -177,6 +177,7 @@ document.addEventListener("DOMContentLoaded", function () {
 function pickMeshFromCanvas() {
   const canvas = flock.scene?.getEngine?.().getRenderingCanvas?.();
   if (!canvas || !flock.scene) return;
+  GizmoMenuManager.toggle(true);
 
   const onPickMesh = function (event) {
     const canvasRect = canvas.getBoundingClientRect();

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -129,7 +129,8 @@ document.addEventListener("DOMContentLoaded", function () {
         window.selectedColor = newColor;
       },
       onClose: () => {
-        // After color picker closes, start mesh selection
+        // Re-activate button: painting mode is still a gizmo action
+        document.getElementById("colorPickerButton")?.classList.add("active");
         pickMeshFromCanvas();
       },
       excludeFromClose: (target) => {
@@ -164,6 +165,7 @@ document.addEventListener("DOMContentLoaded", function () {
     colorButton.addEventListener("click", (event) => {
       event.preventDefault();
       if (colorPicker) {
+        GizmoMenuManager.toggle(false);
         colorPicker.open(window.selectedColor);
       }
     });
@@ -180,10 +182,7 @@ function pickMeshFromCanvas() {
     // Exit if outside canvas
     if (eventIsOutOfCanvasBounds(event, canvasRect)) {
       window.removeEventListener("click", onPickMesh);
-      stopCanvasKeyboardMode();
-      // restore cursors
-      document.body.style.cursor = "default";
-      flock.scene.defaultCursor = "";
+      exitGizmoState();
       return;
     }
 
@@ -191,8 +190,16 @@ function pickMeshFromCanvas() {
     applyColorAtPosition(canvasX, canvasY);
   };
 
+  // Register cleanup so Escape during painting mode also tears down correctly
+  onExit(() => {
+    window.removeEventListener("click", onPickMesh);
+    stopCanvasKeyboardMode();
+    document.body.style.cursor = "default";
+    if (flock.scene) flock.scene.defaultCursor = "";
+  });
+
   startCanvasKeyboardMode((x, y) => applyColorAtPosition(x, y));
-  document.body.style.cursor = "crosshair"; // works
+  document.body.style.cursor = "crosshair";
   flock.scene.defaultCursor = "crosshair";
 
   setTimeout(() => {

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -1292,8 +1292,8 @@ export function toggleGizmo(gizmoType) {
     return;
   }
 
-  GizmoMenuManager.toggle(true);
   exitGizmoState(); // Clean up any existing gizmo state
+  GizmoMenuManager.toggle(true);
   resetAttachedMeshIfMeshAttached();
 
   document.body.style.cursor = "default";

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -105,6 +105,8 @@ function registerBindings() {
     "Escape",
     noMod(() => {
       try {
+        const cameraButton = document.getElementById("cameraButton");
+        if (cameraButton?.classList.contains("active")) handleCameraGizmo();
         exitGizmoState();
         gizmoManager?.attachToMesh(null);
       } catch {

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -583,7 +583,6 @@ export function exitGizmoState() {
     .forEach((btn) => btn.classList.remove("active"));
   disableGizmos();
   document.body.style.cursor = "default";
-  GizmoMenuManager.toggle(false);
 }
 
 // Start the keyboard handler for moving a mesh


### PR DESCRIPTION
## Please apply this after #615 as I think it might result in a merge conflict!

# Summary
Add translations to all languages for descriptions of keyboard shortcuts in the shortcut panel

<img width="790" height="729" alt="image" src="https://github.com/user-attachments/assets/10ca4d54-32bb-43f0-a050-7465d772e13d" />

Also piggybacked a couple of other things:
- External link on KB controls panel to https://hub.flockxr.com/knowledge-base/keyboard-controls/ (specific URL can be changed in config.js) 
- Updated deprecated mac/PC check code

### AI usage
Claude Sonnet 4.6 was used for most of this PR as it was either 1) repetitive work, or 2) translation which I can't do. I checked at every stage that what it was doing was what I wanted/expected. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keyboard shortcuts reference panel added with localized strings for DE, EN, ES, FR, IT, PL, PT, SV.

* **Improvements**
  * Centralized, context-aware shortcut handling across editor, gizmos, canvas, color picker and area/menu navigation.
  * New shortcut registrations for common commands (open, save/export, focus canvas, toggle shortcuts, menu navigation).

* **Chores**
  * Added knowledge-base link for keyboard controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->