### PR TITLE
Bug fixes

### DIFF
--- a/main/blocklyinit.js
+++ b/main/blocklyinit.js
@@ -971,6 +971,11 @@ export function initializeWorkspace() {
     cancelBtn.addEventListener('mousedown', (e) => e.preventDefault());
     cancelBtn.addEventListener('click', closeOverlay);
 
+    // Close search overlay if screen resizes above tablet size
+    window.matchMedia('(max-width: 768px)').addEventListener('change', (e) => {
+      if (!e.matches && overlay.isConnected) closeOverlay();
+    });
+
     // Scrolling the results panel should not trigger the blur-close timeout
     resultsPanel.addEventListener(
       'touchstart',

--- a/style/blockly.css
+++ b/style/blockly.css
@@ -848,6 +848,10 @@ body[data-theme='low-vision'] .blocklyField text.blocklyText.blocklyFieldText.bl
     outline-offset: 2px;
   }
 
+  .mobile-search-overlay input[type='search']::-webkit-search-cancel-button {
+    display: none;
+  }
+
   .mobile-search-cancel {
     flex-shrink: 0;
     background: none;


### PR DESCRIPTION
- Remove duplicate X in expanded toolbox search box
- Close expanded toolbox search if screen resizes larger than 768px mid search

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mobile search overlay now automatically closes when the viewport resizes to larger layouts, preventing the UI from remaining open during screen size transitions.
  * Removed the WebKit search cancel button from the mobile search input for a cleaner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->