### PR TITLE
Prevent Babylon inspector from loading Typekit stylesheet

### DIFF
--- a/tests/tests.html
+++ b/tests/tests.html
@@ -5,6 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Flock Test Example</title>
     <link rel="icon" href="/images/favicon.ico" />
+    <script>
+      // Stop the Babylon inspector from injecting its Typekit stylesheet,
+      // which is blocked by the page's CSP. Matches index.html.
+      window.BABYLON_SKIP_FONT_LOADING = true;
+    </script>
     <style>
       body {
         font-family: Arial, sans-serif;


### PR DESCRIPTION
## Summary
Disable Babylon inspector's automatic Typekit font stylesheet injection in the test HTML file to comply with the page's Content Security Policy (CSP).

## Changes
- Added `window.BABYLON_SKIP_FONT_LOADING = true` configuration in a script tag within the `<head>` of `tests/tests.html`
- This prevents the Babylon inspector from injecting a Typekit stylesheet that would be blocked by CSP
- Matches the same configuration already present in `index.html`

## Details
The Babylon inspector automatically attempts to load a Typekit stylesheet for font rendering. However, this stylesheet URL is blocked by the page's CSP policy. By setting the `BABYLON_SKIP_FONT_LOADING` flag before any Babylon code executes, we prevent this injection and avoid CSP violations while maintaining full inspector functionality.

https://claude.ai/code/session_01M5UWhT73wZstTixJ59thB7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test configuration to prevent unwanted font stylesheet injection, aligning test environment behavior with the main application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flipcomputing/flock/pull/646?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->