### PR TITLE
Translate blockly toasts

### DIFF
--- a/locale/de.js
+++ b/locale/de.js
@@ -1258,4 +1258,12 @@ export default {
   shortcut_category_area_menu: "Bereichsmenü",
   shortcut_category_editor: "Editor",
   shortcut_category_gizmos: "Gizmos",
+
+  // Blockly keyboard navigation toast messages
+  KEYBOARD_NAV_WORKSPACE_NAVIGATION_HINT: "Verwende die Pfeiltasten zum Navigieren", // machine
+  KEYBOARD_NAV_BLOCK_NAVIGATION_HINT: "Verwende die rechte Pfeiltaste, um innerhalb von Blöcken zu navigieren", // machine
+  KEYBOARD_NAV_CONSTRAINED_MOVE_HINT: "Verwende die Pfeiltasten zum Bewegen, dann %1 zum Bestätigen der Position", // machine
+  KEYBOARD_NAV_UNCONSTRAINED_MOVE_HINT: "Halte %1 gedrückt und verwende die Pfeiltasten zum freien Bewegen, dann %2 zum Bestätigen", // machine
+  KEYBOARD_NAV_COPIED_HINT: "Kopiert. Drücke %1 zum Einfügen.", // machine
+  KEYBOARD_NAV_CUT_HINT: "Ausgeschnitten. Drücke %1 zum Einfügen.", // machine
 };

--- a/locale/en.js
+++ b/locale/en.js
@@ -1311,9 +1311,12 @@ export default {
 
   // Blockly keyboard navigation toast messages
   KEYBOARD_NAV_WORKSPACE_NAVIGATION_HINT: "Use the arrow keys to navigate",
-  KEYBOARD_NAV_BLOCK_NAVIGATION_HINT: "Use the right arrow key to navigate inside of blocks",
-  KEYBOARD_NAV_CONSTRAINED_MOVE_HINT: "Use the arrow keys to move, then %1 to accept the position",
-  KEYBOARD_NAV_UNCONSTRAINED_MOVE_HINT: "Hold %1 and use arrow keys to move freely, then %2 to accept the position",
+  KEYBOARD_NAV_BLOCK_NAVIGATION_HINT:
+    "Use the right arrow key to navigate inside of blocks",
+  KEYBOARD_NAV_CONSTRAINED_MOVE_HINT:
+    "Use the arrow keys to move, then %1 to accept the position",
+  KEYBOARD_NAV_UNCONSTRAINED_MOVE_HINT:
+    "Hold %1 and use arrow keys to move freely, then %2 to accept the position",
   KEYBOARD_NAV_COPIED_HINT: "Copied. Press %1 to paste.",
   KEYBOARD_NAV_CUT_HINT: "Cut. Press %1 to paste.",
 };

--- a/locale/en.js
+++ b/locale/en.js
@@ -1308,4 +1308,12 @@ export default {
   shortcut_category_area_menu: "Area menu",
   shortcut_category_editor: "Editor",
   shortcut_category_gizmos: "Gizmos",
+
+  // Blockly keyboard navigation toast messages
+  KEYBOARD_NAV_WORKSPACE_NAVIGATION_HINT: "Use the arrow keys to navigate",
+  KEYBOARD_NAV_BLOCK_NAVIGATION_HINT: "Use the right arrow key to navigate inside of blocks",
+  KEYBOARD_NAV_CONSTRAINED_MOVE_HINT: "Use the arrow keys to move, then %1 to accept the position",
+  KEYBOARD_NAV_UNCONSTRAINED_MOVE_HINT: "Hold %1 and use arrow keys to move freely, then %2 to accept the position",
+  KEYBOARD_NAV_COPIED_HINT: "Copied. Press %1 to paste.",
+  KEYBOARD_NAV_CUT_HINT: "Cut. Press %1 to paste.",
 };

--- a/locale/es.js
+++ b/locale/es.js
@@ -1271,4 +1271,12 @@ export default {
   shortcut_category_area_menu: "Menú de áreas",
   shortcut_category_editor: "Editor",
   shortcut_category_gizmos: "Gizmos",
+
+  // Blockly keyboard navigation toast messages
+  KEYBOARD_NAV_WORKSPACE_NAVIGATION_HINT: "Usa las teclas de flecha para navegar", // machine
+  KEYBOARD_NAV_BLOCK_NAVIGATION_HINT: "Usa la tecla de flecha derecha para navegar dentro de los bloques", // machine
+  KEYBOARD_NAV_CONSTRAINED_MOVE_HINT: "Usa las teclas de flecha para mover, luego %1 para aceptar la posición", // machine
+  KEYBOARD_NAV_UNCONSTRAINED_MOVE_HINT: "Mantén %1 y usa las teclas de flecha para mover libremente, luego %2 para aceptar", // machine
+  KEYBOARD_NAV_COPIED_HINT: "Copiado. Presiona %1 para pegar.", // machine
+  KEYBOARD_NAV_CUT_HINT: "Cortado. Presiona %1 para pegar.", // machine
 };

--- a/locale/fr.js
+++ b/locale/fr.js
@@ -1270,4 +1270,12 @@ export default {
   shortcut_category_area_menu: "Menu des zones",
   shortcut_category_editor: "Éditeur",
   shortcut_category_gizmos: "Gizmos",
+
+  // Blockly keyboard navigation toast messages
+  KEYBOARD_NAV_WORKSPACE_NAVIGATION_HINT: "Utilisez les touches fléchées pour naviguer", // machine
+  KEYBOARD_NAV_BLOCK_NAVIGATION_HINT: "Utilisez la touche fléchée droite pour naviguer à l'intérieur des blocs", // machine
+  KEYBOARD_NAV_CONSTRAINED_MOVE_HINT: "Utilisez les touches fléchées pour déplacer, puis %1 pour accepter la position", // machine
+  KEYBOARD_NAV_UNCONSTRAINED_MOVE_HINT: "Maintenez %1 et utilisez les touches fléchées pour vous déplacer librement, puis %2 pour accepter", // machine
+  KEYBOARD_NAV_COPIED_HINT: "Copié. Appuyez sur %1 pour coller.", // machine
+  KEYBOARD_NAV_CUT_HINT: "Coupé. Appuyez sur %1 pour coller.", // machine
 };

--- a/locale/it.js
+++ b/locale/it.js
@@ -1260,4 +1260,12 @@ export default {
   shortcut_category_area_menu: "Menu delle aree",
   shortcut_category_editor: "Editor",
   shortcut_category_gizmos: "Gizmos",
+
+  // Blockly keyboard navigation toast messages
+  KEYBOARD_NAV_WORKSPACE_NAVIGATION_HINT: "Usa i tasti freccia per navigare", // machine
+  KEYBOARD_NAV_BLOCK_NAVIGATION_HINT: "Usa il tasto freccia destra per navigare all'interno dei blocchi", // machine
+  KEYBOARD_NAV_CONSTRAINED_MOVE_HINT: "Usa i tasti freccia per spostare, poi %1 per accettare la posizione", // machine
+  KEYBOARD_NAV_UNCONSTRAINED_MOVE_HINT: "Tieni premuto %1 e usa i tasti freccia per spostarti liberamente, poi %2 per accettare", // machine
+  KEYBOARD_NAV_COPIED_HINT: "Copiato. Premi %1 per incollare.", // machine
+  KEYBOARD_NAV_CUT_HINT: "Tagliato. Premi %1 per incollare.", // machine
 };

--- a/locale/pl.js
+++ b/locale/pl.js
@@ -1265,4 +1265,12 @@ export default {
   shortcut_category_area_menu: "Menu obszarów",
   shortcut_category_editor: "Edytor",
   shortcut_category_gizmos: "Gizmos",
+
+  // Blockly keyboard navigation toast messages
+  KEYBOARD_NAV_WORKSPACE_NAVIGATION_HINT: "Użyj klawiszy strzałek do nawigacji", // machine
+  KEYBOARD_NAV_BLOCK_NAVIGATION_HINT: "Użyj klawisza strzałki w prawo, aby nawigować wewnątrz bloków", // machine
+  KEYBOARD_NAV_CONSTRAINED_MOVE_HINT: "Użyj klawiszy strzałek do przesuwania, następnie %1 aby zaakceptować pozycję", // machine
+  KEYBOARD_NAV_UNCONSTRAINED_MOVE_HINT: "Przytrzymaj %1 i użyj klawiszy strzałek do swobodnego przesuwania, następnie %2 aby zaakceptować", // machine
+  KEYBOARD_NAV_COPIED_HINT: "Skopiowano. Naciśnij %1, aby wkleić.", // machine
+  KEYBOARD_NAV_CUT_HINT: "Wycięto. Naciśnij %1, aby wkleić.", // machine
 };

--- a/locale/pt.js
+++ b/locale/pt.js
@@ -1257,4 +1257,12 @@ export default {
   shortcut_category_area_menu: "Menu de áreas",
   shortcut_category_editor: "Editor",
   shortcut_category_gizmos: "Gizmos",
+
+  // Blockly keyboard navigation toast messages
+  KEYBOARD_NAV_WORKSPACE_NAVIGATION_HINT: "Use as teclas de seta para navegar", // machine
+  KEYBOARD_NAV_BLOCK_NAVIGATION_HINT: "Use a tecla de seta para a direita para navegar dentro dos blocos", // machine
+  KEYBOARD_NAV_CONSTRAINED_MOVE_HINT: "Use as teclas de seta para mover, depois %1 para aceitar a posição", // machine
+  KEYBOARD_NAV_UNCONSTRAINED_MOVE_HINT: "Segure %1 e use as teclas de seta para mover livremente, depois %2 para aceitar", // machine
+  KEYBOARD_NAV_COPIED_HINT: "Copiado. Pressione %1 para colar.", // machine
+  KEYBOARD_NAV_CUT_HINT: "Recortado. Pressione %1 para colar.", // machine
 };

--- a/locale/sv.js
+++ b/locale/sv.js
@@ -1247,4 +1247,12 @@ export default {
   shortcut_category_area_menu: "Områdesmeny",
   shortcut_category_editor: "Editor",
   shortcut_category_gizmos: "Gizmos",
+
+  // Blockly keyboard navigation toast messages
+  KEYBOARD_NAV_WORKSPACE_NAVIGATION_HINT: "Använd piltangenterna för att navigera", // machine
+  KEYBOARD_NAV_BLOCK_NAVIGATION_HINT: "Använd höger piltangent för att navigera inuti block", // machine
+  KEYBOARD_NAV_CONSTRAINED_MOVE_HINT: "Använd piltangenterna för att flytta, sedan %1 för att acceptera positionen", // machine
+  KEYBOARD_NAV_UNCONSTRAINED_MOVE_HINT: "Håll inne %1 och använd piltangenterna för att flytta fritt, sedan %2 för att acceptera", // machine
+  KEYBOARD_NAV_COPIED_HINT: "Kopierat. Tryck %1 för att klistra in.", // machine
+  KEYBOARD_NAV_CUT_HINT: "Klippt ut. Tryck %1 för att klistra in.", // machine
 };


### PR DESCRIPTION
# Summary
Add translations for blockly toast messages 

### AI usage
Claude Sonnet 4.6 did all of the translations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Enhanced keyboard navigation with guidance messages now available in German, English, Spanish, French, Italian, Polish, Portuguese, and Swedish for workspace and block navigation, movement operations, and clipboard actions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flipcomputing/flock/pull/640?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->