### PR TITLE
Workspace search improvements

### DIFF
--- a/main/blockhandling.js
+++ b/main/blockhandling.js
@@ -591,7 +591,7 @@ function observeBlocklyInputs() {
 
   // Observe only the Blockly container to avoid scanning the entire document
   const blocklyContainer =
-    workspace.getParentSvg()?.closest("#blocklyDiv") ??
+    workspace?.getParentSvg()?.closest("#blocklyDiv") ??
     document.getElementById("blocklyDiv") ??
     document.body;
   observer.observe(blocklyContainer, { childList: true, subtree: true });

--- a/main/blocklyinit.js
+++ b/main/blocklyinit.js
@@ -648,6 +648,52 @@ export function initializeWorkspace() {
   }
   workspaceSearch.init();
 
+  // Fade non-matching blocks during search
+  const blocklyDiv = document.getElementById("blocklyDiv");
+  const originalOpen = workspaceSearch.open.bind(workspaceSearch);
+  const originalClose = workspaceSearch.close.bind(workspaceSearch);
+  workspaceSearch.open = function () {
+    originalOpen();
+    blocklyDiv?.classList.add("blockly-search-active");
+  };
+  workspaceSearch.close = function () {
+    originalClose();
+    blocklyDiv?.classList.remove("blockly-search-active");
+  };
+
+  // Override highlight methods to work at block-group level so the plugin's
+  // injected fill: #000 rule never applies to matched block paths.
+  workspaceSearch.highlightSearchGroup = function (blocks) {
+    const matchTopIds = new Set();
+    blocks.forEach((block) => {
+      block.getSvgRoot()?.classList.add("ws-search-match");
+      let top = block;
+      while (top.getSurroundParent()) top = top.getSurroundParent();
+      matchTopIds.add(top.id);
+    });
+    workspace.getTopBlocks(false).forEach((block) => {
+      if (!matchTopIds.has(block.id)) {
+        block.getSvgRoot()?.classList.add("ws-search-fade");
+      }
+    });
+  };
+  workspaceSearch.unhighlightSearchGroup = function (blocks) {
+    blocks.forEach((block) => block.getSvgRoot()?.classList.remove("ws-search-match"));
+    workspace.getTopBlocks(false).forEach((block) => {
+      block.getSvgRoot()?.classList.remove("ws-search-fade");
+    });
+  };
+  workspaceSearch.highlightCurrentSelection = function (block) {
+    const svg = block.getSvgRoot();
+    if (svg) {
+      svg.classList.add("ws-search-current");
+      svg.parentNode?.appendChild(svg);
+    }
+  };
+  workspaceSearch.unhighlightCurrentSelection = function (block) {
+    block.getSvgRoot()?.classList.remove("ws-search-current");
+  };
+
   // Override the workspace centering for workspace search as it jumps all over the place by default!
   const originalCenter = workspace.centerOnBlock.bind(workspace);
 

--- a/main/blocklyinit.js
+++ b/main/blocklyinit.js
@@ -687,7 +687,10 @@ export function initializeWorkspace() {
     const svg = block.getSvgRoot();
     if (svg) {
       svg.classList.add("ws-search-current");
-      svg.parentNode?.appendChild(svg);
+      let top = block;
+      while (top.getSurroundParent()) top = top.getSurroundParent();
+      const topSvg = top.getSvgRoot();
+      if (topSvg) topSvg.parentNode?.appendChild(topSvg);
     }
   };
   workspaceSearch.unhighlightCurrentSelection = function (block) {

--- a/style/blockly.css
+++ b/style/blockly.css
@@ -427,6 +427,14 @@ body[data-theme="low-vision"] {
   filter: invert(1);
 }
 
+[data-theme="dark"] .blockly-ws-search button:focus,
+[data-theme="dark-contrast"] .blockly-ws-search button:focus,
+[data-theme="low-vision"] .blockly-ws-search button:focus,
+[data-theme="contrast"] .blockly-ws-search button:focus {
+  outline: 3px solid #0033cc; /* inverts to #ffcc33 (~#fc3) after filter: invert(1) */
+  outline-offset: 2px;
+}
+
 /* Responsive Styles */
 @media (max-width: 768px) {
   :root {

--- a/style/blockly.css
+++ b/style/blockly.css
@@ -257,8 +257,22 @@ body[data-theme="low-vision"] {
 }
 
 /* Non-current matches get a pale yellow background */
-#blocklyDiv.blockly-search-active .ws-search-match:not(.ws-search-current) > path.blocklyPath {
+#blocklyDiv.blockly-search-active
+  .ws-search-match:not(.ws-search-current)
+  > path.blocklyPath {
   fill: rgba(255, 242, 0, 0.3) !important;
+}
+
+/* Low-vision: replace fill with a dashed white stroke for better contrast */
+[data-theme="low-vision"]
+  #blocklyDiv.blockly-search-active
+  .ws-search-match:not(.ws-search-current)
+  > path.blocklyPath {
+  fill: revert !important;
+  stroke: #ffffff !important;
+  stroke-width: 10px !important;
+  stroke-dasharray: 8 4;
+  paint-order: stroke fill;
 }
 
 /* Current match gets a yellow outline */

--- a/style/blockly.css
+++ b/style/blockly.css
@@ -198,9 +198,6 @@ textarea.blocklyCommentText.blocklyTextarea.blocklyText {
 }
 
 body[data-theme="contrast"] {
-  .blocklyWidgetDiv .blocklyMenuItemContent {
-    color: black !important;
-  }
   .blocklyField text.blocklyText.blocklyFieldText {
     fill: black !important;
   }
@@ -241,9 +238,6 @@ body[data-theme="low-vision"] {
   }
 }
 
-textarea.blocklyCommentText.blocklyTextarea.blocklyText {
-  color: black;
-}
 /* Search Highlight Styles */
 .blockly-ws-search {
   background: var(--color-bg);
@@ -416,14 +410,6 @@ path.blocklyPath.blockly-ws-search-highlight.blockly-ws-search-current {
   cursor: pointer !important;
 }
 
-path.blocklyPath.blockly-ws-search-highlight {
-  fill: var(--color-search-highlight);
-}
-
-path.blocklyPath.blockly-ws-search-highlight.blockly-ws-search-current {
-  fill: var(--color-border-highlight);
-}
-
 [data-theme="dark"] .blockly-ws-search button,
 [data-theme="dark-contrast"] .blockly-ws-search button,
 [data-theme="low-vision"] .blockly-ws-search button,
@@ -462,16 +448,6 @@ path.blocklyPath.blockly-ws-search-highlight.blockly-ws-search-current {
 [data-theme="low-vision"] .blocklyPath {
   stroke: #e0e0e0 !important;
   stroke-width: 2.5px !important;
-}
-
-/* Toolbox category selection outline */
-.blocklyToolboxCategoryContainer[aria-selected="true"][aria-level="1"]
-  > .blocklyToolboxCategory,
-.blocklyToolboxCategoryContainer[aria-selected="true"][aria-level="2"]
-  > .blocklyToolboxCategory {
-  outline: 2px solid var(--color-outline-focus);
-  outline-offset: -2px;
-  border-radius: 4px;
 }
 
 /* 2. Default item text color */
@@ -566,23 +542,6 @@ body[data-theme="dark"] .blocklyTreeLabel {
 
 .blocklyToolboxCategoryContainer:focus {
   outline: none !important;
-}
-
-.blocklyToolboxCategoryContainer[aria-selected="true"][aria-level="1"]
-  > .blocklyToolboxCategory {
-  outline: 2px solid #fc3;
-  outline-offset: -2px;
-  border-radius: 4px;
-}
-
-/* Add custom selection outline for both level 1 and 2 categories */
-.blocklyToolboxCategoryContainer[aria-selected="true"][aria-level="1"]
-  > .blocklyToolboxCategory,
-.blocklyToolboxCategoryContainer[aria-selected="true"][aria-level="2"]
-  > .blocklyToolboxCategory {
-  outline: 2px solid #fc3;
-  outline-offset: -2px;
-  border-radius: 4px;
 }
 
 [data-theme="contrast"] .blocklyText {
@@ -777,22 +736,6 @@ body[data-theme="low-vision"]
   }
 }
 
-.blocklyToolboxCategoryContainer[aria-selected="true"][aria-level="1"]
-  > .blocklyToolboxCategory {
-  outline: 2px solid #fc3;
-  outline-offset: -2px;
-  border-radius: 4px;
-}
-
-.blocklyToolboxCategoryContainer[aria-selected="true"][aria-level="1"]
-  > .blocklyToolboxCategory,
-.blocklyToolboxCategoryContainer[aria-selected="true"][aria-level="2"]
-  > .blocklyToolboxCategory {
-  outline: 2px solid #fc3;
-  outline-offset: -2px;
-  border-radius: 4px;
-}
-
 /* Keyboard focus for image BUTTON fields only (e.g. plus/minus/toggle icons) */
 .blocklyKeyboardNavigation .blocklyActiveFocus.blocklyImageField {
   outline: 5px solid var(--block-outline-focus);
@@ -947,11 +890,6 @@ body[data-theme="low-vision"]
   fill: #c9b85a !important;
   stroke: #a89940 !important;
   stroke-width: 2px !important;
-}
-
-/* Wrap long lines inside the workspace-comment editor */
-textarea.blocklyCommentText.blocklyTextarea.blocklyText {
-  color: black;
 }
 
 /* Keep block comment editor constrained to its bubble */

--- a/style/blockly.css
+++ b/style/blockly.css
@@ -256,6 +256,11 @@ body[data-theme="low-vision"] {
   transition: opacity 0.15s ease;
 }
 
+/* Non-current matches get a pale yellow background */
+#blocklyDiv.blockly-search-active .ws-search-match:not(.ws-search-current) > path.blocklyPath {
+  fill: rgba(255, 242, 0, 0.3) !important;
+}
+
 /* Current match gets a yellow outline */
 #blocklyDiv.blockly-search-active .ws-search-current > path.blocklyPath {
   stroke: var(--block-outline-focus) !important;

--- a/style/blockly.css
+++ b/style/blockly.css
@@ -4,9 +4,9 @@
   --color-bg: white;
   --color-text: black;
   --color-text-label: var(--color-text);
-  --axis-x-color: #1A9EE0;
-  --axis-y-color: #00CC96;
-  --axis-z-color: #F07020;
+  --axis-x-color: #1a9ee0;
+  --axis-y-color: #00cc96;
+  --axis-z-color: #f07020;
   --color-border-highlight: #ee5d6c;
   --color-search-highlight: #ed808b;
   --color-shadow: grey;
@@ -191,7 +191,9 @@ textarea.blocklyCommentText.blocklyTextarea.blocklyText {
   fill: rgba(255, 255, 255, 0.85) !important;
 }
 
-[data-theme="low-vision"] .blocklyMainWorkspaceScrollbar .blocklyScrollbarHandle {
+[data-theme="low-vision"]
+  .blocklyMainWorkspaceScrollbar
+  .blocklyScrollbarHandle {
   fill: rgba(224, 224, 224, 0.85) !important;
 }
 
@@ -414,24 +416,19 @@ path.blocklyPath.blockly-ws-search-highlight.blockly-ws-search-current {
   cursor: pointer !important;
 }
 
-/* Search Highlight Styles */
-.blockly-ws-search {
-  background: var(--color-bg);
-  margin-top: 5px;
-  border: solid var(--color-border-highlight) 4px;
-  box-shadow: 0px 10px 20px var(--color-shadow);
-  justify-content: center;
-  padding: 0.25em;
-  position: absolute;
-  z-index: 70;
-}
-
 path.blocklyPath.blockly-ws-search-highlight {
   fill: var(--color-search-highlight);
 }
 
 path.blocklyPath.blockly-ws-search-highlight.blockly-ws-search-current {
   fill: var(--color-border-highlight);
+}
+
+[data-theme="dark"] .blockly-ws-search button,
+[data-theme="dark-contrast"] .blockly-ws-search button,
+[data-theme="low-vision"] .blockly-ws-search button,
+[data-theme="contrast"] .blockly-ws-search button {
+  filter: invert(1);
 }
 
 /* Responsive Styles */
@@ -578,7 +575,6 @@ body[data-theme="dark"] .blocklyTreeLabel {
   border-radius: 4px;
 }
 
-
 /* Add custom selection outline for both level 1 and 2 categories */
 .blocklyToolboxCategoryContainer[aria-selected="true"][aria-level="1"]
   > .blocklyToolboxCategory,
@@ -623,7 +619,9 @@ body[data-theme="low-vision"]
 }
 
 [data-theme="low-vision"] .blocklyEditableText > rect,
-[data-theme="low-vision"] .blocklyNonEditableText > rect:not(.blocklyDropdownRect) {
+[data-theme="low-vision"]
+  .blocklyNonEditableText
+  > rect:not(.blocklyDropdownRect) {
   fill: #ffffff !important;
   stroke: #cfcfcf !important;
   stroke-width: 1.5px !important;
@@ -802,14 +800,22 @@ body[data-theme="low-vision"]
 }
 
 /* Keyboard focus for DROPDOWN fields */
-.blocklyKeyboardNavigation .blocklyActiveFocus.blocklyDropdownField .blocklyDropdownRect,
-.blocklyKeyboardNavigation .blocklyActiveFocus.blocklyFieldDropdown .blocklyDropdownRect,
-.blocklyKeyboardNavigation .blocklyActiveFocus.blocklyEditableText .blocklyDropdownRect {
+.blocklyKeyboardNavigation
+  .blocklyActiveFocus.blocklyDropdownField
+  .blocklyDropdownRect,
+.blocklyKeyboardNavigation
+  .blocklyActiveFocus.blocklyFieldDropdown
+  .blocklyDropdownRect,
+.blocklyKeyboardNavigation
+  .blocklyActiveFocus.blocklyEditableText
+  .blocklyDropdownRect {
   stroke: var(--block-outline-focus) !important;
   stroke-width: 3px !important;
 }
 
-.blocklyKeyboardNavigation .blocklyActiveFocus.blocklyImageField image[style*="cursor: pointer"] {
+.blocklyKeyboardNavigation
+  .blocklyActiveFocus.blocklyImageField
+  image[style*="cursor: pointer"] {
   stroke: var(--block-outline-focus);
   stroke-width: 5px;
 }
@@ -821,19 +827,27 @@ body[data-theme="low-vision"]
 }
 
 /* Passive keyboard focus for DROPDOWN fields */
-.blocklyKeyboardNavigation .blocklyPassiveFocus.blocklyDropdownField .blocklyDropdownRect,
-.blocklyKeyboardNavigation .blocklyPassiveFocus.blocklyFieldDropdown .blocklyDropdownRect,
-.blocklyKeyboardNavigation .blocklyPassiveFocus.blocklyEditableText .blocklyDropdownRect {
+.blocklyKeyboardNavigation
+  .blocklyPassiveFocus.blocklyDropdownField
+  .blocklyDropdownRect,
+.blocklyKeyboardNavigation
+  .blocklyPassiveFocus.blocklyFieldDropdown
+  .blocklyDropdownRect,
+.blocklyKeyboardNavigation
+  .blocklyPassiveFocus.blocklyEditableText
+  .blocklyDropdownRect {
   stroke: var(--color-outline-focus) !important;
   stroke-width: 3px !important;
   stroke-dasharray: 4 2;
 }
 
-.blocklyKeyboardNavigation .blocklyPassiveFocus.blocklyImageField image[style*="cursor: pointer"] {
+.blocklyKeyboardNavigation
+  .blocklyPassiveFocus.blocklyImageField
+  image[style*="cursor: pointer"] {
   stroke: var(--color-outline-focus);
   stroke-width: 5px;
-  stroke-dasharray: 4 2;      /* Blockly-style short dash */
-  stroke-linecap: butt;       /* square dash ends */
+  stroke-dasharray: 4 2; /* Blockly-style short dash */
+  stroke-linecap: butt; /* square dash ends */
   vector-effect: non-scaling-stroke;
 }
 
@@ -948,13 +962,21 @@ textarea.blocklyCommentText.blocklyTextarea.blocklyText {
   box-sizing: border-box !important;
 }
 
-
 /* XYZ axis input outlines — survive theme changes via CSS */
 [data-xyz-active] > [data-axis="X"] .blocklyPath,
-[data-axis="X"].blocklySelected .blocklyPath { stroke: var(--axis-x-color) !important; stroke-width: 2px !important; }
+[data-axis="X"].blocklySelected .blocklyPath {
+  stroke: var(--axis-x-color) !important;
+  stroke-width: 2px !important;
+}
 
 [data-xyz-active] > [data-axis="Y"] .blocklyPath,
-[data-axis="Y"].blocklySelected .blocklyPath { stroke: var(--axis-y-color) !important; stroke-width: 2px !important; }
+[data-axis="Y"].blocklySelected .blocklyPath {
+  stroke: var(--axis-y-color) !important;
+  stroke-width: 2px !important;
+}
 
 [data-xyz-active] > [data-axis="Z"] .blocklyPath,
-[data-axis="Z"].blocklySelected .blocklyPath { stroke: var(--axis-z-color) !important; stroke-width: 2px !important; }
+[data-axis="Z"].blocklySelected .blocklyPath {
+  stroke: var(--axis-z-color) !important;
+  stroke-width: 2px !important;
+}

--- a/style/blockly.css
+++ b/style/blockly.css
@@ -250,12 +250,17 @@ body[data-theme="low-vision"] {
   z-index: 70;
 }
 
-path.blocklyPath.blockly-ws-search-highlight {
-  fill: var(--color-search-highlight);
+/* Fade top-level blocks that contain no search matches */
+#blocklyDiv.blockly-search-active .ws-search-fade {
+  opacity: 0.4;
+  transition: opacity 0.15s ease;
 }
 
-path.blocklyPath.blockly-ws-search-highlight.blockly-ws-search-current {
-  fill: var(--color-border-highlight);
+/* Current match gets a yellow outline */
+#blocklyDiv.blockly-search-active .ws-search-current > path.blocklyPath {
+  stroke: var(--block-outline-focus) !important;
+  stroke-width: 10px !important;
+  paint-order: stroke fill;
 }
 
 @media (min-width: 769px) {


### PR DESCRIPTION
# Summary
Makes buttons in workspace search visible in dark themes, and changes the behaviour of the highlighting of matches in the search.

- Prev / Next / Close buttons now visible in all themes
- In all themes, the selected match is outlined in yellow. 
- In light/dark theme, other matches not selected are highlighted in yellow. In low vision theme, other matches have a dashed white outline.

⚠️  I think this needs to be reviewed by Danny for advice. I've explored some other possibilities in the tasks Google doc. 

### AI usage
Claude Sonnet 4.6 used throughout for code changes, all changes reviewed and accepted (and many rejected!) by a human.

