### PR TITLE
Update GitHub Actions workflows to use Node.js 24 and latest actions

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -7,10 +7,10 @@ jobs:
   eslint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
       - run: npm ci
       - run: npx eslint .
         continue-on-error: true # Remove to block PRs that fail the check

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -7,9 +7,9 @@ jobs:
   prettier:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
       - run: npx prettier --check .
         continue-on-error: true # Remove to block PRs that fail the check

--- a/.github/workflows/run-mocha-tests.yml
+++ b/.github/workflows/run-mocha-tests.yml
@@ -16,15 +16,15 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-2022]
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [24.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: testable
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -29,7 +29,7 @@ jobs:
       url: ${{ steps.deploy_to_pages.outputs.github_pages_url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Vite Github Pages Deployer
         uses: skywarth/vite-github-pages-deployer@master
         id: deploy_to_pages


### PR DESCRIPTION
## Summary
This PR updates all GitHub Actions workflows to use the latest versions of GitHub Actions and upgrades the Node.js runtime to version 24.

## Key Changes
- Updated `actions/checkout` from v4 to v5 across all workflows (v3 to v5 in static.yml)
- Updated `actions/setup-node` from v4 to v5 across all workflows
- Upgraded Node.js version from 20 to 24 in eslint and prettier workflows
- Simplified the test matrix in run-mocha-tests.yml to only test against Node.js 24.x (removed 20.x and 22.x)

## Implementation Details
- The changes ensure all CI/CD pipelines use the latest stable versions of GitHub Actions
- Node.js 24 is now the single target version for test execution, aligning with the project's minimum supported version
- All four workflow files (eslint.yml, prettier.yml, run-mocha-tests.yml, and static.yml) have been updated consistently

https://claude.ai/code/session_014CcKnGU8aXgFQ2rqxQq1FW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to use latest versions of checkout and Node.js setup actions.
  * Updated CI/CD pipeline to run on Node.js 24.x.
  * Standardized workflow configuration across linting, formatting, testing, and deployment pipelines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flipcomputing/flock/pull/656?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->