### PR TITLE
Standardise area highlights

### DIFF
--- a/main/main.js
+++ b/main/main.js
@@ -620,12 +620,16 @@ function registerTopBlockReorderShortcuts() {
       callback: (ws, event, shortcut) => handler(ws, event, shortcut, orig),
     });
   }
- 
+
   function openSession(ws) {
     session = null;
     const block = focusedBlock();
     if (!TOP_BLOCK_TYPES.includes(block.type)) return;
-    console.log("Moving top block", block.type, TOP_BLOCK_TYPES.includes(block.type));
+    console.log(
+      "Moving top block",
+      block.type,
+      TOP_BLOCK_TYPES.includes(block.type),
+    );
     const snapshot = new Map();
     for (const b of ws.getTopBlocks(false) || []) {
       snapshot.set(b, b.getRelativeToSurfaceXY().y);
@@ -869,6 +873,7 @@ function initializeApp() {
     // <input> when the toolbox receives focus, so moving focus inline
     // here causes the 't' keypress to be typed into the search box.
     setTimeout(() => {
+      Blockly.keyboardNavigationController?.setIsActive(true);
       const toolbox = workspace.getToolbox?.();
       if (!toolbox) return;
 

--- a/style/blockly.css
+++ b/style/blockly.css
@@ -631,7 +631,7 @@ body[data-theme="dark"] .blocklyTreeLabel {
 }
 
 .blocklyWorkspaceFocusRing {
-  stroke: none !important;
+  stroke: var(--color-outline-focus) !important;
 }
 
 .blocklyKeyboardNavigation .blocklyToolbox:has(.blocklyActiveFocus),

--- a/style/blockly.css
+++ b/style/blockly.css
@@ -538,7 +538,10 @@ body[data-theme="low-vision"] {
   box-shadow: 0 0 0 4px #000 !important;
 }
 
-[data-theme="low-vision"] .blocklyFieldColour .blocklyFieldGrid .blocklyFieldGridItem:focus {
+[data-theme="low-vision"]
+  .blocklyFieldColour
+  .blocklyFieldGrid
+  .blocklyFieldGridItem:focus {
   box-shadow: 0 0 0 4px #fff !important;
 }
 
@@ -625,6 +628,10 @@ body[data-theme="dark"] .blocklyTreeLabel {
 
 .blocklyToolboxCategoryContainer:focus {
   outline: none !important;
+}
+
+.blocklyWorkspaceFocusRing {
+  stroke: none !important;
 }
 
 .blocklyKeyboardNavigation .blocklyToolbox:has(.blocklyActiveFocus),

--- a/style/blockly.css
+++ b/style/blockly.css
@@ -263,7 +263,7 @@ body[data-theme="low-vision"] {
 .blockly-ws-search {
   background: var(--color-bg);
   margin-top: 5px;
-  border: solid var(--color-border-highlight) 4px;
+  /*border: solid var(--color-border-highlight) 4px;*/
   box-shadow: 0px 10px 20px var(--color-shadow);
   justify-content: center;
   padding: 0.25em;

--- a/style/blockly.css
+++ b/style/blockly.css
@@ -263,7 +263,6 @@ body[data-theme="low-vision"] {
 .blockly-ws-search {
   background: var(--color-bg);
   margin-top: 5px;
-  /*border: solid var(--color-border-highlight) 4px;*/
   box-shadow: 0px 10px 20px var(--color-shadow);
   justify-content: center;
   padding: 0.25em;

--- a/style/blockly.css
+++ b/style/blockly.css
@@ -12,7 +12,7 @@
   --color-shadow: grey;
   --color-outline-focus: #fc3;
   --block-outline-focus: #fff200;
-  --color-toolbox-focus: var(--color-outline-focus);
+  --color-toolbox-focus: var(--block-outline-focus);
 
   /* Dropdown & menu semantics */
   --color-dropdown-text: var(--color-text);
@@ -370,24 +370,16 @@ body[data-theme="low-vision"] {
   outline: none;
 }
 
-/* Toolbox category selection outline */
-.blocklyToolboxCategoryContainer[aria-selected="true"][aria-level="1"]
-  > .blocklyToolboxCategory,
-.blocklyToolboxCategoryContainer[aria-selected="true"][aria-level="2"]
-  > .blocklyToolboxCategory {
-  outline: 5px solid var(--color-toolbox-focus);
-  outline-offset: 0px;
-  border-radius: 4px;
-}
-
 /* Keyboard-focused toolbox category (Blockly 13 FocusManager active node) */
-.blocklyKeyboardNavigation .blocklyToolbox .blocklyActiveFocus,
 .blocklyKeyboardNavigation
   .blocklyToolbox
   .blocklyActiveFocus
-  > .blocklyToolboxCategory {
-  outline: 5px solid var(--color-toolbox-focus) !important;
-  outline-offset: 0px !important;
+  > .blocklyToolboxCategory,
+.blocklyKeyboardNavigation
+  .blocklyToolbox
+  .blocklyToolboxCategory.blocklyActiveFocus {
+  outline: none !important;
+  box-shadow: inset 0 0 0 3px var(--color-toolbox-focus) !important;
   border-radius: 4px;
 }
 


### PR DESCRIPTION
# Summary
Makes highlights within the toolbox and workspace more consistent.

- Blue highlight on workspace replaced by flock's darker yellow highlight
- Coral highlight on workspace search removed
- Categories within the toolbar now highlight in the lighter yellow for consistency, and the highlighting is improved


### AI usage
Claude Sonnet 4.6 used throughout, all changes reviewed by a human before being applied. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Keyboard navigation is now activated when using the Mod+KeyT shortcut.

* **Style**
  * Improved visual feedback for keyboard navigation focus indicators in the toolbox.
  * Removed default border from search highlight overlay for cleaner appearance.
  * Enhanced focus ring styling for better accessibility support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flipcomputing/flock/pull/641?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->