### PR TITLE
Move position of keyboard controls panel (again!)

### DIFF
--- a/accessibility/keyboardui.js
+++ b/accessibility/keyboardui.js
@@ -577,6 +577,10 @@ const InfoPanel = {
     btn.textContent = label;
     btn.addEventListener("click", () => this.toggle(id));
     this._tablist.appendChild(btn);
+    const divider = document.createElement("div");
+    divider.className = "toolbar-divider";
+    divider.setAttribute("aria-hidden", "true");
+    this._tablist.appendChild(divider);
 
     const panel = document.createElement("div");
     panel.id = `info-tab-panel-${id}`;
@@ -623,14 +627,31 @@ const InfoPanel = {
   },
 };
 
+const SHORTCUTS_FONT_SIZES = [0.8, 1.0, 1.2, 1.4, 1.6, 1.8];
+const SHORTCUTS_FONT_SIZE_KEY = "flock-shortcuts-font-size";
+const SHORTCUTS_FONT_SIZE_DEFAULT = 1.2;
+
 const ShortcutsPanel = {
   panel: null,
   previousFocus: null,
+  fontSize: parseFloat(localStorage.getItem(SHORTCUTS_FONT_SIZE_KEY)) || SHORTCUTS_FONT_SIZE_DEFAULT,
 
   init() {
     this.createPanel();
     this.setupListeners();
     window.flockShortcutsPanel = this;
+  },
+
+  adjustFontSize(delta) {
+    const sizes = SHORTCUTS_FONT_SIZES;
+    const idx = sizes.indexOf(this.fontSize);
+    const next = sizes[Math.max(0, Math.min(sizes.length - 1, idx + delta))];
+    if (next === this.fontSize) return;
+    this.fontSize = next;
+    localStorage.setItem(SHORTCUTS_FONT_SIZE_KEY, next);
+    this.panel.querySelector("#shortcuts-table").style.fontSize = next + "em";
+    this.panel.querySelector(".shortcuts-decrease-btn").disabled = next === sizes[0];
+    this.panel.querySelector(".shortcuts-increase-btn").disabled = next === sizes[sizes.length - 1];
   },
 
   createPanel() {
@@ -644,11 +665,23 @@ const ShortcutsPanel = {
     panel.innerHTML = `
         <div class="shortcuts-panel-header">
           <h2 id="shortcuts-panel-title" class="shortcuts-panel-title"></h2>
-          <a href="${SHORTCUTS_HELP_URL}" target="_blank" rel="noopener noreferrer" class="help-link-button" aria-label="${translate("shortcut_panel_help_link")}"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="16" height="16" aria-hidden="true"><!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.--><path d="M320 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l82.7 0L201.4 265.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L448 109.3l0 82.7c0 17.7 14.3 32 32 32s32-14.3 32-32l0-160c0-17.7-14.3-32-32-32L320 0zM80 32C35.8 32 0 67.8 0 112L0 432c0 44.2 35.8 80 80 80l320 0c44.2 0 80-35.8 80-80l0-112c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 112c0 8.8-7.2 16-16 16L80 448c-8.8 0-16-7.2-16-16l0-320c0-8.8 7.2-16 16-16l112 0c17.7 0 32-14.3 32-32s-14.3-32-32-32L80 32z"/></svg></a>
+          <div class="shortcuts-panel-controls">
+            <button class="bigbutton shortcuts-decrease-btn" aria-label="Decrease text size" title="Decrease text size"><span aria-hidden="true">A</span></button>
+            <button class="bigbutton shortcuts-increase-btn" aria-label="Increase text size" title="Increase text size"><span aria-hidden="true">A</span></button>
+            <a href="${SHORTCUTS_HELP_URL}" target="_blank" rel="noopener noreferrer" class="help-link-button" aria-label="${translate("shortcut_panel_help_link")}"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="16" height="16" aria-hidden="true"><!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.--><path fill="currentColor" d="M320 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l82.7 0L201.4 265.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L448 109.3l0 82.7c0 17.7 14.3 32 32 32s32-14.3 32-32l0-160c0-17.7-14.3-32-32-32L320 0zM80 32C35.8 32 0 67.8 0 112L0 432c0 44.2 35.8 80 80 80l320 0c44.2 0 80-35.8 80-80l0-112c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 112c0 8.8-7.2 16-16 16L80 448c-8.8 0-16-7.2-16-16l0-320c0-8.8 7.2-16 16-16l112 0c17.7 0 32-14.3 32-32s-14.3-32-32-32L80 32z"/></svg></a>
+          </div>
         </div>
-        <table id="shortcuts-table"><tbody></tbody></table>
+        <table id="shortcuts-table"><colgroup><col style="width:33%"><col></colgroup><tbody></tbody></table>
       `;
     this.panel = panel;
+    const sizes = SHORTCUTS_FONT_SIZES;
+    const decreaseBtn = panel.querySelector(".shortcuts-decrease-btn");
+    const increaseBtn = panel.querySelector(".shortcuts-increase-btn");
+    decreaseBtn.disabled = this.fontSize === sizes[0];
+    increaseBtn.disabled = this.fontSize === sizes[sizes.length - 1];
+    decreaseBtn.addEventListener("click", () => this.adjustFontSize(-1));
+    increaseBtn.addEventListener("click", () => this.adjustFontSize(1));
+    panel.querySelector("#shortcuts-table").style.fontSize = this.fontSize + "em";
     this.renderContent();
   },
 

--- a/accessibility/keyboardui.js
+++ b/accessibility/keyboardui.js
@@ -557,6 +557,79 @@ function formatKeys(keys) {
     .join("");
 }
 
+const InfoPanel = {
+  _tabs: new Map(),
+  _activeId: null,
+
+  init() {
+    this._el = document.getElementById("info-panel");
+    this._tablist = document.getElementById("info-panel-tabs");
+    this._body = document.getElementById("info-panel-body");
+  },
+
+  register(id, label) {
+    const btn = document.createElement("button");
+    btn.id = `info-tab-btn-${id}`;
+    btn.className = "info-tab-btn";
+    btn.setAttribute("role", "tab");
+    btn.setAttribute("aria-selected", "false");
+    btn.setAttribute("aria-controls", `info-tab-panel-${id}`);
+    btn.textContent = label;
+    btn.addEventListener("click", () => this.toggle(id));
+    this._tablist.appendChild(btn);
+
+    const panel = document.createElement("div");
+    panel.id = `info-tab-panel-${id}`;
+    panel.className = "info-tab-panel hidden";
+    panel.setAttribute("role", "tabpanel");
+    panel.setAttribute("aria-labelledby", `info-tab-btn-${id}`);
+    panel.tabIndex = 0;
+    this._body.appendChild(panel);
+
+    this._tabs.set(id, { btn, panel });
+    return panel;
+  },
+
+  activate(id) {
+    if (this._activeId && this._activeId !== id) {
+      const cur = this._tabs.get(this._activeId);
+      cur.btn.setAttribute("aria-selected", "false");
+      cur.btn.classList.remove("active");
+      cur.panel.classList.add("hidden");
+    }
+    const tab = this._tabs.get(id);
+    if (!tab) return;
+    this._activeId = id;
+    tab.btn.setAttribute("aria-selected", "true");
+    tab.btn.classList.add("active");
+    tab.panel.classList.remove("hidden");
+    this._el.classList.remove("hidden");
+  },
+
+  deactivate(id) {
+    const tab = this._tabs.get(id);
+    if (!tab) return;
+    tab.btn.setAttribute("aria-selected", "false");
+    tab.btn.classList.remove("active");
+    tab.panel.classList.add("hidden");
+    if (this._activeId === id) {
+      this._activeId = null;
+      const anyVisible = [...this._tabs.values()].some(
+        (t) => !t.panel.classList.contains("hidden"),
+      );
+      if (!anyVisible) this._el.classList.add("hidden");
+    }
+  },
+
+  toggle(id) {
+    const tab = this._tabs.get(id);
+    if (!tab) return;
+    tab.panel.classList.contains("hidden")
+      ? this.activate(id)
+      : this.deactivate(id);
+  },
+};
+
 const ShortcutsPanel = {
   panel: null,
   previousFocus: null,
@@ -568,28 +641,22 @@ const ShortcutsPanel = {
   },
 
   createPanel() {
-    const div = document.createElement("div");
-    div.id = "shortcutsPanel";
-    div.className = "shortcuts-panel hidden";
-    div.setAttribute("role", "region");
-    div.setAttribute("aria-label", translate("shortcut_panel_title"));
-    div.tabIndex = 0;
-    div.innerHTML = `
+    const panel = InfoPanel.register(
+      "shortcuts",
+      translate("shortcut_panel_title"),
+    );
+    panel.innerHTML = `
         <div class="shortcuts-panel-header">
-          <h1 id="shortcuts-panel-title">${translate("shortcut_panel_title")}</h1>
           <a href="${SHORTCUTS_HELP_URL}" target="_blank" rel="noopener noreferrer" class="help-link-button" aria-label="${translate("shortcut_panel_help_link")}"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="16" height="16" aria-hidden="true"><!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.--><path d="M320 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l82.7 0L201.4 265.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L448 109.3l0 82.7c0 17.7 14.3 32 32 32s32-14.3 32-32l0-160c0-17.7-14.3-32-32-32L320 0zM80 32C35.8 32 0 67.8 0 112L0 432c0 44.2 35.8 80 80 80l320 0c44.2 0 80-35.8 80-80l0-112c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 112c0 8.8-7.2 16-16 16L80 448c-8.8 0-16-7.2-16-16l0-320c0-8.8 7.2-16 16-16l112 0c17.7 0 32-14.3 32-32s-14.3-32-32-32L80 32z"/></svg></a>
         </div>
         <table id="shortcuts-table"><tbody></tbody></table>
       `;
-    document.getElementById("maincontent").appendChild(div);
-    this.panel = div;
+    this.panel = panel;
   },
 
   renderContent() {
-    this.panel.setAttribute("aria-label", translate("shortcut_panel_title"));
-    this.panel.querySelector("#shortcuts-panel-title").textContent = translate(
-      "shortcut_panel_title",
-    );
+    document.getElementById("info-tab-btn-shortcuts").textContent =
+      translate("shortcut_panel_title");
     this.panel
       .querySelector(".help-link-button")
       .setAttribute("aria-label", translate("shortcut_panel_help_link"));
@@ -611,8 +678,7 @@ const ShortcutsPanel = {
   show() {
     this.renderContent();
     this.previousFocus = document.activeElement;
-    this.panel.classList.remove("hidden");
-    document.body.classList.add("shortcuts-panel-open");
+    InfoPanel.activate("shortcuts");
     this.panel.focus();
     document.getElementById("shortcutsBtn")?.classList.add("active");
   },
@@ -626,8 +692,7 @@ const ShortcutsPanel = {
   hide() {
     this.previousFocus?.focus();
     this.previousFocus = null;
-    this.panel.classList.add("hidden");
-    document.body.classList.remove("shortcuts-panel-open");
+    InfoPanel.deactivate("shortcuts");
     document.getElementById("shortcutsBtn")?.classList.remove("active");
   },
 
@@ -637,13 +702,14 @@ const ShortcutsPanel = {
 
   setupListeners() {
     this.panel.addEventListener("keydown", (e) => {
+      const scroller = document.getElementById("info-panel-body");
       if (e.key === "ArrowUp") {
         e.preventDefault();
-        this.panel.scrollBy({ top: -100, behavior: "instant" });
+        scroller?.scrollBy({ top: -100, behavior: "instant" });
       }
       if (e.key === "ArrowDown") {
         e.preventDefault();
-        this.panel.scrollBy({ top: 100, behavior: "instant" });
+        scroller?.scrollBy({ top: 100, behavior: "instant" });
       }
       if (e.key === "Escape") {
         e.preventDefault();
@@ -657,6 +723,7 @@ const ShortcutsPanel = {
 // Start it up
 AreaManager.init();
 GizmoMenuManager.init();
+InfoPanel.init();
 ShortcutsPanel.init();
 
-export { ShortcutsPanel, GizmoMenuManager };
+export { InfoPanel, ShortcutsPanel, GizmoMenuManager };

--- a/accessibility/keyboardui.js
+++ b/accessibility/keyboardui.js
@@ -634,7 +634,9 @@ const SHORTCUTS_FONT_SIZE_DEFAULT = 1.2;
 const ShortcutsPanel = {
   panel: null,
   previousFocus: null,
-  fontSize: parseFloat(localStorage.getItem(SHORTCUTS_FONT_SIZE_KEY)) || SHORTCUTS_FONT_SIZE_DEFAULT,
+  fontSize:
+    parseFloat(localStorage.getItem(SHORTCUTS_FONT_SIZE_KEY)) ||
+    SHORTCUTS_FONT_SIZE_DEFAULT,
 
   init() {
     this.createPanel();
@@ -650,8 +652,10 @@ const ShortcutsPanel = {
     this.fontSize = next;
     localStorage.setItem(SHORTCUTS_FONT_SIZE_KEY, next);
     this.panel.querySelector("#shortcuts-table").style.fontSize = next + "em";
-    this.panel.querySelector(".shortcuts-decrease-btn").disabled = next === sizes[0];
-    this.panel.querySelector(".shortcuts-increase-btn").disabled = next === sizes[sizes.length - 1];
+    this.panel.querySelector(".shortcuts-decrease-btn").disabled =
+      next === sizes[0];
+    this.panel.querySelector(".shortcuts-increase-btn").disabled =
+      next === sizes[sizes.length - 1];
   },
 
   createPanel() {
@@ -681,7 +685,8 @@ const ShortcutsPanel = {
     increaseBtn.disabled = this.fontSize === sizes[sizes.length - 1];
     decreaseBtn.addEventListener("click", () => this.adjustFontSize(-1));
     increaseBtn.addEventListener("click", () => this.adjustFontSize(1));
-    panel.querySelector("#shortcuts-table").style.fontSize = this.fontSize + "em";
+    panel.querySelector("#shortcuts-table").style.fontSize =
+      this.fontSize + "em";
     this.renderContent();
   },
 
@@ -689,8 +694,9 @@ const ShortcutsPanel = {
     document
       .getElementById("info-tab-btn-shortcuts")
       .setAttribute("aria-label", translate("shortcut_panel_title"));
-    this.panel.querySelector("#shortcuts-panel-title").textContent =
-      translate("shortcut_panel_title");
+    this.panel.querySelector("#shortcuts-panel-title").textContent = translate(
+      "shortcut_panel_title",
+    );
     this.panel
       .querySelector(".help-link-button")
       .setAttribute("aria-label", translate("shortcut_panel_help_link"));

--- a/accessibility/keyboardui.js
+++ b/accessibility/keyboardui.js
@@ -570,7 +570,7 @@ const InfoPanel = {
   register(id, label) {
     const btn = document.createElement("button");
     btn.id = `info-tab-btn-${id}`;
-    btn.className = "info-tab-btn";
+    btn.className = "info-tab-btn bigbutton";
     btn.setAttribute("role", "tab");
     btn.setAttribute("aria-selected", "false");
     btn.setAttribute("aria-controls", `info-tab-panel-${id}`);
@@ -603,7 +603,6 @@ const InfoPanel = {
     tab.btn.setAttribute("aria-selected", "true");
     tab.btn.classList.add("active");
     tab.panel.classList.remove("hidden");
-    this._el.classList.remove("hidden");
   },
 
   deactivate(id) {
@@ -612,13 +611,7 @@ const InfoPanel = {
     tab.btn.setAttribute("aria-selected", "false");
     tab.btn.classList.remove("active");
     tab.panel.classList.add("hidden");
-    if (this._activeId === id) {
-      this._activeId = null;
-      const anyVisible = [...this._tabs.values()].some(
-        (t) => !t.panel.classList.contains("hidden"),
-      );
-      if (!anyVisible) this._el.classList.add("hidden");
-    }
+    if (this._activeId === id) this._activeId = null;
   },
 
   toggle(id) {
@@ -645,17 +638,25 @@ const ShortcutsPanel = {
       "shortcuts",
       translate("shortcut_panel_title"),
     );
+    const btn = document.getElementById("info-tab-btn-shortcuts");
+    btn.setAttribute("aria-label", translate("shortcut_panel_title"));
+    btn.innerHTML = `<div class="icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512"><path fill="currentColor" d="M64 64C28.7 64 0 92.7 0 128L0 384c0 35.3 28.7 64 64 64l448 0c35.3 0 64-28.7 64-64l0-256c0-35.3-28.7-64-64-64L64 64zM175.1 224l16 0c8.8 0 16 7.2 16 16l0 16c0 8.8-7.2 16-16 16l-16 0c-8.8 0-16-7.2-16-16l0-16c0-8.8 7.2-16 16-16zm-72 32c0 8.8-7.2 16-16 16l-16 0c-8.8 0-16-7.2-16-16l0-16c0-8.8 7.2-16 16-16l16 0c8.8 0 16 7.2 16 16l0 16zm128 0c0 8.8-7.2 16-16 16l-16 0c-8.8 0-16-7.2-16-16l0-16c0-8.8 7.2-16 16-16l16 0c8.8 0 16 7.2 16 16l0 16zm128 0c0 8.8-7.2 16-16 16l-16 0c-8.8 0-16-7.2-16-16l0-16c0-8.8 7.2-16 16-16l16 0c8.8 0 16 7.2 16 16l0 16zm72-32l16 0c8.8 0 16 7.2 16 16l0 16c0 8.8-7.2 16-16 16l-16 0c-8.8 0-16-7.2-16-16l0-16c0-8.8 7.2-16 16-16zM80 336c0-8.8 7.2-16 16-16l288 0c8.8 0 16 7.2 16 16l0 16c0 8.8-7.2 16-16 16l-288 0c-8.8 0-16-7.2-16-16l0-16zm336-16l16 0c8.8 0 16 7.2 16 16l0 16c0 8.8-7.2 16-16 16l-16 0c-8.8 0-16-7.2-16-16l0-16c0-8.8 7.2-16 16-16z"/></svg></div>`;
     panel.innerHTML = `
         <div class="shortcuts-panel-header">
+          <h2 id="shortcuts-panel-title" class="shortcuts-panel-title"></h2>
           <a href="${SHORTCUTS_HELP_URL}" target="_blank" rel="noopener noreferrer" class="help-link-button" aria-label="${translate("shortcut_panel_help_link")}"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="16" height="16" aria-hidden="true"><!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.--><path d="M320 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l82.7 0L201.4 265.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L448 109.3l0 82.7c0 17.7 14.3 32 32 32s32-14.3 32-32l0-160c0-17.7-14.3-32-32-32L320 0zM80 32C35.8 32 0 67.8 0 112L0 432c0 44.2 35.8 80 80 80l320 0c44.2 0 80-35.8 80-80l0-112c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 112c0 8.8-7.2 16-16 16L80 448c-8.8 0-16-7.2-16-16l0-320c0-8.8 7.2-16 16-16l112 0c17.7 0 32-14.3 32-32s-14.3-32-32-32L80 32z"/></svg></a>
         </div>
         <table id="shortcuts-table"><tbody></tbody></table>
       `;
     this.panel = panel;
+    this.renderContent();
   },
 
   renderContent() {
-    document.getElementById("info-tab-btn-shortcuts").textContent =
+    document
+      .getElementById("info-tab-btn-shortcuts")
+      .setAttribute("aria-label", translate("shortcut_panel_title"));
+    this.panel.querySelector("#shortcuts-panel-title").textContent =
       translate("shortcut_panel_title");
     this.panel
       .querySelector(".help-link-button")

--- a/accessibility/keyboardui.js
+++ b/accessibility/keyboardui.js
@@ -749,6 +749,7 @@ const ShortcutsPanel = {
         e.preventDefault();
         e.stopPropagation();
         this.hide();
+        document.getElementById("info-tab-btn-shortcuts")?.focus();
       }
     });
   },

--- a/index.html
+++ b/index.html
@@ -1419,25 +1419,6 @@
                   </svg>
                 </div>
               </button>
-              <div class="toolbar-divider" aria-hidden="true"></div>
-              <button
-                class="bigbutton"
-                id="shortcutsBtn"
-                aria-label="Keyboard shortcuts"
-                title="Keyboard shortcuts"
-                data-i18n="shortcut_panel_title"
-                data-i18n-attrs="title,aria-label"
-              >
-                <div class="icon" aria-hidden="true">
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512">
-                    <!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->
-                    <path
-                      fill="currentColor"
-                      d="M64 64C28.7 64 0 92.7 0 128L0 384c0 35.3 28.7 64 64 64l448 0c35.3 0 64-28.7 64-64l0-256c0-35.3-28.7-64-64-64L64 64zM175.1 224l16 0c8.8 0 16 7.2 16 16l0 16c0 8.8-7.2 16-16 16l-16 0c-8.8 0-16-7.2-16-16l0-16c0-8.8 7.2-16 16-16zm-72 32c0 8.8-7.2 16-16 16l-16 0c-8.8 0-16-7.2-16-16l0-16c0-8.8 7.2-16 16-16l16 0c8.8 0 16 7.2 16 16l0 16zm128 0c0 8.8-7.2 16-16 16l-16 0c-8.8 0-16-7.2-16-16l0-16c0-8.8 7.2-16 16-16l16 0c8.8 0 16 7.2 16 16l0 16zm128 0c0 8.8-7.2 16-16 16l-16 0c-8.8 0-16-7.2-16-16l0-16c0-8.8 7.2-16 16-16l16 0c8.8 0 16 7.2 16 16l0 16zm72-32l16 0c8.8 0 16 7.2 16 16l0 16c0 8.8-7.2 16-16 16l-16 0c-8.8 0-16-7.2-16-16l0-16c0-8.8 7.2-16 16-16zM80 336c0-8.8 7.2-16 16-16l288 0c8.8 0 16 7.2 16 16l0 16c0 8.8-7.2 16-16 16l-288 0c-8.8 0-16-7.2-16-16l0-16zm336-16l16 0c8.8 0 16 7.2 16 16l0 16c0 8.8-7.2 16-16 16l-16 0c-8.8 0-16-7.2-16-16l0-16c0-8.8 7.2-16 16-16z"
-                    />
-                  </svg>
-                </div>
-              </button>
             </div>
           </section>
         </div>

--- a/index.html
+++ b/index.html
@@ -1285,12 +1285,31 @@
                   />
                 </svg>
               </button>
+              <div id="flocklink">
+                <a
+                  href="https://flockxr.com/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  id="info-panel-link"
+                  data-i18n="info_panel_link"
+                  aria-label="Visit Flock XR website (opens in new tab)"
+                  title="Visit Flock XR website"
+                >
+                  <img
+                    src="./images/inline-flock-xr.svg"
+                    alt="Flock XR logo"
+                    id="flocklogo"
+                  />
+                  <span class="sr-only">
+                    Visit Flock XR website in a new tab
+                  </span>
+                </a>
+              </div>
             </aside>
             <!-- Info panel collapse starts -->
 
             <aside
               id="info-panel"
-              class="hidden"
               role="complementary"
               aria-label="Information panel"
             >
@@ -1301,31 +1320,6 @@
               ></div>
               <div id="info-panel-body"></div>
             </aside>
-
-            <footer id="site-footer">
-              <nav aria-label="Footer navigation">
-                <div id="flocklink">
-                  <a
-                    href="https://flockxr.com/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    id="info-panel-link"
-                    data-i18n="info_panel_link"
-                    aria-label="Visit Flock XR website (opens in new tab)"
-                    title="Visit Flock XR website"
-                  >
-                    <img
-                      src="./images/inline-flock-xr.svg"
-                      alt="Flock XR logo"
-                      id="flocklogo"
-                    />
-                    <span class="sr-only">
-                      Visit Flock XR website in a new tab
-                    </span>
-                  </a>
-                </div>
-              </nav>
-            </footer>
           </section>
           <div
             class="resizer"

--- a/index.html
+++ b/index.html
@@ -1290,9 +1290,17 @@
 
             <aside
               id="info-panel"
+              class="hidden"
               role="complementary"
               aria-label="Information panel"
-            ></aside>
+            >
+              <div
+                id="info-panel-tabs"
+                role="tablist"
+                aria-label="Information panel tabs"
+              ></div>
+              <div id="info-panel-body"></div>
+            </aside>
 
             <footer id="site-footer">
               <nav aria-label="Footer navigation">

--- a/main/input.js
+++ b/main/input.js
@@ -67,8 +67,15 @@ export function setupInput() {
         .querySelectorAll("#gizmoButtons button, #gizmoButtons input")
         .forEach(pushUnique);
 
-      // 4) Logo link + resizer
+      // 4) Logo link, keyboard tab, shortcuts panel contents (if open), resizer
       pushUnique(document.querySelector("#info-panel-link"));
+      pushUnique(document.querySelector("#info-tab-btn-shortcuts"));
+      const shortcutsTabPanel = document.getElementById("info-tab-panel-shortcuts");
+      if (shortcutsTabPanel && !shortcutsTabPanel.classList.contains("hidden")) {
+        shortcutsTabPanel
+          .querySelectorAll("a[href], button:not([disabled])")
+          .forEach(pushUnique);
+      }
       pushUnique(document.querySelector("#resizer"));
 
       // 5) Search inputs (toolbox flyout etc.)

--- a/main/input.js
+++ b/main/input.js
@@ -72,6 +72,7 @@ export function setupInput() {
       pushUnique(document.querySelector("#info-tab-btn-shortcuts"));
       const shortcutsTabPanel = document.getElementById("info-tab-panel-shortcuts");
       if (shortcutsTabPanel && !shortcutsTabPanel.classList.contains("hidden")) {
+        pushUnique(shortcutsTabPanel);
         shortcutsTabPanel
           .querySelectorAll("a[href], button:not([disabled])")
           .forEach(pushUnique);
@@ -151,7 +152,7 @@ export function setupInput() {
           .forEach(pushUnique);
       }
 
-      ["#undoBtn", "#redoBtn", "#zoomOutBtn", "#zoomInBtn", "#shortcutsBtn"].forEach((sel) =>
+      ["#undoBtn", "#redoBtn", "#zoomOutBtn", "#zoomInBtn"].forEach((sel) =>
         pushUnique(document.querySelector(sel)),
       );
 

--- a/main/main.js
+++ b/main/main.js
@@ -257,7 +257,7 @@ function applyEmbedMode() {
   if (infoPanel) infoPanel.style.display = "none";
 
   if (canvasArea) {
-    canvasArea.style.display = "block";
+    canvasArea.style.display = "";
     canvasArea.style.width = "100%";
     canvasArea.style.height = "100%";
     canvasArea.style.flex = "1 1 100%";

--- a/main/view.js
+++ b/main/view.js
@@ -168,7 +168,7 @@ function switchView(view) {
     viewMode = "both";
     codeMode = "both";
     blocklyArea.style.display = "block";
-    canvasArea.style.display = "block";
+    canvasArea.style.display = "";
     flockLink.style.display = "block";
     if (resizer) resizer.style.display = "block";
     blocklyArea.style.width = "0";
@@ -187,7 +187,7 @@ function switchView(view) {
   } else if (view === "canvas") {
     viewMode = "canvas";
     blocklyArea.style.display = "none";
-    canvasArea.style.display = "block";
+    canvasArea.style.display = "";
     flockLink.style.display = "block";
     if (resizer) resizer.style.display = "none";
     onResize("reset");
@@ -365,7 +365,7 @@ export function showCanvasView() {
 
     // Hide code, show canvas full width
     blocklyArea.style.display = "none";
-    canvasArea.style.display = "block";
+    canvasArea.style.display = "";
     canvasArea.style.width = "100%";
     canvasArea.style.flex = "1 1 100%";
 
@@ -525,7 +525,7 @@ export function togglePlayMode() {
   } else {
     if (flock.scene) flock.scene.debugLayer.hide();
     blocklyArea.style.display = "block";
-    canvasArea.style.display = "block";
+    canvasArea.style.display = "";
     gizmoButtons.style.display = "block";
     bottomBar.style.display = "block";
     flockLink.style.display = "block";
@@ -577,7 +577,7 @@ export function toggleDesignMode() {
   } else {
     blocklyArea.style.display = "none";
     codeMode = "none";
-    canvasArea.style.display = "block";
+    canvasArea.style.display = "";
     canvasArea.style.width = "0";
     gizmoButtons.style.display = "block";
     flockLink.style.display = "none";

--- a/style.css
+++ b/style.css
@@ -495,7 +495,8 @@ button {
   z-index: 100;
 }
 
-#blocklyZoomControls .toolbar-divider {
+#blocklyZoomControls .toolbar-divider,
+#info-panel-tabs .toolbar-divider {
   width: 1px;
   height: 24px;
   background-color: var(--color-border);
@@ -1611,9 +1612,6 @@ body.color-picker-open #renderCanvas {
   table-layout: fixed;
 }
 
-#shortcuts-table td:first-child {
-  width: 70%;
-}
 
 #shortcuts-table td {
   padding: 0.5em;
@@ -1695,6 +1693,31 @@ kbd {
   font-size: 1.5em;
   font-weight: bold;
   margin: 0;
+}
+
+.shortcuts-panel-controls {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.shortcuts-decrease-btn,
+.shortcuts-increase-btn {
+  font-weight: bold;
+  margin-left: 0;
+}
+
+.shortcuts-decrease-btn span {
+  font-size: 0.75em;
+}
+
+.shortcuts-increase-btn span {
+  font-size: 1.1em;
+}
+
+.shortcuts-panel-header .help-link-button {
+  color: var(--color-text-primary);
+  margin-left: 12px;
 }
 
 .shortcuts-panel-header .help-link-button:focus {

--- a/style.css
+++ b/style.css
@@ -373,7 +373,6 @@
     transform: rotate(360deg);
   }
 }
-p
 
 /* Hide main content by default - more aggressive for deployment */
 #flockeditor {

--- a/style.css
+++ b/style.css
@@ -258,11 +258,6 @@
   --color-outline-focus: #e0e0e0;
 }
 
-#info-panel {
-  margin-top: 25px;
-  margin-left: 10px;
-  margin-right: 10px;
-}
 
 ::placeholder {
   color: var(--color-text-primary);
@@ -474,6 +469,9 @@ button {
 #canvasArea {
   position: relative;
   background-color: #f3f3f3;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
 #codePanel {
@@ -890,8 +888,8 @@ button {
 }
 
 @media only screen and (orientation: portrait) and (max-width: 1024px) {
-  #info-panel {
-    display: block;
+  #info-panel:not(.hidden) {
+    display: flex;
   }
 
   #site-footer {
@@ -1657,43 +1655,75 @@ kbd {
   font-size: 1.2em;
 }
 
-/* Shortcuts panel — overlays main content area, does not affect editor layout */
-.shortcuts-panel {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  right: 0;
-  width: 400px;
-  box-sizing: border-box;
-  background-color: var(--color-bg);
-  padding: 1.5em;
-  overflow-y: auto;
-  z-index: 90;
+/* Info panel tabs */
+#info-panel {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  border-top: 1px solid var(--color-border);
 }
 
-.shortcuts-panel:focus {
+#info-panel-tabs {
+  display: flex;
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--color-border);
+  background-color: var(--color-bg);
+}
+
+.info-tab-btn {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: 0.5em 1em;
+  cursor: pointer;
+  font-size: 0.9em;
+  color: var(--color-text-primary);
+  margin-bottom: -1px;
+}
+
+.info-tab-btn:hover {
+  background-color: var(--color-button-bg-hover);
+}
+
+.info-tab-btn.active {
+  border-bottom-color: var(--color-primary);
+  font-weight: bold;
+}
+
+.info-tab-btn:focus {
   outline: 2px solid var(--color-focus);
   outline-offset: -2px;
 }
 
+#info-panel-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.info-tab-panel {
+  padding: 1em;
+}
+
+.info-tab-panel:focus {
+  outline: 2px solid var(--color-focus);
+  outline-offset: -2px;
+}
+
+/* Shortcuts tab content */
 .shortcuts-panel-header {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
   margin-bottom: 0.5em;
 }
 
-.shortcuts-panel .help-link-button:focus {
+.shortcuts-panel-header .help-link-button:focus {
   outline: 2px solid var(--color-focus);
   outline-offset: 2px;
   border-radius: 2px;
 }
 
-.shortcuts-panel h1 {
-  font-size: 1.8em;
-  margin: 0;
-}
-
-.shortcuts-panel #shortcuts-table {
+#shortcuts-table {
   margin-bottom: 1.5em;
 }

--- a/style.css
+++ b/style.css
@@ -580,7 +580,7 @@ button {
   display: flex;
   flex-wrap: wrap;
   gap: 5px;
-  padding: 0;
+  padding: 5px 5px 25px 0px;
   margin: 0;
   box-sizing: border-box;
 }
@@ -785,21 +785,11 @@ button {
   right: -15px;
 }
 
-#site-footer {
-  position: absolute;
-  bottom: 0;
-  right: 0;
-  padding: 0.3em;
-  background: transparent;
-  width: auto;
-  z-index: 10;
-  display: flex;
-  justify-content: flex-end;
-  align-items: flex-end;
-}
-
 #flocklink {
-  background: transparent;
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  padding: 0 0.5em;
 }
 
 #flocklink img {
@@ -877,24 +867,14 @@ button {
     display: none;
   }
 
-  #site-footer {
-    padding-bottom: calc(8px + max(8px, env(safe-area-inset-bottom, 0px)));
-    padding-right: 8px;
-  }
-
   .resizer {
     display: none;
   }
 }
 
 @media only screen and (orientation: portrait) and (max-width: 1024px) {
-  #info-panel:not(.hidden) {
+  #info-panel {
     display: flex;
-  }
-
-  #site-footer {
-    padding-bottom: calc(8px + max(8px, env(safe-area-inset-bottom, 0px)));
-    padding-right: 8px;
   }
 
   .resizer {
@@ -1664,39 +1644,31 @@ kbd {
   border-top: 1px solid var(--color-border);
 }
 
-#info-panel-tabs {
-  display: flex;
-  flex-shrink: 0;
-  border-bottom: 1px solid var(--color-border);
-  background-color: var(--color-bg);
-}
-
 .info-tab-btn {
-  background: none;
-  border: none;
-  border-bottom: 2px solid transparent;
-  padding: 0.5em 1em;
-  cursor: pointer;
-  font-size: 0.9em;
-  color: var(--color-text-primary);
-  margin-bottom: -1px;
-}
-
-.info-tab-btn:hover {
-  background-color: var(--color-button-bg-hover);
+  border-radius: 0;
 }
 
 .info-tab-btn.active {
-  border-bottom-color: var(--color-primary);
-  font-weight: bold;
+  background-color: var(--color-button-bg-hover);
+  box-shadow: none;
 }
 
-.info-tab-btn:focus {
-  outline: 2px solid var(--color-focus);
-  outline-offset: -2px;
+#info-panel-tabs {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  height: 50px;
+  min-height: 50px;
+  max-height: 50px;
+  padding: 0px 4px 2px 8px;
+  border-bottom: 1px solid var(--color-border);
+  background-color: var(--color-bg);
+  box-sizing: border-box;
 }
+
 
 #info-panel-body {
+  background-color: var(--color-bg);
   flex: 1;
   min-height: 0;
   overflow-y: auto;
@@ -1714,8 +1686,15 @@ kbd {
 /* Shortcuts tab content */
 .shortcuts-panel-header {
   display: flex;
-  justify-content: flex-end;
+  align-items: center;
+  justify-content: space-between;
   margin-bottom: 0.5em;
+}
+
+.shortcuts-panel-title {
+  font-size: 1.5em;
+  font-weight: bold;
+  margin: 0;
 }
 
 .shortcuts-panel-header .help-link-button:focus {

--- a/style/blockly.css
+++ b/style/blockly.css
@@ -260,10 +260,6 @@ body[data-theme="low-vision"] {
 }
 
 /* Search Highlight Styles */
-.shortcuts-panel-open .blockly-ws-search {
-  transform: translateX(-400px);
-}
-
 .blockly-ws-search {
   background: var(--color-bg);
   margin-top: 5px;

--- a/ui/axis-keyboard.js
+++ b/ui/axis-keyboard.js
@@ -15,7 +15,7 @@ export function createAxisKeyboardHandler({
   function handler(event) {
     const t = event.target;
     // Don't capture keys when focus is in the code panel, top menu, or docs
-    if (t?.closest?.("#codePanel, header, .shortcuts-panel")) return;
+    if (t?.closest?.("#codePanel, header, #info-panel")) return;
     // Don't interfere with text inputs
     const tag = (t?.tagName || "").toLowerCase();
     if (

--- a/ui/canvas-utils.js
+++ b/ui/canvas-utils.js
@@ -159,7 +159,7 @@ function ensureCircle() {
 // Deal with key down events for canvas keyboard mode
 function handleKeydown(event) {
   if (!keyboardCursorActive) return;
-  if (event.target?.closest?.(".shortcuts-panel")) return;
+  if (event.target?.closest?.("#info-panel")) return;
 
   // If a button was focused and they pressed enter/space, don't
   // move the circle, interact with the button


### PR DESCRIPTION
# Summary
Moves the keyboard controls panel into a tabbed area underneath the canvas. Still opened with `Ctrl` + `/` or by clicking on the keyboard icon in the tabs panel. 

<img width="633" height="464" alt="image" src="https://github.com/user-attachments/assets/9809c71e-3cd7-47f8-b2d5-00d91e4fdcef" />

- Panel should be correctly in tab order
- Flock logo has moved up
- Text size increase/decrease buttons to zoom in just for this panel

### AI usage
Claude Sonnet 4.6 used throughout but everything checked and designed by a human. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tabbed info panel for organizing interface elements and content.

* **Improvements**
  * Reorganized keyboard shortcuts interface into the tabbed panel structure.
  * Relocated shortcuts button and external link to sidebar for streamlined layout.
  * Enhanced keyboard navigation to include new tab controls in focus management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flipcomputing/flock/pull/645?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->