### PR TITLE
Grid focus highlight improvements

### DIFF
--- a/style.css
+++ b/style.css
@@ -720,13 +720,9 @@ button {
 }
 
 #shapes-dropdown ul li.keyboard-focused {
-  background-color: var(--color-bg-glass-focused);
-  box-shadow: 0 0 0 2px #007acc;
+  outline: 3px solid var(--color-outline-focus);
+  outline-offset: -3px;
   border-radius: 5px;
-}
-
-#shapes-dropdown ul li.keyboard-focused img {
-  transform: scale(1.2);
 }
 
 /* Scrollable Container with Arrows */

--- a/style/blockly.css
+++ b/style/blockly.css
@@ -537,6 +537,10 @@ body[data-theme="low-vision"] {
   box-shadow: 0 0 0 4px #fff !important;
 }
 
+.blocklyFieldGrid .blocklyFieldGridItem:focus {
+  outline: 3px solid var(--color-outline-focus) !important;
+}
+
 body .blocklyHtmlInput {
   font-family:
     "Atkinson Hyperlegible Next", "Asap", Helvetica, Arial, Lucida, sans-serif !important;

--- a/style/blockly.css
+++ b/style/blockly.css
@@ -524,6 +524,11 @@ body[data-theme="low-vision"] {
   color: var(--color-menu-item-text) !important;
 }
 
+/* Fix offsetParent so the plugin's scroll-into-view logic targets the right container. */
+.blocklyFieldGridContainer {
+  position: relative;
+}
+
 /* Ensure key labels in field_grid_dropdown are readable on light dropdowns. */
 .blocklyFieldGrid .blocklyFieldGridItem {
   color: #000000 !important;

--- a/ui/colourpicker.css
+++ b/ui/colourpicker.css
@@ -532,7 +532,7 @@
 .color-picker-close:focus {
   background: #f0f0f0;
   color: #333;
-  outline: 3px solid var(--color-outline-focus);
+  outline: 3px solid var(--color-focus);
   outline-offset: 2px;
 }
 
@@ -655,7 +655,7 @@
 
 .color-brightness:hover,
 .color-brightness:focus {
-  outline: 3px solid var(--color-outline-focus);
+  outline: 3px solid var(--color-focus);
   outline-offset: 2px;
   transform: scale(1.02);
 }
@@ -707,7 +707,7 @@
 .advanced-toggle:hover,
 .advanced-toggle:focus {
   background: #e8e8e8;
-  outline: 3px solid var(--color-outline-focus);
+  outline: 3px solid var(--color-focus);
   outline-offset: 2px;
 }
 
@@ -751,7 +751,7 @@
 }
 
 .rgb-slider:focus {
-  outline: 3px solid var(--color-outline-focus);
+  outline: 3px solid var(--color-focus);
   outline-offset: 2px;
 }
 
@@ -787,7 +787,7 @@
 }
 
 .rgb-number:focus {
-  outline: 3px solid var(--color-outline-focus);
+  outline: 3px solid var(--color-focus);
   outline-offset: 2px;
 }
 
@@ -807,7 +807,7 @@
 }
 
 .css-color-input:focus {
-  outline: 3px solid var(--color-outline-focus);
+  outline: 3px solid var(--color-focus);
   outline-offset: 2px;
 }
 

--- a/ui/colourpicker.css
+++ b/ui/colourpicker.css
@@ -532,7 +532,7 @@
 .color-picker-close:focus {
   background: #f0f0f0;
   color: #333;
-  outline: 3px solid #511d91;
+  outline: 3px solid var(--color-outline-focus);
   outline-offset: 2px;
 }
 
@@ -655,7 +655,7 @@
 
 .color-brightness:hover,
 .color-brightness:focus {
-  outline: 3px solid #511d91;
+  outline: 3px solid var(--color-outline-focus);
   outline-offset: 2px;
   transform: scale(1.02);
 }
@@ -707,8 +707,7 @@
 .advanced-toggle:hover,
 .advanced-toggle:focus {
   background: #e8e8e8;
-  border-color: #511d91;
-  outline: 3px solid #511d91;
+  outline: 3px solid var(--color-outline-focus);
   outline-offset: 2px;
 }
 
@@ -752,7 +751,7 @@
 }
 
 .rgb-slider:focus {
-  outline: 3px solid #511d91;
+  outline: 3px solid var(--color-outline-focus);
   outline-offset: 2px;
 }
 
@@ -788,9 +787,8 @@
 }
 
 .rgb-number:focus {
-  outline: 3px solid #511d91;
+  outline: 3px solid var(--color-outline-focus);
   outline-offset: 2px;
-  border-color: #511d91;
 }
 
 /* CSS input */
@@ -805,13 +803,12 @@
   border-radius: 8px;
   font-size: 16px;
   font-family: monospace;
-  transition: all 0.2s ease;
+  transition: border-color 0.2s ease;
 }
 
 .css-color-input:focus {
-  outline: 3px solid #511d91;
+  outline: 3px solid var(--color-outline-focus);
   outline-offset: 2px;
-  border-color: #511d91;
 }
 
 /* Action buttons */


### PR DESCRIPTION
# Summary 
Improve focus highlighting in various places:
- When selecting a material (also fixed a bug where using kb nav in this grid didn't bother to scroll)
<img width="690" height="660" alt="image" src="https://github.com/user-attachments/assets/c2dda9aa-067a-4308-a57b-80c14c6afb58" />

- When selecting an object - now just uses standard highlight outline to show focus, plus the mouseover (removed background highlight for focus which was confusing in addition to the mouseover)
<img width="536" height="427" alt="image" src="https://github.com/user-attachments/assets/fd158c2f-4e05-4836-8699-cfde8ab4549c" />

- Fixed an odd bug I noticed in the colour picker where the hex code field previously had a double bordered purple highlight(??) It's now consistent with other focus highlights. 

<img width="542" height="504" alt="image" src="https://github.com/user-attachments/assets/54330dfd-0fa9-462c-8d23-0a136b821c7e" />

### Notes
I noticed that when you use the left/right to scroll through meshes on the add shape menu, the column alignment of the grid gets out of line. I'll record this as an issue. 

### AI usage
Claude Sonnet 4.6 used throughout, with all changes designed and approved by a human. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved focus indicators across interactive elements by updating outline styling and colors. All focus indicators now use theme-based variables instead of hardcoded values, providing consistent visual feedback during keyboard navigation for dropdown menus, field grids, and color controls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flipcomputing/flock/pull/628)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->