### PR TITLE
Prevent duplicate canvas event listener registration

### DIFF
--- a/flock.js
+++ b/flock.js
@@ -1273,55 +1273,59 @@ export const flock = {
       console.error("Error initializing CSG2:", error);
     }
 
-    flock.canvas.addEventListener(
-      "touchend",
-      (event) => {
-        if (event.touches.length === 0) {
-          const input = flock.scene.activeCamera.inputs?.attached?.pointers;
-          // Add null check for input itself
-          if (
-            input &&
-            (input._pointA !== null ||
-              input._pointB !== null ||
-              input._isMultiTouch === true)
-          ) {
-            flock._hardResetCameraControls(flock.scene.activeCamera, {
-              reattachDelayMs: 100,
-              noPreventDefault: true,
-            });
+    if (!flock._canvasListenersRegistered) {
+      flock._canvasListenersRegistered = true;
+
+      flock.canvas.addEventListener(
+        "touchend",
+        (event) => {
+          if (event.touches.length === 0) {
+            const input = flock.scene.activeCamera.inputs?.attached?.pointers;
+            // Add null check for input itself
+            if (
+              input &&
+              (input._pointA !== null ||
+                input._pointB !== null ||
+                input._isMultiTouch === true)
+            ) {
+              flock._hardResetCameraControls(flock.scene.activeCamera, {
+                reattachDelayMs: 100,
+                noPreventDefault: true,
+              });
+            }
           }
-        }
-      },
-      { passive: false },
-    );
+        },
+        { passive: false },
+      );
 
-    flock.canvas.addEventListener("keydown", function (event) {
-      flock.canvas.currentKeyPressed = event.key;
-      flock.canvas.pressedKeys.add(event.key);
-    });
+      flock.canvas.addEventListener("keydown", function (event) {
+        flock.canvas.currentKeyPressed = event.key;
+        flock.canvas.pressedKeys.add(event.key);
+      });
 
-    flock.canvas.addEventListener("keyup", function (event) {
-      flock.canvas.pressedKeys.delete(event.key);
-    });
+      flock.canvas.addEventListener("keyup", function (event) {
+        flock.canvas.pressedKeys.delete(event.key);
+      });
 
-    flock.canvas.addEventListener("blur", () => {
-      // Clear all pressed keys when window loses focus
-      flock.canvas.pressedKeys.clear();
-      flock.canvas.pressedButtons.clear();
-      flock._hardResetCameraControls(flock.scene?.activeCamera);
-    });
+      flock.canvas.addEventListener("blur", () => {
+        // Clear all pressed keys when window loses focus
+        flock.canvas.pressedKeys.clear();
+        flock.canvas.pressedButtons.clear();
+        flock._hardResetCameraControls(flock.scene?.activeCamera);
+      });
 
-    // Hardening for rare pointer/input desync where camera keeps moving
-    // after input ends or browser focus changes.
-    window.addEventListener("blur", () => {
-      flock.canvas.pressedKeys.clear();
-      flock.canvas.pressedButtons.clear();
-      flock._hardResetCameraControls(flock.scene?.activeCamera);
-    });
+      // Hardening for rare pointer/input desync where camera keeps moving
+      // after input ends or browser focus changes.
+      window.addEventListener("blur", () => {
+        flock.canvas.pressedKeys.clear();
+        flock.canvas.pressedButtons.clear();
+        flock._hardResetCameraControls(flock.scene?.activeCamera);
+      });
 
-    window.addEventListener("pointerup", () => {
-      flock._hardResetCameraControls(flock.scene?.activeCamera);
-    });
+      window.addEventListener("pointerup", () => {
+        flock._hardResetCameraControls(flock.scene?.activeCamera);
+      });
+    }
 
     flock.engineReady = true;
   },


### PR DESCRIPTION
## Summary
Wrapped all canvas and window event listener registrations in a guard condition to prevent duplicate listener attachment when the initialization function is called multiple times.

## Key Changes
- Added `flock._canvasListenersRegistered` flag to track whether listeners have already been registered
- Wrapped all event listener attachments (touchend, keydown, keyup, blur, pointerup) in a conditional block that only executes once
- This prevents memory leaks and duplicate event handling that could occur if the initialization code runs more than once

## Implementation Details
The change uses a simple boolean flag (`flock._canvasListenersRegistered`) to ensure that the event listener registration block only executes on the first initialization. This is a common pattern for preventing duplicate listener registration in scenarios where initialization functions may be called multiple times during the application lifecycle.

https://claude.ai/code/session_01QYFwXKPZrjm2RxVFKcKNvA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where input event listeners were being registered multiple times during initialization, preventing potential performance issues and input handling anomalies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->