### PR TITLE
Zoom control bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -1342,8 +1342,25 @@
             <div
               id="blocklyZoomControls"
               role="toolbar"
-              aria-label="Zoom controls"
+              aria-label="Workspace controls"
             >
+              <button class="bigbutton" id="undoBtn" aria-label="Undo" title="Undo">
+                <div class="icon" aria-hidden="true">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+                    <!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->
+                    <path fill="currentColor" d="M48.5 224H40c-13.3 0-24-10.7-24-24V72c0-9.7 5.8-18.5 14.8-22.2s19.3-1.7 26.2 5.2L98.6 96.6c87.6-86.5 228.7-86.2 315.8 1c87.8 87.8 87.8 230.2 0 318s-230.2 87.8-318 0c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0c62.5 62.5 163.8 62.5 226.3 0s62.5-163.8 0-226.3c-62.2-62.2-162.7-62.5-225.3-1L185 183c6.9 6.9 8.9 17.2 5.2 26.2s-12.5 14.8-22.2 14.8H48.5z"/>
+                  </svg>
+                </div>
+              </button>
+              <button class="bigbutton" id="redoBtn" aria-label="Redo" title="Redo">
+                <div class="icon" aria-hidden="true">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+                    <!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->
+                    <path fill="currentColor" d="M463.5 224H472c13.3 0 24-10.7 24-24V72c0-9.7-5.8-18.5-14.8-22.2s-19.3-1.7-26.2 5.2L413.4 96.6c-87.6-86.5-228.7-86.2-315.8 1c-87.8 87.8-87.8 230.2 0 318s230.2 87.8 318 0c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0c-62.5 62.5-163.8 62.5-226.3 0s-62.5-163.8 0-226.3c62.2-62.2 162.7-62.5 225.3-1L327 183c-6.9 6.9-8.9 17.2-5.2 26.2s12.5 14.8 22.2 14.8H463.5z"/>
+                  </svg>
+                </div>
+              </button>
+              <div class="toolbar-divider" aria-hidden="true"></div>
               <button class="bigbutton" id="zoomOutBtn" aria-label="Zoom out" title="Zoom out">
                 <div class="icon" aria-hidden="true">
                   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">

--- a/index.html
+++ b/index.html
@@ -1344,7 +1344,7 @@
               role="toolbar"
               aria-label="Workspace controls"
             >
-              <button class="bigbutton" id="undoBtn" aria-label="Undo" title="Undo">
+              <button class="bigbutton" id="undoBtn" aria-label="Undo" title="Undo" data-i18n="toolbar_undo" data-i18n-attrs="title,aria-label">
                 <div class="icon" aria-hidden="true">
                   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
                     <!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->
@@ -1352,7 +1352,7 @@
                   </svg>
                 </div>
               </button>
-              <button class="bigbutton" id="redoBtn" aria-label="Redo" title="Redo">
+              <button class="bigbutton" id="redoBtn" aria-label="Redo" title="Redo" data-i18n="toolbar_redo" data-i18n-attrs="title,aria-label">
                 <div class="icon" aria-hidden="true">
                   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
                     <!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->
@@ -1361,7 +1361,7 @@
                 </div>
               </button>
               <div class="toolbar-divider" aria-hidden="true"></div>
-              <button class="bigbutton" id="zoomOutBtn" aria-label="Zoom out" title="Zoom out">
+              <button class="bigbutton" id="zoomOutBtn" aria-label="Zoom out" title="Zoom out" data-i18n="toolbar_zoom_out" data-i18n-attrs="title,aria-label">
                 <div class="icon" aria-hidden="true">
                   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
                     <!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->
@@ -1369,7 +1369,7 @@
                   </svg>
                 </div>
               </button>
-              <button class="bigbutton" id="zoomInBtn" aria-label="Zoom in" title="Zoom in">
+              <button class="bigbutton" id="zoomInBtn" aria-label="Zoom in" title="Zoom in" data-i18n="toolbar_zoom_in" data-i18n-attrs="title,aria-label">
                 <div class="icon" aria-hidden="true">
                   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
                     <!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->

--- a/index.html
+++ b/index.html
@@ -1339,6 +1339,28 @@
               Drag and drop code blocks to create your program. Use arrow keys
               and Enter to navigate and interact with blocks.
             </div>
+            <div
+              id="blocklyZoomControls"
+              role="toolbar"
+              aria-label="Zoom controls"
+            >
+              <button class="bigbutton" id="zoomOutBtn" aria-label="Zoom out" title="Zoom out">
+                <div class="icon" aria-hidden="true">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+                    <!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->
+                    <path fill="currentColor" d="M416 208c0 45.9-14.9 88.3-40 122.7L502.6 457.4c12.5 12.5 12.5 32.8 0 45.3s-32.8 12.5-45.3 0L330.7 376c-34.4 25.2-76.8 40-122.7 40C93.1 416 0 322.9 0 208S93.1 0 208 0S416 93.1 416 208zM136 184c-13.3 0-24 10.7-24 24s10.7 24 24 24l144 0c13.3 0 24-10.7 24-24s-10.7-24-24-24l-144 0z"/>
+                  </svg>
+                </div>
+              </button>
+              <button class="bigbutton" id="zoomInBtn" aria-label="Zoom in" title="Zoom in">
+                <div class="icon" aria-hidden="true">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+                    <!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->
+                    <path fill="currentColor" d="M416 208c0 45.9-14.9 88.3-40 122.7L502.6 457.4c12.5 12.5 12.5 32.8 0 45.3s-32.8 12.5-45.3 0L330.7 376c-34.4 25.2-76.8 40-122.7 40C93.1 416 0 322.9 0 208S93.1 0 208 0S416 93.1 416 208zM184 296c0 13.3 10.7 24 24 24s24-10.7 24-24l0-64 64 0c13.3 0 24-10.7 24-24s-10.7-24-24-24l-64 0 0-64c0-13.3-10.7-24-24-24s-24 10.7-24 24l0 64-64 0c-13.3 0-24 10.7-24 24s10.7 24 24 24l64 0 0 64z"/>
+                  </svg>
+                </div>
+              </button>
+            </div>
           </section>
         </div>
       </main>

--- a/locale/de.js
+++ b/locale/de.js
@@ -1208,4 +1208,10 @@ export default {
   RightUpLeg_option: "Rechter Oberschenkel",
   RightLeg_option: "Rechtes Schienbein",
   RightFoot_option: "Rechter Fuß",
+
+  // Workspace toolbar
+  toolbar_undo_ui: "Rückgängig",
+  toolbar_redo_ui: "Wiederholen",
+  toolbar_zoom_out_ui: "Verkleinern",
+  toolbar_zoom_in_ui: "Vergrößern",
 };

--- a/locale/en.js
+++ b/locale/en.js
@@ -1259,4 +1259,10 @@ export default {
   // Service worker update notification
   update_available_ui: "A new version of Flock is available.",
   reload_button_ui: "Reload",
+
+  // Workspace toolbar
+  toolbar_undo_ui: "Undo",
+  toolbar_redo_ui: "Redo",
+  toolbar_zoom_out_ui: "Zoom out",
+  toolbar_zoom_in_ui: "Zoom in",
 };

--- a/locale/es.js
+++ b/locale/es.js
@@ -1221,4 +1221,10 @@ export default {
   RightUpLeg_option: "Muslo derecho", // human
   RightLeg_option: "Espinilla derecha", // human
   RightFoot_option: "Pie derecho", // human
+
+  // Workspace toolbar
+  toolbar_undo_ui: "Deshacer",
+  toolbar_redo_ui: "Rehacer",
+  toolbar_zoom_out_ui: "Alejar",
+  toolbar_zoom_in_ui: "Acercar",
 };

--- a/locale/fr.js
+++ b/locale/fr.js
@@ -147,8 +147,7 @@ export default {
     "glisser %1 vers x %2 y %3 z %4 en %5 secondes \n%6 retour? %7 boucle? %8 %9",
   glide_to_object:
     "glisser %1 vers %2 en %6 secondes\ndécalage x: %3 y: %4 z: %5\n%7 retour? %8 boucle? %9 %10",
-  glide_to_axis:
-    "glisser %1 %2 %3 en %4 secondes\n%5 retour? %6 boucle? %7 %8",
+  glide_to_axis: "glisser %1 %2 %3 en %4 secondes\n%5 retour? %6 boucle? %7 %8",
   rotate_anim:
     "tourner %1 vers x %2 y %3 z %4 en %5 ms\n%6 inverse? %7 boucle? %8 %9",
   rotate_anim_seconds:
@@ -1220,4 +1219,10 @@ export default {
   RightUpLeg_option: "Cuisse droite",
   RightLeg_option: "Tibia droit",
   RightFoot_option: "Pied droit",
+
+  // Workspace toolbar
+  toolbar_undo_ui: "Annuler",
+  toolbar_redo_ui: "Rétablir",
+  toolbar_zoom_out_ui: "Dézoomer",
+  toolbar_zoom_in_ui: "Zoomer",
 };

--- a/locale/it.js
+++ b/locale/it.js
@@ -1211,4 +1211,10 @@ export default {
   RightUpLeg_option: "Coscia destra",
   RightLeg_option: "Stinco destro",
   RightFoot_option: "Piede destro",
+
+  // Workspace toolbar
+  toolbar_undo_ui: "Annulla",
+  toolbar_redo_ui: "Ripeti",
+  toolbar_zoom_out_ui: "Riduci zoom",
+  toolbar_zoom_in_ui: "Aumenta zoom",
 };

--- a/locale/pl.js
+++ b/locale/pl.js
@@ -1215,4 +1215,10 @@ export default {
   RightUpLeg_option: "Prawe udo",
   RightLeg_option: "Prawe podudzie",
   RightFoot_option: "Prawa stopa",
+
+  // Workspace toolbar
+  toolbar_undo_ui: "Cofnij",
+  toolbar_redo_ui: "Ponów",
+  toolbar_zoom_out_ui: "Oddal",
+  toolbar_zoom_in_ui: "Przybliż",
 };

--- a/locale/pt.js
+++ b/locale/pt.js
@@ -1207,4 +1207,10 @@ export default {
   RightUpLeg_option: "Coxa direita",
   RightLeg_option: "Canela direita",
   RightFoot_option: "Pé direito",
+
+  // Workspace toolbar
+  toolbar_undo_ui: "Desfazer",
+  toolbar_redo_ui: "Refazer",
+  toolbar_zoom_out_ui: "Reduzir zoom",
+  toolbar_zoom_in_ui: "Aumentar zoom",
 };

--- a/locale/sv.js
+++ b/locale/sv.js
@@ -1198,4 +1198,10 @@ export default {
   RightUpLeg_option: "Höger lår",
   RightLeg_option: "Höger smalben",
   RightFoot_option: "Höger fot",
+
+  // Workspace toolbar
+  toolbar_undo_ui: "Ångra",
+  toolbar_redo_ui: "Gör om",
+  toolbar_zoom_out_ui: "Zooma ut",
+  toolbar_zoom_in_ui: "Zooma in",
 };

--- a/main/accessibility.js
+++ b/main/accessibility.js
@@ -11,6 +11,12 @@ const AreaManager = {
     { selector: "#resizer", label: "5", pad: -3, name: "Resizer" },
     { selector: ".blocklyToolbox", label: "6", name: "Toolbox" },
     { selector: "svg.blocklySvg", label: "7", name: "Code editor" },
+    {
+      selector: "#blocklyZoomControls",
+      label: "8",
+      name: "Workspace controls",
+      extend: { top: -8 },
+    },
   ],
 
   init() {
@@ -131,11 +137,16 @@ const AreaManager = {
 
         const highlight = document.createElement("div");
         const pad = area.pad ?? 1;
+        const ext = area.extend ?? {};
+        const eTop = ext.top ?? 0;
+        const eBottom = ext.bottom ?? 0;
+        const eLeft = ext.left ?? 0;
+        const eRight = ext.right ?? 0;
         highlight.className = "area-outline";
-        highlight.style.top = `${rect.top - pad}px`;
-        highlight.style.left = `${rect.left - pad}px`;
-        highlight.style.width = `${rect.width + pad * 2}px`;
-        highlight.style.height = `${rect.height + pad * 2}px`;
+        highlight.style.top = `${rect.top - pad - eTop}px`;
+        highlight.style.left = `${rect.left - pad - eLeft}px`;
+        highlight.style.width = `${rect.width + pad * 2 + eLeft + eRight}px`;
+        highlight.style.height = `${rect.height + pad * 2 + eTop + eBottom}px`;
         container.appendChild(highlight);
       }
     });

--- a/main/input.js
+++ b/main/input.js
@@ -130,6 +130,11 @@ export function setupInput() {
         pushUnique(workspaceGroup);
       }
 
+      // 6b) Workspace toolbar
+      ["#undoBtn", "#redoBtn", "#zoomOutBtn", "#zoomInBtn"].forEach((sel) =>
+        pushUnique(document.querySelector(sel)),
+      );
+
       // 7) Main UI controls (in natural order)
       [
         "#menuBtn",

--- a/main/main.js
+++ b/main/main.js
@@ -586,6 +586,14 @@ function initializeApp() {
   stopCodeButton.addEventListener("click", stopCode);
   exportCodeButton.addEventListener("click", exportCode);
 
+  // Add zoom in and out buttons
+  const zoomInBtn = document.getElementById("zoomInBtn");
+  const zoomOutBtn = document.getElementById("zoomOutBtn");
+  if (zoomInBtn)
+    zoomInBtn.addEventListener("click", () => workspace.zoomCenter(1));
+  if (zoomOutBtn)
+    zoomOutBtn.addEventListener("click", () => workspace.zoomCenter(-1));
+
   // Make open button work with keyboard
   if (openButton) {
     openButton.addEventListener("click", () => {

--- a/main/main.js
+++ b/main/main.js
@@ -586,13 +586,19 @@ function initializeApp() {
   stopCodeButton.addEventListener("click", stopCode);
   exportCodeButton.addEventListener("click", exportCode);
 
-  // Add zoom in and out buttons
+  // Add toolbar buttons
   const zoomInBtn = document.getElementById("zoomInBtn");
   const zoomOutBtn = document.getElementById("zoomOutBtn");
+  const undoBtn = document.getElementById("undoBtn");
+  const redoBtn = document.getElementById("redoBtn");
   if (zoomInBtn)
     zoomInBtn.addEventListener("click", () => workspace.zoomCenter(1));
   if (zoomOutBtn)
     zoomOutBtn.addEventListener("click", () => workspace.zoomCenter(-1));
+  if (undoBtn)
+    undoBtn.addEventListener("click", () => workspace.undo(false));
+  if (redoBtn)
+    redoBtn.addEventListener("click", () => workspace.undo(true));
 
   // Make open button work with keyboard
   if (openButton) {

--- a/style.css
+++ b/style.css
@@ -836,6 +836,14 @@ button {
     justify-content: center;
     touch-action: manipulation;
   }
+
+  #blocklyZoomControls {
+    bottom: calc(9px + max(8px, env(safe-area-inset-bottom, 0px)));
+  }
+
+  #blocklyDiv {
+    height: calc(100% - 59px - max(8px, env(safe-area-inset-bottom, 0px))) !important;
+  }
 }
 
 @media only screen and (orientation: landscape) and (max-width: 768px) {

--- a/style.css
+++ b/style.css
@@ -474,6 +474,27 @@ button {
   position: relative;
   background-color: #f3f3f3;
 }
+
+#codePanel {
+  position: relative;
+}
+
+#blocklyZoomControls {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 50px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+  padding: 0 8px;
+  background-color: var(--color-bg);
+  box-shadow: 0px 0px 10px var(--color-shadow);
+  z-index: 10;
+}
 [data-theme="dark"] #canvasArea {
   background-color: #2c2c2c !important;
 }
@@ -868,7 +889,7 @@ button {
 
   #blocklyDiv {
     width: 100% !important;
-    height: 100% !important;
+    height: calc(100% - 50px) !important;
     position: relative;
   }
 

--- a/style.css
+++ b/style.css
@@ -495,6 +495,13 @@ button {
   box-shadow: 0px 0px 10px var(--color-shadow);
   z-index: 10;
 }
+
+#blocklyZoomControls .toolbar-divider {
+  width: 1px;
+  height: 24px;
+  background-color: var(--color-border);
+  margin: 0 4px;
+}
 [data-theme="dark"] #canvasArea {
   background-color: #2c2c2c !important;
 }

--- a/style/blockly.css
+++ b/style/blockly.css
@@ -4,9 +4,9 @@
   --color-bg: white;
   --color-text: black;
   --color-text-label: var(--color-text);
-  --axis-x-color: #1A9EE0;
-  --axis-y-color: #00CC96;
-  --axis-z-color: #F07020;
+  --axis-x-color: #1a9ee0;
+  --axis-y-color: #00cc96;
+  --axis-z-color: #f07020;
   --color-border-highlight: #ee5d6c;
   --color-search-highlight: #ed808b;
   --color-shadow: grey;
@@ -191,7 +191,9 @@ textarea.blocklyCommentText.blocklyTextarea.blocklyText {
   fill: rgba(255, 255, 255, 0.85) !important;
 }
 
-[data-theme="low-vision"] .blocklyMainWorkspaceScrollbar .blocklyScrollbarHandle {
+[data-theme="low-vision"]
+  .blocklyMainWorkspaceScrollbar
+  .blocklyScrollbarHandle {
   fill: rgba(224, 224, 224, 0.85) !important;
 }
 
@@ -339,6 +341,8 @@ path.blocklyPath.blockly-ws-search-highlight.blockly-ws-search-current {
   border-radius: 4px;
 }
 
+.blocklyZoomIn,
+.blocklyZoomOut,
 .blocklyZoomReset {
   display: none;
 }
@@ -578,7 +582,6 @@ body[data-theme="dark"] .blocklyTreeLabel {
   border-radius: 4px;
 }
 
-
 /* Add custom selection outline for both level 1 and 2 categories */
 .blocklyToolboxCategoryContainer[aria-selected="true"][aria-level="1"]
   > .blocklyToolboxCategory,
@@ -623,7 +626,9 @@ body[data-theme="low-vision"]
 }
 
 [data-theme="low-vision"] .blocklyEditableText > rect,
-[data-theme="low-vision"] .blocklyNonEditableText > rect:not(.blocklyDropdownRect) {
+[data-theme="low-vision"]
+  .blocklyNonEditableText
+  > rect:not(.blocklyDropdownRect) {
   fill: #ffffff !important;
   stroke: #cfcfcf !important;
   stroke-width: 1.5px !important;
@@ -802,14 +807,22 @@ body[data-theme="low-vision"]
 }
 
 /* Keyboard focus for DROPDOWN fields */
-.blocklyKeyboardNavigation .blocklyActiveFocus.blocklyDropdownField .blocklyDropdownRect,
-.blocklyKeyboardNavigation .blocklyActiveFocus.blocklyFieldDropdown .blocklyDropdownRect,
-.blocklyKeyboardNavigation .blocklyActiveFocus.blocklyEditableText .blocklyDropdownRect {
+.blocklyKeyboardNavigation
+  .blocklyActiveFocus.blocklyDropdownField
+  .blocklyDropdownRect,
+.blocklyKeyboardNavigation
+  .blocklyActiveFocus.blocklyFieldDropdown
+  .blocklyDropdownRect,
+.blocklyKeyboardNavigation
+  .blocklyActiveFocus.blocklyEditableText
+  .blocklyDropdownRect {
   stroke: var(--block-outline-focus) !important;
   stroke-width: 3px !important;
 }
 
-.blocklyKeyboardNavigation .blocklyActiveFocus.blocklyImageField image[style*="cursor: pointer"] {
+.blocklyKeyboardNavigation
+  .blocklyActiveFocus.blocklyImageField
+  image[style*="cursor: pointer"] {
   stroke: var(--block-outline-focus);
   stroke-width: 5px;
 }
@@ -821,19 +834,27 @@ body[data-theme="low-vision"]
 }
 
 /* Passive keyboard focus for DROPDOWN fields */
-.blocklyKeyboardNavigation .blocklyPassiveFocus.blocklyDropdownField .blocklyDropdownRect,
-.blocklyKeyboardNavigation .blocklyPassiveFocus.blocklyFieldDropdown .blocklyDropdownRect,
-.blocklyKeyboardNavigation .blocklyPassiveFocus.blocklyEditableText .blocklyDropdownRect {
+.blocklyKeyboardNavigation
+  .blocklyPassiveFocus.blocklyDropdownField
+  .blocklyDropdownRect,
+.blocklyKeyboardNavigation
+  .blocklyPassiveFocus.blocklyFieldDropdown
+  .blocklyDropdownRect,
+.blocklyKeyboardNavigation
+  .blocklyPassiveFocus.blocklyEditableText
+  .blocklyDropdownRect {
   stroke: var(--color-outline-focus) !important;
   stroke-width: 3px !important;
   stroke-dasharray: 4 2;
 }
 
-.blocklyKeyboardNavigation .blocklyPassiveFocus.blocklyImageField image[style*="cursor: pointer"] {
+.blocklyKeyboardNavigation
+  .blocklyPassiveFocus.blocklyImageField
+  image[style*="cursor: pointer"] {
   stroke: var(--color-outline-focus);
   stroke-width: 5px;
-  stroke-dasharray: 4 2;      /* Blockly-style short dash */
-  stroke-linecap: butt;       /* square dash ends */
+  stroke-dasharray: 4 2; /* Blockly-style short dash */
+  stroke-linecap: butt; /* square dash ends */
   vector-effect: non-scaling-stroke;
 }
 
@@ -948,13 +969,21 @@ textarea.blocklyCommentText.blocklyTextarea.blocklyText {
   box-sizing: border-box !important;
 }
 
-
 /* XYZ axis input outlines — survive theme changes via CSS */
 [data-xyz-active] > [data-axis="X"] .blocklyPath,
-[data-axis="X"].blocklySelected .blocklyPath { stroke: var(--axis-x-color) !important; stroke-width: 2px !important; }
+[data-axis="X"].blocklySelected .blocklyPath {
+  stroke: var(--axis-x-color) !important;
+  stroke-width: 2px !important;
+}
 
 [data-xyz-active] > [data-axis="Y"] .blocklyPath,
-[data-axis="Y"].blocklySelected .blocklyPath { stroke: var(--axis-y-color) !important; stroke-width: 2px !important; }
+[data-axis="Y"].blocklySelected .blocklyPath {
+  stroke: var(--axis-y-color) !important;
+  stroke-width: 2px !important;
+}
 
 [data-xyz-active] > [data-axis="Z"] .blocklyPath,
-[data-axis="Z"].blocklySelected .blocklyPath { stroke: var(--axis-z-color) !important; stroke-width: 2px !important; }
+[data-axis="Z"].blocklySelected .blocklyPath {
+  stroke: var(--axis-z-color) !important;
+  stroke-width: 2px !important;
+}


### PR DESCRIPTION
# Summary
Adds a new toolbar at the bottom right of the editor workspace, with controls for zooming in and out, and undo/redo.

<img width="516" height="288" alt="image" src="https://github.com/user-attachments/assets/aa97ba7a-f58c-490f-a642-8d06a191b92a" />

- New buttons appear in the tab order
- A new area 8 has been added to the area overlay to quickly tab to this area
- Layout works on mobile (tested on iPhone 14) 


### AI usage
Claude Sonnet 4.6 was used throughout this PR but all changes were approved individually by me. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a workspace controls toolbar in the code editor with undo, redo, zoom in, and zoom out buttons.

* **Accessibility**
  * Keyboard navigation and focus handling extended to include the new toolbar; visual focus/highlight positioning improved.

* **Style**
  * Layout and responsive adjustments to accommodate the toolbar across screen sizes.

* **Localization**
  * Added translations for toolbar labels in multiple languages.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flipcomputing/flock/pull/617)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->