### PR TITLE
Add workspace comments to tab order

### DIFF
--- a/main/input.js
+++ b/main/input.js
@@ -120,16 +120,41 @@ export function setupInput() {
         pushUnique(workspaceGroup);
       }
 
-      // 6b) Workspace toolbar
-      [
-        "#undoBtn",
-        "#redoBtn",
-        "#zoomOutBtn",
-        "#zoomInBtn",
-        "#shortcutsBtn",
-      ].forEach((sel) => pushUnique(document.querySelector(sel)));
+      // 6a) Workspace comments and block comment icons
+      document.querySelectorAll("g.blocklyComment").forEach((el) => {
+        if (!el.hasAttribute("tabindex") || el.tabIndex < 0)
+          el.setAttribute("tabindex", "0");
+        if (!el.getAttribute("role")) el.setAttribute("role", "group");
+        if (!el.getAttribute("aria-label"))
+          el.setAttribute("aria-label", "Workspace comment");
+        pushUnique(el);
+      });
+      document.querySelectorAll("g.blocklyCommentIconGroup").forEach((el) => {
+        if (!el.hasAttribute("tabindex") || el.tabIndex < 0)
+          el.setAttribute("tabindex", "0");
+        if (!el.getAttribute("role")) el.setAttribute("role", "button");
+        if (!el.getAttribute("aria-label"))
+          el.setAttribute("aria-label", "Block comment");
+        pushUnique(el);
+      });
+      document
+        .querySelectorAll("textarea.blocklyCommentText")
+        .forEach(pushUnique);
 
-      // 6c) Shortcuts panel (when visible)
+      // 6c) Trash can
+
+      const trashCan = document.querySelector("g.blocklyTrash");
+      if (trashCan) {
+        if (!trashCan.hasAttribute("tabindex") || trashCan.tabIndex < 0)
+          trashCan.setAttribute("tabindex", "0");
+        trashCan.setAttribute("role", "button");
+        if (!trashCan.getAttribute("aria-label"))
+          trashCan.setAttribute("aria-label", "Trash");
+        pushUnique(trashCan);
+      }
+
+      // 6c) Shortcuts panel (when visible), then undo/redo/zoom
+ 
       const shortcutsPanel = document.getElementById("shortcutsPanel");
       pushUnique(shortcutsPanel);
       if (shortcutsPanel) {
@@ -137,6 +162,12 @@ export function setupInput() {
           .querySelectorAll("a[href], button:not([disabled])")
           .forEach(pushUnique);
       }
+
+      ["#undoBtn", "#redoBtn", "#zoomOutBtn", "#zoomInBtn", "#shortcutsBtn"].forEach((sel) =>
+        pushUnique(document.querySelector(sel)),
+      );
+
+  
 
       // 7) Main UI controls (in natural order)
       [

--- a/main/input.js
+++ b/main/input.js
@@ -141,18 +141,7 @@ export function setupInput() {
         .querySelectorAll("textarea.blocklyCommentText")
         .forEach(pushUnique);
 
-      // 6c) Trash can
-
-      const trashCan = document.querySelector("g.blocklyTrash");
-      if (trashCan) {
-        if (!trashCan.hasAttribute("tabindex") || trashCan.tabIndex < 0)
-          trashCan.setAttribute("tabindex", "0");
-        trashCan.setAttribute("role", "button");
-        if (!trashCan.getAttribute("aria-label"))
-          trashCan.setAttribute("aria-label", "Trash");
-        pushUnique(trashCan);
-      }
-
+     
       // 6c) Shortcuts panel (when visible), then undo/redo/zoom
  
       const shortcutsPanel = document.getElementById("shortcutsPanel");

--- a/main/input.js
+++ b/main/input.js
@@ -129,14 +129,6 @@ export function setupInput() {
           el.setAttribute("aria-label", "Workspace comment");
         pushUnique(el);
       });
-      document.querySelectorAll("g.blocklyCommentIconGroup").forEach((el) => {
-        if (!el.hasAttribute("tabindex") || el.tabIndex < 0)
-          el.setAttribute("tabindex", "0");
-        if (!el.getAttribute("role")) el.setAttribute("role", "button");
-        if (!el.getAttribute("aria-label"))
-          el.setAttribute("aria-label", "Block comment");
-        pushUnique(el);
-      });
       document
         .querySelectorAll("textarea.blocklyCommentText")
         .forEach(pushUnique);

--- a/style/blockly.css
+++ b/style/blockly.css
@@ -264,6 +264,11 @@ body[data-theme="low-vision"] {
   transform: translateX(-400px);
 }
 
+.shortcuts-panel-open .blocklyTrash {
+  translate: -400px 0;
+  transition: translate 0.2s ease;
+}
+
 .blockly-ws-search {
   background: var(--color-bg);
   margin-top: 5px;

--- a/style/blockly.css
+++ b/style/blockly.css
@@ -264,11 +264,6 @@ body[data-theme="low-vision"] {
   transform: translateX(-400px);
 }
 
-.shortcuts-panel-open .blocklyTrash {
-  translate: -400px 0;
-  transition: translate 0.2s ease;
-}
-
 .blockly-ws-search {
   background: var(--color-bg);
   margin-top: 5px;


### PR DESCRIPTION
# Summary
- Adds _workspace_ comments to tab order 
- Puts shortcut panel before bottom toolbar in tab order (but we have agreed to move the panel)

### AI usage
Claude Sonnet 4.6 used as co-author, all code checked individually by a human. 

### Notes
Comments are tabbed to in DOM order (i.e. the order in which they were added to the project). I investigated some kind of vertical order but it seemed very unreliable as it would involve calculating positions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Comment nodes in the workspace are now properly included in keyboard navigation and receive appropriate screen reader attributes for improved accessibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flipcomputing/flock/pull/644?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->