### PR TITLE
Document M shortcut

### DIFF
--- a/accessibility/keyboardui.js
+++ b/accessibility/keyboardui.js
@@ -425,6 +425,11 @@ function getShortcuts() {
       keys: `Esc`,
       category: translate("shortcut_category_editor"),
     },
+    {
+      label: translate("shortcut_start_move_block"),
+      keys: `M`,
+      category: translate("shortcut_category_editor"),
+    },
 
     {
       label: translate("shortcut_open_gizmos"),

--- a/locale/de.js
+++ b/locale/de.js
@@ -1242,6 +1242,7 @@ export default {
   shortcut_select_previous_result: "Vorheriges Suchergebnis",
   shortcut_focus_result: "Zum ausgewählten Suchergebnis springen",
   shortcut_move_through_blocks: "Durch Blöcke navigieren",
+  shortcut_start_move_block: "Block verschieben",
   shortcut_open_gizmos: "Gizmos",
   shortcut_select_gizmo: "Gizmo auswählen",
   shortcut_keyboard_cursor_gizmos: "Tastaturcursor für Gizmos",

--- a/locale/en.js
+++ b/locale/en.js
@@ -1292,6 +1292,7 @@ export default {
   shortcut_select_previous_result: "Previous search result",
   shortcut_focus_result: "Go to selected search result",
   shortcut_move_through_blocks: "Move through blocks",
+  shortcut_start_move_block: "Move block",
   shortcut_open_gizmos: "Gizmos",
   shortcut_select_gizmo: "Select gizmo",
   shortcut_keyboard_cursor_gizmos: "Keyboard cursor for gizmos",

--- a/locale/es.js
+++ b/locale/es.js
@@ -1255,6 +1255,7 @@ export default {
   shortcut_select_previous_result: "Resultado de búsqueda anterior",
   shortcut_focus_result: "Ir al resultado de búsqueda seleccionado",
   shortcut_move_through_blocks: "Navegar por los bloques",
+  shortcut_start_move_block: "Mover bloque",
   shortcut_open_gizmos: "Gizmos",
   shortcut_select_gizmo: "Seleccionar gizmo",
   shortcut_keyboard_cursor_gizmos: "Cursor de teclado para gizmos",

--- a/locale/fr.js
+++ b/locale/fr.js
@@ -1254,6 +1254,7 @@ export default {
   shortcut_select_previous_result: "Résultat de recherche précédent",
   shortcut_focus_result: "Aller au résultat de recherche sélectionné",
   shortcut_move_through_blocks: "Naviguer dans les blocs",
+  shortcut_start_move_block: "Déplacer le bloc",
   shortcut_open_gizmos: "Gizmos",
   shortcut_select_gizmo: "Sélectionner un gizmo",
   shortcut_keyboard_cursor_gizmos: "Curseur clavier pour les gizmos",

--- a/locale/it.js
+++ b/locale/it.js
@@ -1244,6 +1244,7 @@ export default {
   shortcut_select_previous_result: "Risultato di ricerca precedente",
   shortcut_focus_result: "Vai al risultato di ricerca selezionato",
   shortcut_move_through_blocks: "Navigare tra i blocchi",
+  shortcut_start_move_block: "Sposta blocco",
   shortcut_open_gizmos: "Gizmos",
   shortcut_select_gizmo: "Seleziona gizmo",
   shortcut_keyboard_cursor_gizmos: "Cursore da tastiera per i gizmos",

--- a/locale/pl.js
+++ b/locale/pl.js
@@ -1249,6 +1249,7 @@ export default {
   shortcut_select_previous_result: "Poprzedni wynik wyszukiwania",
   shortcut_focus_result: "Przejdź do wybranego wyniku wyszukiwania",
   shortcut_move_through_blocks: "Nawiguj między blokami",
+  shortcut_start_move_block: "Przesuń blok",
   shortcut_open_gizmos: "Gizmos",
   shortcut_select_gizmo: "Wybierz gizmo",
   shortcut_keyboard_cursor_gizmos: "Kursor klawiatury dla gizmos",

--- a/locale/pt.js
+++ b/locale/pt.js
@@ -1241,6 +1241,7 @@ export default {
   shortcut_select_previous_result: "Resultado de pesquisa anterior",
   shortcut_focus_result: "Ir para o resultado de pesquisa selecionado",
   shortcut_move_through_blocks: "Navegar pelos blocos",
+  shortcut_start_move_block: "Mover bloco",
   shortcut_open_gizmos: "Gizmos",
   shortcut_select_gizmo: "Selecionar gizmo",
   shortcut_keyboard_cursor_gizmos: "Cursor de teclado para gizmos",

--- a/locale/sv.js
+++ b/locale/sv.js
@@ -1231,6 +1231,7 @@ export default {
   shortcut_select_previous_result: "Föregående sökresultat",
   shortcut_focus_result: "Gå till valt sökresultat",
   shortcut_move_through_blocks: "Navigera bland block",
+  shortcut_start_move_block: "Flytta block",
   shortcut_open_gizmos: "Gizmos",
   shortcut_select_gizmo: "Välj gizmo",
   shortcut_keyboard_cursor_gizmos: "Tangentbordskursor för gizmos",


### PR DESCRIPTION
# Summary
Document the M shortcut to move blocks (discovered as missing in a spike to do with toasts) 

### AI use
Claude Sonnet 4.6 did the translations. I did the code. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcut (M) to start moving blocks with multi-language support (German, English, Spanish, French, Italian, Polish, Portuguese, Swedish).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flipcomputing/flock/pull/630)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->