### PR TITLE
Tidy keyboard controls panel

### DIFF
--- a/accessibility/keyboardui.js
+++ b/accessibility/keyboardui.js
@@ -666,6 +666,7 @@ const ShortcutsPanel = {
     );
     const btn = document.getElementById("info-tab-btn-shortcuts");
     btn.setAttribute("aria-label", translate("shortcut_panel_title"));
+    btn.setAttribute("title", translate("shortcut_panel_title"));
     btn.innerHTML = `<div class="icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512"><path fill="currentColor" d="M64 64C28.7 64 0 92.7 0 128L0 384c0 35.3 28.7 64 64 64l448 0c35.3 0 64-28.7 64-64l0-256c0-35.3-28.7-64-64-64L64 64zM175.1 224l16 0c8.8 0 16 7.2 16 16l0 16c0 8.8-7.2 16-16 16l-16 0c-8.8 0-16-7.2-16-16l0-16c0-8.8 7.2-16 16-16zm-72 32c0 8.8-7.2 16-16 16l-16 0c-8.8 0-16-7.2-16-16l0-16c0-8.8 7.2-16 16-16l16 0c8.8 0 16 7.2 16 16l0 16zm128 0c0 8.8-7.2 16-16 16l-16 0c-8.8 0-16-7.2-16-16l0-16c0-8.8 7.2-16 16-16l16 0c8.8 0 16 7.2 16 16l0 16zm128 0c0 8.8-7.2 16-16 16l-16 0c-8.8 0-16-7.2-16-16l0-16c0-8.8 7.2-16 16-16l16 0c8.8 0 16 7.2 16 16l0 16zm72-32l16 0c8.8 0 16 7.2 16 16l0 16c0 8.8-7.2 16-16 16l-16 0c-8.8 0-16-7.2-16-16l0-16c0-8.8 7.2-16 16-16zM80 336c0-8.8 7.2-16 16-16l288 0c8.8 0 16 7.2 16 16l0 16c0 8.8-7.2 16-16 16l-288 0c-8.8 0-16-7.2-16-16l0-16zm336-16l16 0c8.8 0 16 7.2 16 16l0 16c0 8.8-7.2 16-16 16l-16 0c-8.8 0-16-7.2-16-16l0-16c0-8.8 7.2-16 16-16z"/></svg></div>`;
     panel.innerHTML = `
         <div class="shortcuts-panel-header">

--- a/accessibility/keyboardui.js
+++ b/accessibility/keyboardui.js
@@ -607,6 +607,7 @@ const InfoPanel = {
     tab.btn.setAttribute("aria-selected", "true");
     tab.btn.classList.add("active");
     tab.panel.classList.remove("hidden");
+    tab.panel.focus();
   },
 
   deactivate(id) {
@@ -719,7 +720,6 @@ const ShortcutsPanel = {
     this.renderContent();
     this.previousFocus = document.activeElement;
     InfoPanel.activate("shortcuts");
-    this.panel.focus();
     document.getElementById("shortcutsBtn")?.classList.add("active");
   },
 

--- a/index.html
+++ b/index.html
@@ -1285,26 +1285,6 @@
                   />
                 </svg>
               </button>
-              <div id="flocklink">
-                <a
-                  href="https://flockxr.com/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  id="info-panel-link"
-                  data-i18n="info_panel_link"
-                  aria-label="Visit Flock XR website (opens in new tab)"
-                  title="Visit Flock XR website"
-                >
-                  <img
-                    src="./images/inline-flock-xr.svg"
-                    alt="Flock XR logo"
-                    id="flocklogo"
-                  />
-                  <span class="sr-only">
-                    Visit Flock XR website in a new tab
-                  </span>
-                </a>
-              </div>
             </aside>
             <!-- Info panel collapse starts -->
 
@@ -1313,12 +1293,33 @@
               role="complementary"
               aria-label="Information panel"
             >
+              <div id="info-panel-body"></div>
               <div
                 id="info-panel-tabs"
                 role="tablist"
                 aria-label="Information panel tabs"
-              ></div>
-              <div id="info-panel-body"></div>
+              >
+                <div id="flocklink">
+                  <a
+                    href="https://flockxr.com/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    id="info-panel-link"
+                    data-i18n="info_panel_link"
+                    aria-label="Visit Flock XR website (opens in new tab)"
+                    title="Visit Flock XR website"
+                  >
+                    <img
+                      src="./images/inline-flock-xr.svg"
+                      alt="Flock XR logo"
+                      id="flocklogo"
+                    />
+                    <span class="sr-only">
+                      Visit Flock XR website in a new tab
+                    </span>
+                  </a>
+                </div>
+              </div>
             </aside>
           </section>
           <div

--- a/main/context.js
+++ b/main/context.js
@@ -113,20 +113,21 @@ export const ContextManager = {
     style.textContent = `
             #flock-context-debug {
                 position: fixed !important;
-                bottom: 30px !important;
-                left: 30px !important;
+                top: 0 !important;
+                left: 50% !important;
+                transform: translateX(-50%) !important;
                 background: rgba(0, 0, 0, 0.85) !important;
                 color: #00ff00 !important;
-                padding: 10px 15px !important;
+                padding: 4px 12px !important;
                 font-family: 'Consolas', 'Monaco', monospace !important;
-                font-size: 14px !important;
+                font-size: 12px !important;
                 z-index: 999999 !important;
-                border: 2px solid #00ff00 !important;
-                border-radius: 6px !important;
+                border: 1px solid #00ff00 !important;
+                border-top: none !important;
+                border-radius: 0 0 6px 6px !important;
                 pointer-events: none !important;
-                display: block !important;
-                visibility: visible !important;
-                min-width: 200px !important;
+                width: 400px !important;
+                overflow: hidden !important;
             }
         `;
     document.head.appendChild(style);
@@ -134,8 +135,7 @@ export const ContextManager = {
     // 2. Create the Element
     const debugDiv = document.createElement("div");
     debugDiv.id = "flock-context-debug";
-    debugDiv.innerHTML = `CONTEXT: <span id="ctx-value">...</span><br>
-    INPUT: <span id="input-debug-value">...</span>`;
+    debugDiv.innerHTML = `CONTEXT: <span id="ctx-value">...</span><br>INPUT: <span id="input-debug-value">...</span>`;
     document.body.appendChild(debugDiv);
 
     // Update loop

--- a/main/input.js
+++ b/main/input.js
@@ -1,44 +1,44 @@
-import * as Blockly from "blockly";
-import { translate } from "./translation.js";
+import * as Blockly from 'blockly';
+import { translate } from './translation.js';
 
 export function setupInput() {
   // Get the canvas element
-  const canvas = document.getElementById("renderCanvas");
+  const canvas = document.getElementById('renderCanvas');
   if (!canvas) return;
 
   // For mouse events
-  canvas.addEventListener("mousedown", disableSelection);
-  document.addEventListener("mousedown", enableSelection);
+  canvas.addEventListener('mousedown', disableSelection);
+  document.addEventListener('mousedown', enableSelection);
 
   // For touch events (mobile)
-  canvas.addEventListener("touchstart", disableSelection);
-  document.addEventListener("touchstart", enableSelection);
+  canvas.addEventListener('touchstart', disableSelection);
+  document.addEventListener('touchstart', enableSelection);
 
   // Disable text selection on the body when the canvas is touched or clicked
   function disableSelection() {
-    document.body.style.userSelect = "none"; // Disable text selection
+    document.body.style.userSelect = 'none'; // Disable text selection
   }
 
   // Enable text selection when touching or clicking outside the canvas
   function enableSelection(event) {
     // Check if the event target is outside the canvas
     if (!canvas.contains(event.target)) {
-      document.body.style.userSelect = "auto"; // Enable text selection
+      document.body.style.userSelect = 'auto'; // Enable text selection
     }
   }
 
   // Focus management and keyboard navigation
   function initializeFocusManagement() {
     // Modal focus trapping
-    const modal = document.getElementById("infoModal");
+    const modal = document.getElementById('infoModal');
     if (modal) {
-      modal.addEventListener("keydown", trapFocus);
+      modal.addEventListener('keydown', trapFocus);
     }
 
     // Enhanced canvas keyboard support
-    const canvas = document.getElementById("renderCanvas");
+    const canvas = document.getElementById('renderCanvas');
     if (canvas) {
-      canvas.addEventListener("keydown", handleCanvasKeyboard);
+      canvas.addEventListener('keydown', handleCanvasKeyboard);
     }
 
     // Set up custom tab order management
@@ -52,61 +52,58 @@ export function setupInput() {
       // Helper: add once if visible & enabled
       const pushUnique = (el) => {
         if (!el) return;
-        const disabled = "disabled" in el && el.disabled;
+        const disabled = 'disabled' in el && el.disabled;
         if (isElementVisible(el) && !disabled && !elements.includes(el)) {
           elements.push(el);
         }
       };
 
       // 1) Canvas
-      pushUnique(document.getElementById("renderCanvas"));
-      pushUnique(document.getElementById("babylonUnmuteButton"));
+      pushUnique(document.getElementById('renderCanvas'));
+      pushUnique(document.getElementById('babylonUnmuteButton'));
 
       // 2) Gizmo buttons
-      document
-        .querySelectorAll("#gizmoButtons button, #gizmoButtons input")
-        .forEach(pushUnique);
+      document.querySelectorAll('#gizmoButtons button, #gizmoButtons input').forEach(pushUnique);
 
-      // 4) Logo link, keyboard tab, shortcuts panel contents (if open), resizer
-      pushUnique(document.querySelector("#info-panel-link"));
-      pushUnique(document.querySelector("#info-tab-btn-shortcuts"));
-      const shortcutsTabPanel = document.getElementById("info-tab-panel-shortcuts");
-      if (shortcutsTabPanel && !shortcutsTabPanel.classList.contains("hidden")) {
+      // 4) Keyboard tab, shortcuts panel contents (if open), logo link, resizer
+      pushUnique(document.querySelector('#info-tab-btn-shortcuts'));
+
+      const shortcutsTabPanel = document.getElementById('info-tab-panel-shortcuts');
+      if (shortcutsTabPanel && !shortcutsTabPanel.classList.contains('hidden')) {
         pushUnique(shortcutsTabPanel);
-        shortcutsTabPanel
-          .querySelectorAll("a[href], button:not([disabled])")
-          .forEach(pushUnique);
+        shortcutsTabPanel.querySelectorAll('a[href], button:not([disabled])').forEach(pushUnique);
       }
-      pushUnique(document.querySelector("#resizer"));
+      pushUnique(document.querySelector('#info-panel-link'));
+      pushUnique(document.querySelector('#resizer'));
 
       // 5) Search inputs (toolbox flyout etc.)
       document
         .querySelectorAll(
-          '.blocklySearchInput, .blocklyTreeSearch input, input[placeholder*="Search"]',
+          '.blocklySearchInput, .blocklyTreeSearch input, input[placeholder*="Search"]'
         )
         .forEach(pushUnique);
 
       // Find the *visible* search flyout
-      const flyout = Array.from(
-        document.querySelectorAll("svg.blocklyToolboxFlyout"),
-      ).find((svg) => {
-        const r = svg.getBoundingClientRect();
-        return r.width > 0 && r.height > 0;
-      });
+      const flyout = Array.from(document.querySelectorAll('svg.blocklyToolboxFlyout')).find(
+        (svg) => {
+          const r = svg.getBoundingClientRect();
+          return r.width > 0 && r.height > 0;
+        }
+      );
 
       if (flyout) {
         // Prefer the inner workspace <g>, fall back to the svg
-        const ws = flyout.querySelector("g.blocklyWorkspace");
+        const ws = flyout.querySelector('g.blocklyWorkspace');
         const target = ws || flyout;
 
         // Ensure it can receive focus
-        if (!target.hasAttribute("tabindex") || target.tabIndex < 0) {
-          target.setAttribute("tabindex", "0");
+        if (!target.hasAttribute('tabindex') || target.tabIndex < 0) {
+          target.setAttribute('tabindex', '0');
         }
-        target.setAttribute("focusable", "true");
-        target.setAttribute("role", "group");
-        if (!target.getAttribute("aria-label")) {
-          target.setAttribute("aria-label", "Toolbox search results");
+        target.setAttribute('focusable', 'true');
+        target.setAttribute('role', 'group');
+        if (!target.getAttribute('aria-label')) {
+          target.setAttribute('aria-label', 'Toolbox search results');
         }
 
         // Return just the flyout target (you can merge this into your larger list)
@@ -115,62 +112,53 @@ export function setupInput() {
 
       // 6) Blockly MAIN WORKSPACE
       document
-        .querySelectorAll(".blockly-ws-search input, .blockly-ws-search button")
+        .querySelectorAll('.blockly-ws-search input, .blockly-ws-search button')
         .forEach(pushUnique);
-      const blocklySvg = document.querySelector("svg.blocklySvg");
-      const workspaceGroup = blocklySvg?.querySelector("g.blocklyWorkspace");
+      const blocklySvg = document.querySelector('svg.blocklySvg');
+      const workspaceGroup = blocklySvg?.querySelector('g.blocklyWorkspace');
 
       if (workspaceGroup && isElementVisible(blocklySvg)) {
         // Force tabIndex=0 — Blockly's focus manager may have set it to -1
-        workspaceGroup.setAttribute("tabindex", "0");
-        workspaceGroup.setAttribute("role", "group");
-        workspaceGroup.setAttribute("aria-label", "Blocks workspace");
+        workspaceGroup.setAttribute('tabindex', '0');
+        workspaceGroup.setAttribute('role', 'group');
+        workspaceGroup.setAttribute('aria-label', 'Blocks workspace');
         pushUnique(workspaceGroup);
       }
 
       // 6a) Workspace comments and block comment icons
-      document.querySelectorAll("g.blocklyComment").forEach((el) => {
-        if (!el.hasAttribute("tabindex") || el.tabIndex < 0)
-          el.setAttribute("tabindex", "0");
-        if (!el.getAttribute("role")) el.setAttribute("role", "group");
-        if (!el.getAttribute("aria-label"))
-          el.setAttribute("aria-label", "Workspace comment");
+      document.querySelectorAll('g.blocklyComment').forEach((el) => {
+        if (!el.hasAttribute('tabindex') || el.tabIndex < 0) el.setAttribute('tabindex', '0');
+        if (!el.getAttribute('role')) el.setAttribute('role', 'group');
+        if (!el.getAttribute('aria-label')) el.setAttribute('aria-label', 'Workspace comment');
         pushUnique(el);
       });
-      document
-        .querySelectorAll("textarea.blocklyCommentText")
-        .forEach(pushUnique);
+      document.querySelectorAll('textarea.blocklyCommentText').forEach(pushUnique);
 
-     
       // 6c) Shortcuts panel (when visible), then undo/redo/zoom
- 
-      const shortcutsPanel = document.getElementById("shortcutsPanel");
+
+      const shortcutsPanel = document.getElementById('shortcutsPanel');
       pushUnique(shortcutsPanel);
       if (shortcutsPanel) {
-        shortcutsPanel
-          .querySelectorAll("a[href], button:not([disabled])")
-          .forEach(pushUnique);
+        shortcutsPanel.querySelectorAll('a[href], button:not([disabled])').forEach(pushUnique);
       }
 
-      ["#undoBtn", "#redoBtn", "#zoomOutBtn", "#zoomInBtn"].forEach((sel) =>
-        pushUnique(document.querySelector(sel)),
+      ['#undoBtn', '#redoBtn', '#zoomOutBtn', '#zoomInBtn'].forEach((sel) =>
+        pushUnique(document.querySelector(sel))
       );
-
-  
 
       // 7) Main UI controls (in natural order)
       [
-        "#menuBtn",
-        "#runCodeButton",
-        "#stopCodeButton",
-        "#openButton",
-        "#colorPickerButton",
-        "#projectName",
-        "#exportCodeButton",
-        "#exampleSelect",
-        "#toggleDesign",
-        "#togglePlay",
-        "#fullscreenToggle",
+        '#menuBtn',
+        '#runCodeButton',
+        '#stopCodeButton',
+        '#openButton',
+        '#colorPickerButton',
+        '#projectName',
+        '#exportCodeButton',
+        '#exampleSelect',
+        '#toggleDesign',
+        '#togglePlay',
+        '#fullscreenToggle',
       ].forEach((sel) => pushUnique(document.querySelector(sel)));
 
       return elements;
@@ -183,7 +171,7 @@ export function setupInput() {
       let currentElement = element;
       while (currentElement) {
         const style = window.getComputedStyle(currentElement);
-        if (style.display === "none" || style.visibility === "hidden") {
+        if (style.display === 'none' || style.visibility === 'hidden') {
           return false;
         }
         currentElement = currentElement.parentElement;
@@ -196,34 +184,31 @@ export function setupInput() {
       return rect.width > 0 && rect.height > 0;
     }
 
-    document.addEventListener("keydown", (e) => {
+    document.addEventListener('keydown', (e) => {
       if (
-        document.activeElement.id === "resizer" &&
-        ["ArrowLeft", "ArrowRight", "Home"].includes(e.key)
+        document.activeElement.id === 'resizer' &&
+        ['ArrowLeft', 'ArrowRight', 'Home'].includes(e.key)
       ) {
         return; // Don't prevent default, let resizer handle it
       }
 
-      if (e.key !== "Tab") return;
+      if (e.key !== 'Tab') return;
       const activeElement = document.activeElement;
 
       // Let workspace search handle tabs when focussed
-      if (activeElement?.closest?.(".blockly-ws-search")) {
+      if (activeElement?.closest?.('.blockly-ws-search')) {
         return;
       }
 
       // Special handling for details navigation
-      const detailsElement = document.getElementById("info-details");
+      const detailsElement = document.getElementById('info-details');
 
       // If we're on the summary and details is closed, use custom management
-      if (
-        activeElement.matches("#info-details summary") &&
-        !detailsElement.open
-      ) {
+      if (activeElement.matches('#info-details summary') && !detailsElement.open) {
         // Let custom management handle this - will go to next UI element
       }
       // If we're anywhere inside open details content, let browser handle it
-      else if (activeElement.closest("#info-details") && detailsElement.open) {
+      else if (activeElement.closest('#info-details') && detailsElement.open) {
         return; // Let browser handle navigation within details
       }
 
@@ -237,24 +222,21 @@ export function setupInput() {
       // (e.g. Blockly moved focus internally to a block within the flyout/workspace)
       if (currentIndex === -1) {
         currentIndex = focusableElements.findIndex(
-          (el) => el !== currentElement && el.contains?.(currentElement),
+          (el) => el !== currentElement && el.contains?.(currentElement)
         );
       }
 
       // Only manage tab navigation for our tracked elements
-      if (currentIndex === -1 || currentElement.closest("details[open]"))
-        return;
+      if (currentIndex === -1 || currentElement.closest('details[open]')) return;
 
       e.preventDefault();
 
       // Calculate next index with wraparound
       let nextIndex;
       if (e.shiftKey) {
-        nextIndex =
-          currentIndex === 0 ? focusableElements.length - 1 : currentIndex - 1;
+        nextIndex = currentIndex === 0 ? focusableElements.length - 1 : currentIndex - 1;
       } else {
-        nextIndex =
-          currentIndex === focusableElements.length - 1 ? 0 : currentIndex + 1;
+        nextIndex = currentIndex === focusableElements.length - 1 ? 0 : currentIndex + 1;
       }
 
       const nextElement = focusableElements[nextIndex];
@@ -264,41 +246,32 @@ export function setupInput() {
           nextElement.focus();
 
           // Announce for screen readers
-          if (nextElement.id === "renderCanvas") {
-            announceToScreenReader(translate("canvas_focus_navigation"));
-          } else if (nextElement.closest("#gizmoButtons")) {
+          if (nextElement.id === 'renderCanvas') {
+            announceToScreenReader(translate('canvas_focus_navigation'));
+          } else if (nextElement.closest('#gizmoButtons')) {
             const label =
-              nextElement.getAttribute("aria-label") ||
+              nextElement.getAttribute('aria-label') ||
               nextElement.title ||
-              translate("design_tool_label");
-            const focusedMessage = translate("focused_element_suffix").replace(
-              "{name}",
-              label,
-            );
+              translate('design_tool_label');
+            const focusedMessage = translate('focused_element_suffix').replace('{name}', label);
             announceToScreenReader(focusedMessage);
           } else if (
-            nextElement.classList?.contains("blocklySearchInput") ||
-            nextElement.type === "search"
+            nextElement.classList?.contains('blocklySearchInput') ||
+            nextElement.type === 'search'
           ) {
-            announceToScreenReader(translate("search_toolbox_focused"));
-          } else if (nextElement.id === "blocklyDiv") {
-            announceToScreenReader(translate("code_workspace_focused"));
-          } else if (
-            nextElement.tagName === "BUTTON" ||
-            nextElement.tagName === "LABEL"
-          ) {
+            announceToScreenReader(translate('search_toolbox_focused'));
+          } else if (nextElement.id === 'blocklyDiv') {
+            announceToScreenReader(translate('code_workspace_focused'));
+          } else if (nextElement.tagName === 'BUTTON' || nextElement.tagName === 'LABEL') {
             const text =
-              nextElement.getAttribute("aria-label") ||
+              nextElement.getAttribute('aria-label') ||
               nextElement.title ||
               nextElement.textContent ||
-              translate("interactive_element_label");
-            const focusedMessage = translate("focused_element_suffix").replace(
-              "{name}",
-              text,
-            );
+              translate('interactive_element_label');
+            const focusedMessage = translate('focused_element_suffix').replace('{name}', text);
             announceToScreenReader(focusedMessage);
-          } else if (nextElement.id === "resizer") {
-            announceToScreenReader(translate("panel_resizer_focused"));
+          } else if (nextElement.id === 'resizer') {
+            announceToScreenReader(translate('panel_resizer_focused'));
           }
         }
       }
@@ -306,11 +279,11 @@ export function setupInput() {
   }
 
   function trapFocus(e) {
-    if (e.key !== "Tab") return;
+    if (e.key !== 'Tab') return;
 
     const modal = e.currentTarget;
     const focusableElements = modal.querySelectorAll(
-      'button, input, select, textarea, [href], [tabindex]:not([tabindex="-1"])',
+      'button, input, select, textarea, [href], [tabindex]:not([tabindex="-1"])'
     );
 
     const firstElement = focusableElements[0];
@@ -327,45 +300,41 @@ export function setupInput() {
 
   function handleCanvasKeyboard(e) {
     // Handle Ctrl+Z for undo when canvas is focused
-    if (
-      (e.ctrlKey || e.metaKey) &&
-      e.key.toLowerCase() === "z" &&
-      !e.shiftKey
-    ) {
+    if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'z' && !e.shiftKey) {
       e.preventDefault();
       const workspace = window.mainWorkspace || Blockly.getMainWorkspace();
       if (workspace) {
         workspace.undo(false);
-        announceToScreenReader(translate("undo_performed"));
+        announceToScreenReader(translate('undo_performed'));
       }
       return;
     }
 
     // Handle Ctrl+Shift+Z or Ctrl+Y for redo when canvas is focused
     if (
-      ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key.toLowerCase() === "z") ||
-      (e.ctrlKey && e.key.toLowerCase() === "y")
+      ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key.toLowerCase() === 'z') ||
+      (e.ctrlKey && e.key.toLowerCase() === 'y')
     ) {
       e.preventDefault();
       const workspace = window.mainWorkspace || Blockly.getMainWorkspace();
       if (workspace) {
         workspace.undo(true);
-        announceToScreenReader(translate("redo_performed"));
+        announceToScreenReader(translate('redo_performed'));
       }
       return;
     }
 
     // Announce camera movements to screen readers
     const announcements = {
-      ArrowUp: translate("camera_moving_forward"),
-      ArrowDown: translate("camera_moving_backward"),
-      ArrowLeft: translate("camera_moving_left"),
-      ArrowRight: translate("camera_moving_right"),
-      w: translate("moving_forward"),
-      s: translate("moving_backward"),
-      a: translate("moving_left"),
-      d: translate("moving_right"),
-      " ": translate("action_triggered"),
+      ArrowUp: translate('camera_moving_forward'),
+      ArrowDown: translate('camera_moving_backward'),
+      ArrowLeft: translate('camera_moving_left'),
+      ArrowRight: translate('camera_moving_right'),
+      w: translate('moving_forward'),
+      s: translate('moving_backward'),
+      a: translate('moving_left'),
+      d: translate('moving_right'),
+      ' ': translate('action_triggered'),
     };
 
     if (announcements[e.key]) {
@@ -380,11 +349,11 @@ export function setupInput() {
 }
 
 export function announceToScreenReader(message) {
-  const announcer = document.getElementById("announcements");
+  const announcer = document.getElementById('announcements');
   if (announcer) {
     announcer.textContent = message;
     setTimeout(() => {
-      announcer.textContent = "";
+      announcer.textContent = '';
     }, 1000);
   }
 }

--- a/main/view.js
+++ b/main/view.js
@@ -574,7 +574,7 @@ export function toggleDesignMode() {
     switchView("both");
     flock.scene.debugLayer.hide();
     flockLink.style.display = "block";
-    infoPanel.style.display = "block";
+    infoPanel.style.display = "flex";
   } else {
     blocklyArea.style.display = "none";
     codeMode = "none";

--- a/style.css
+++ b/style.css
@@ -1663,7 +1663,6 @@ kbd {
   flex-direction: column;
   flex: 1;
   min-height: 0;
-  border-top: 1px solid var(--color-border);
 }
 
 .info-tab-btn {
@@ -1682,18 +1681,26 @@ kbd {
   height: 50px;
   min-height: 50px;
   max-height: 50px;
-  padding: 0px 4px 2px 8px;
-  border-bottom: 1px solid var(--color-border);
+  padding: 2px 4px 0px 8px;
+  border-top: 1px solid var(--color-border);
   background-color: var(--color-bg);
   box-sizing: border-box;
 }
 
+#info-panel-tabs #flocklink {
+  order: 999;
+}
+
 
 #info-panel-body {
-  background-color: var(--color-bg);
+  background-color: inherit;
   flex: 1;
   min-height: 0;
   overflow-y: auto;
+}
+
+#info-panel:has(.info-tab-btn.active) #info-panel-body {
+  background-color: var(--color-bg);
 }
 
 .info-tab-panel {

--- a/style.css
+++ b/style.css
@@ -880,6 +880,10 @@ button {
     bottom: calc(9px + max(8px, env(safe-area-inset-bottom, 0px)));
   }
 
+  #info-panel-tabs {
+    margin-bottom: calc(9px + max(8px, env(safe-area-inset-bottom, 0px)));
+  }
+
   #blocklyDiv {
     height: calc(
       100% - 59px - max(8px, env(safe-area-inset-bottom, 0px))


### PR DESCRIPTION
# Summary
Move position of tabs to bottom on the keyboard controls info panel.

<img width="1335" height="1133" alt="image" src="https://github.com/user-attachments/assets/43b90eca-f0de-46bd-802d-f1edf529f408" />

- Make sure that opening/closing the inspector doesn't cause a bug where the panel can't be closed
- Make sure tabs panel appears above swap mode bar on mobile
- Move flock logo back to its original place

### AI usage
Claude Sonnet 4.6 used throughout, designed by a human and all changes checked individually (and in some cases, rejected!) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced keyboard navigation with improved focus management and contextual screen reader announcements
  * Expanded keyboard shortcuts accessibility with refined tab ordering and focus indicators

* **Bug Fixes**
  * Resolved focus-wrapping logic issues during keyboard navigation

* **Style**
  * Updated Information Panel layout and responsive styling
  * Refined debug overlay appearance and positioning

* **Accessibility**
  * Added ARIA labels and semantic roles for keyboard navigation
  * Improved screen reader announcements for keyboard users

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flipcomputing/flock/pull/652?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->