### PR TITLE
Add scene disposal checks to prevent errors during cleanup

### DIFF
--- a/api/models.js
+++ b/api/models.js
@@ -144,13 +144,26 @@ export const flockModels = {
       .then((container) => {
         // The scene was disposed / the load was aborted while this
         // container was still loading. Drop it without touching the
-        // (now null) scene. onAbort has already rejected readyPromise
-        // and released the reserved name.
+        // (now null) scene. On the abort path onAbort has already
+        // rejected readyPromise and released the reserved name; on the
+        // disposed-without-abort path we must do that cleanup here so
+        // whenModelReady waiters settle and the name isn't leaked.
         if (signal?.aborted || !flock.scene || flock.scene.isDisposed) {
           try {
             container?.dispose?.();
           } catch (_) {
             console.warn("Suppressed non-critical error:", _);
+          }
+          if (!signal?.aborted) {
+            rejectReady(new Error("scene disposed"));
+            flock.modelReadyPromises.delete(meshName);
+            if (
+              originalBase !== meshName &&
+              flock.modelReadyPromises.get(originalBase) === readyPromise
+            ) {
+              flock.modelReadyPromises.delete(originalBase);
+            }
+            flock._releaseName?.(meshName);
           }
           cleanupAbort();
           return;

--- a/api/models.js
+++ b/api/models.js
@@ -33,6 +33,12 @@ export const flockModels = {
       }
     };
 
+    // --- bail if there is no live scene (e.g. called during dispose) ---
+    if (!flock.scene || flock.scene.isDisposed) {
+      console.warn("createCharacter: no active scene");
+      return "error_no_scene";
+    }
+
     // --- validate ---
     if (!modelName || typeof modelName !== "string" || modelName.length > 100) {
       console.warn("createCharacter: invalid modelName");
@@ -94,6 +100,11 @@ export const flockModels = {
       resolveReady = res;
       rejectReady = rej;
     });
+    // Aborted loads reject this promise; attach a benign catch so the
+    // rejection never surfaces as an unhandled rejection when no
+    // whenModelReady consumer attached a handler. Real consumers still
+    // observe the rejection via their own .then/.catch registrations.
+    readyPromise.catch(() => {});
     flock.modelReadyPromises.set(meshName, readyPromise);
     // Also register the pre-sanitization name (e.g. "dimnnd monkey" → "dimnndmonkey").
     // This lets event handlers declared before createCharacter (which still hold the
@@ -131,6 +142,20 @@ export const flockModels = {
       { signal: flock.abortController?.signal },
     )
       .then((container) => {
+        // The scene was disposed / the load was aborted while this
+        // container was still loading. Drop it without touching the
+        // (now null) scene. onAbort has already rejected readyPromise
+        // and released the reserved name.
+        if (signal?.aborted || !flock.scene || flock.scene.isDisposed) {
+          try {
+            container?.dispose?.();
+          } catch (_) {
+            console.warn("Suppressed non-critical error:", _);
+          }
+          cleanupAbort();
+          return;
+        }
+
         container.addAllToScene();
 
         const mesh = container.meshes[0];
@@ -303,6 +328,10 @@ export const flockModels = {
     };
 
     try {
+      if (!flock.scene || flock.scene.isDisposed) {
+        console.warn("createObject: no active scene");
+        return "error_no_scene";
+      }
       if (flock.maxMeshesReached()) return "error_" + flock.scene.getUniqueId();
 
       let [desiredBase, bKey] = modelId.includes("__")
@@ -337,6 +366,7 @@ export const flockModels = {
 
       if (flock.modelsBeingLoaded[modelName]) {
         flock.modelsBeingLoaded[modelName].then(() => {
+          if (!flock.scene || flock.scene.isDisposed) return;
           flock._recycleOldestByKey(modelName);
           const mesh = flock.modelCache[modelName].clone(
             flock.modelCache[modelName].name,
@@ -358,6 +388,17 @@ export const flockModels = {
       // ... inside the loadPromise.then block ...
 
       loadPromise.then((container) => {
+        // Scene disposed while the container was loading: drop it.
+        if (!flock.scene || flock.scene.isDisposed) {
+          try {
+            container?.dispose?.();
+          } catch (_) {
+            console.warn("Suppressed non-critical error:", _);
+          }
+          delete flock.modelsBeingLoaded[modelName];
+          return;
+        }
+
         container.addAllToScene();
         container.animationGroups.forEach((ag) => ag.stop());
         container.meshes.forEach((m) => {


### PR DESCRIPTION
## Summary
Add defensive checks throughout the model loading and object creation pipeline to gracefully handle cases where the scene is disposed or becomes unavailable during asynchronous operations. This prevents errors and unhandled promise rejections when operations complete after scene cleanup.

## Key Changes
- **Early scene validation**: Added checks at the start of `createCharacter` and `createObject` to bail out if no active scene exists
- **Promise rejection handling**: Attached a catch handler to `readyPromise` to prevent unhandled rejection warnings when loads are aborted without consumers
- **Post-load scene checks**: Added disposal checks in `.then()` blocks after container loading completes, ensuring we don't attempt to add meshes to a disposed scene
- **Graceful cleanup**: When a scene is disposed during loading, containers are properly disposed and internal state (like `modelsBeingLoaded`) is cleaned up
- **Error suppression**: Wrapped disposal calls in try-catch to suppress non-critical errors during cleanup

## Implementation Details
The changes follow a consistent pattern: check if `flock.scene` is null or `flock.scene.isDisposed` at critical points where the scene is accessed. This is particularly important in promise chains where the scene state can change between when the promise was created and when it resolves. The implementation ensures that even if a scene is disposed mid-operation, no errors propagate and resources are properly cleaned up.

https://claude.ai/code/session_01ENptDkxsw6UEFt5BDdydPt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced scene validity checks when creating characters and objects, returning appropriate error codes when scenes are unavailable.
  * Suppressed unhandled rejection warnings during asset loading.
  * Improved cleanup and resource disposal when scenes are disposed during character or object creation.
  * Fixed edge cases where asset containers could remain unmanaged if scenes were disposed while loading.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flipcomputing/flock/pull/648?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->