### PR TITLE
Workspace search on mobile 

### DIFF
--- a/index.html
+++ b/index.html
@@ -1342,6 +1342,23 @@
             >
               <button
                 class="bigbutton"
+                id="workspaceSearchBtn"
+                aria-label="Find in workspace"
+                title="Find in workspace"
+              >
+                <div class="icon" aria-hidden="true">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+                    <!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->
+                    <path
+                      fill="currentColor"
+                      d="M416 208c0 45.9-14.9 88.3-40 122.7L502.6 457.4c12.5 12.5 12.5 32.8 0 45.3s-32.8 12.5-45.3 0L330.7 376c-34.4 25.2-76.8 40-122.7 40C93.1 416 0 322.9 0 208S93.1 0 208 0S416 93.1 416 208zM208 352a144 144 0 1 0 0-288 144 144 0 1 0 0 288z"
+                    />
+                  </svg>
+                </div>
+              </button>
+              <div class="toolbar-divider" aria-hidden="true"></div>
+              <button
+                class="bigbutton"
                 id="undoBtn"
                 aria-label="Undo"
                 title="Undo"

--- a/locale/de.js
+++ b/locale/de.js
@@ -1122,6 +1122,7 @@ export default {
   toolbox_search_placeholder: "Suchen",
   search_no_matching: "Keine passenden Blöcke gefunden",
   workspace_search_placeholder: "Im Bereich suchen",
+  close: "Schließen",
   code_workspace_focused: "Code-Arbeitsbereich fokussiert",
   interactive_element_label: "Interaktives Element",
   panel_resizer_focused:

--- a/locale/en.js
+++ b/locale/en.js
@@ -1130,6 +1130,7 @@ export default {
   focused_element_suffix: "{name} focused",
   search_toolbox_focused: "Search toolbox focused",
   workspace_search_placeholder: "Find in workspace",
+  close: "Close",
   toolbox_search_placeholder: "Search",
   search_no_matching: "No matching blocks found",
   code_workspace_focused: "Code workspace focused",

--- a/locale/es.js
+++ b/locale/es.js
@@ -1141,6 +1141,7 @@ export default {
   search_toolbox_focused: "Búsqueda de la caja de herramientas enfocada", // human
   toolbox_search_placeholder: "Buscar",
   workspace_search_placeholder: "Buscar en el espacio",
+  close: "Cerrar",
   search_no_matching: "No se encontraron bloques",
   code_workspace_focused: "Espacio de trabajo de código enfocado", // human
   interactive_element_label: "Elemento interactivo", // human

--- a/locale/fr.js
+++ b/locale/fr.js
@@ -1136,6 +1136,7 @@ export default {
   toolbox_search_placeholder: "Rechercher",
   search_no_matching: "Aucun bloc correspondant",
   workspace_search_placeholder: "Chercher dans l'espace",
+  close: "Fermer",
   code_workspace_focused: "Espace de travail du code focalisé",
   interactive_element_label: "Élément interactif",
   panel_resizer_focused:

--- a/locale/it.js
+++ b/locale/it.js
@@ -1137,6 +1137,7 @@ export default {
   toolbox_search_placeholder: "Cerca",
   search_no_matching: "Nessun blocco trovato",
   workspace_search_placeholder: "Trova nell'area",
+  close: "Chiudi",
   code_workspace_focused: "Area di lavoro del codice focalizzata",
   interactive_element_label: "Elemento interattivo",
   panel_resizer_focused:

--- a/locale/pl.js
+++ b/locale/pl.js
@@ -1136,6 +1136,7 @@ export default {
   toolbox_search_placeholder: "Szukaj",
   search_no_matching: "Nie znaleziono pasujących bloków",
   workspace_search_placeholder: "Znajdź w obszarze",
+  close: "Zamknij",
   code_workspace_focused: "Skupiono przestrzeń kodu",
   interactive_element_label: "Element interaktywny",
   panel_resizer_focused:

--- a/locale/pt.js
+++ b/locale/pt.js
@@ -1128,6 +1128,7 @@ export default {
   toolbox_search_placeholder: "Pesquisar",
   search_no_matching: "Nenhum bloco encontrado",
   workspace_search_placeholder: "Localizar no espaço",
+  close: "Fechar",
   code_workspace_focused: "Área de trabalho de código focada",
   interactive_element_label: "Elemento interativo",
   panel_resizer_focused:

--- a/locale/sv.js
+++ b/locale/sv.js
@@ -1117,6 +1117,7 @@ export default {
   toolbox_search_placeholder: "Sök",
   search_no_matching: "Inga matchande block hittades",
   workspace_search_placeholder: "Sök i arbetsytan",
+  close: "Stäng",
   code_workspace_focused: "Kodarbetsytan har fokus",
   interactive_element_label: "Interaktivt element",
   panel_resizer_focused:

--- a/main/blocklyinit.js
+++ b/main/blocklyinit.js
@@ -1792,6 +1792,21 @@ export function createBlocklyWorkspace() {
     });
   })();
 
+  // Add "Find in workspace" to the workspace context menu.
+  (function registerWorkspaceSearchContextMenuItem() {
+    const registry = Blockly.ContextMenuRegistry.registry;
+    const id = 'workspaceFindInWorkspace';
+    if (registry.getItem?.(id)) return;
+    registry.register({
+      id,
+      weight: 50,
+      displayText: () => translate('workspace_search_placeholder'),
+      preconditionFn: () => 'enabled',
+      callback: () => window.flockWorkspaceSearch?.open(),
+      scopeType: Blockly.ContextMenuRegistry.ScopeType.WORKSPACE,
+    });
+  })();
+
   // Register cut/copy/paste at the top of the block context menu (weights 1/2/3).
   (function registerClipboardContextMenuItems() {
     const registry = Blockly.ContextMenuRegistry.registry;

--- a/main/blocklyinit.js
+++ b/main/blocklyinit.js
@@ -971,7 +971,7 @@ export function initializeWorkspace() {
     cancelBtn.addEventListener('mousedown', (e) => e.preventDefault());
     cancelBtn.addEventListener('click', closeOverlay);
 
-    // Close search overlay if screen resizes above tablet size
+    // Close search overlay if screen resizes above tablet size (768px)
     window.matchMedia('(max-width: 768px)').addEventListener('change', (e) => {
       if (!e.matches && overlay.isConnected) closeOverlay();
     });
@@ -1076,7 +1076,10 @@ export function initializeWorkspace() {
   };
 
   wsMobileInput.addEventListener('input', () => {
-    workspaceSearch.searchAndHighlight(wsMobileInput.value.trim(), workspaceSearch.preserveSelected);
+    workspaceSearch.searchAndHighlight(
+      wsMobileInput.value.trim(),
+      workspaceSearch.preserveSelected
+    );
   });
   wsMobileInput.addEventListener('keydown', (e) => {
     if (e.key === 'Escape') workspaceSearch.close();

--- a/main/blocklyinit.js
+++ b/main/blocklyinit.js
@@ -1014,11 +1014,104 @@ export function initializeWorkspace() {
   const blocklyDiv = document.getElementById('blocklyDiv');
   const originalOpen = workspaceSearch.open.bind(workspaceSearch);
   const originalClose = workspaceSearch.close.bind(workspaceSearch);
+
+  // Mobile workspace search bar (≤480px): full-width fixed bar with prev/next
+  const isMobileWS = () => window.matchMedia('(max-width: 768px)').matches;
+
+  const wsMobileBar = document.createElement('div');
+  wsMobileBar.className = 'ws-search-mobile-bar';
+
+  const wsMobileInput = document.createElement('input');
+  wsMobileInput.type = 'text';
+  wsMobileInput.className = 'ws-search-mobile-input';
+  wsMobileInput.placeholder = translate('workspace_search_placeholder');
+  wsMobileInput.setAttribute('autocomplete', 'one-time-code');
+
+  const wsMobileCount = document.createElement('span');
+  wsMobileCount.className = 'ws-search-mobile-count';
+  wsMobileCount.setAttribute('aria-live', 'polite');
+
+  const wsMobilePrev = document.createElement('button');
+  wsMobilePrev.type = 'button';
+  wsMobilePrev.className = 'ws-search-mobile-btn';
+  wsMobilePrev.setAttribute('aria-label', 'Previous match');
+  wsMobilePrev.textContent = '▲';
+
+  const wsMobileNext = document.createElement('button');
+  wsMobileNext.type = 'button';
+  wsMobileNext.className = 'ws-search-mobile-btn';
+  wsMobileNext.setAttribute('aria-label', 'Next match');
+  wsMobileNext.textContent = '▼';
+
+  const wsMobileClose = document.createElement('button');
+  wsMobileClose.type = 'button';
+  wsMobileClose.className = 'ws-search-mobile-btn ws-search-mobile-close';
+  wsMobileClose.setAttribute('aria-label', 'Close search');
+  wsMobileClose.textContent = '×';
+
+  wsMobileBar.append(wsMobileInput, wsMobileCount, wsMobilePrev, wsMobileNext, wsMobileClose);
+
+  const updateWsMobileCount = () => {
+    const total = workspaceSearch.blocks?.length ?? 0;
+    const idx = workspaceSearch.currentBlockIndex ?? -1;
+    wsMobileCount.textContent = wsMobileInput.value.trim()
+      ? total === 0
+        ? '0'
+        : `${idx + 1}/${total}`
+      : '';
+  };
+
+  const originalSetCurrentBlock = workspaceSearch.setCurrentBlock?.bind(workspaceSearch);
+  if (originalSetCurrentBlock) {
+    workspaceSearch.setCurrentBlock = function (index) {
+      originalSetCurrentBlock(index);
+      if (wsMobileBar.isConnected) updateWsMobileCount();
+    };
+  }
+
+  const originalSearchAndHighlight = workspaceSearch.searchAndHighlight.bind(workspaceSearch);
+  workspaceSearch.searchAndHighlight = function (text, preserve) {
+    originalSearchAndHighlight(text, preserve);
+    if (wsMobileBar.isConnected) updateWsMobileCount();
+  };
+
+  wsMobileInput.addEventListener('input', () => {
+    workspaceSearch.searchAndHighlight(wsMobileInput.value.trim(), workspaceSearch.preserveSelected);
+  });
+  wsMobileInput.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') workspaceSearch.close();
+    else if (e.key === 'Enter') e.shiftKey ? workspaceSearch.previous() : workspaceSearch.next();
+  });
+  wsMobilePrev.addEventListener('mousedown', (e) => e.preventDefault());
+  wsMobilePrev.addEventListener('click', () => workspaceSearch.previous());
+  wsMobileNext.addEventListener('mousedown', (e) => e.preventDefault());
+  wsMobileNext.addEventListener('click', () => workspaceSearch.next());
+  wsMobileClose.addEventListener('mousedown', (e) => e.preventDefault());
+  wsMobileClose.addEventListener('click', () => workspaceSearch.close());
+
+  window.matchMedia('(max-width: 768px)').addEventListener('change', (e) => {
+    if (!e.matches && wsMobileBar.isConnected) workspaceSearch.close();
+  });
+
   workspaceSearch.open = function () {
-    originalOpen();
+    if (isMobileWS()) {
+      document.body.appendChild(wsMobileBar);
+      wsMobileInput.value = workspaceSearch.searchText || '';
+      if (wsMobileInput.value) {
+        workspaceSearch.searchAndHighlight(wsMobileInput.value, workspaceSearch.preserveSelected);
+      }
+      updateWsMobileCount();
+      wsMobileInput.focus();
+    } else {
+      originalOpen();
+    }
     blocklyDiv?.classList.add('blockly-search-active');
   };
   workspaceSearch.close = function () {
+    if (wsMobileBar.isConnected) {
+      wsMobileInput.value = '';
+      wsMobileBar.remove();
+    }
     originalClose();
     blocklyDiv?.classList.remove('blockly-search-active');
   };

--- a/main/blocklyinit.js
+++ b/main/blocklyinit.js
@@ -766,6 +766,7 @@ export function initializeWorkspace() {
     const cancelBtn = document.createElement('button');
     cancelBtn.type = 'button';
     cancelBtn.className = 'mobile-search-cancel';
+    cancelBtn.setAttribute('aria-label', translate('close'));
     cancelBtn.textContent = '×';
     overlay.appendChild(cancelBtn);
 
@@ -1034,19 +1035,19 @@ export function initializeWorkspace() {
   const wsMobilePrev = document.createElement('button');
   wsMobilePrev.type = 'button';
   wsMobilePrev.className = 'ws-search-mobile-btn';
-  wsMobilePrev.setAttribute('aria-label', 'Previous match');
+  wsMobilePrev.setAttribute('aria-label', translate('shortcut_select_previous_result'));
   wsMobilePrev.textContent = '▲';
 
   const wsMobileNext = document.createElement('button');
   wsMobileNext.type = 'button';
   wsMobileNext.className = 'ws-search-mobile-btn';
-  wsMobileNext.setAttribute('aria-label', 'Next match');
+  wsMobileNext.setAttribute('aria-label', translate('shortcut_select_next_result'));
   wsMobileNext.textContent = '▼';
 
   const wsMobileClose = document.createElement('button');
   wsMobileClose.type = 'button';
   wsMobileClose.className = 'ws-search-mobile-btn ws-search-mobile-close';
-  wsMobileClose.setAttribute('aria-label', 'Close search');
+  wsMobileClose.setAttribute('aria-label', translate('close'));
   wsMobileClose.textContent = '×';
 
   wsMobileBar.append(wsMobileInput, wsMobileCount, wsMobilePrev, wsMobileNext, wsMobileClose);

--- a/main/input.js
+++ b/main/input.js
@@ -112,7 +112,7 @@ export function setupInput() {
 
       // 6) Blockly MAIN WORKSPACE
       document
-        .querySelectorAll('.blockly-ws-search input, .blockly-ws-search button')
+        .querySelectorAll('.blockly-ws-search input, .blockly-ws-search button, .ws-search-mobile-bar input, .ws-search-mobile-bar button')
         .forEach(pushUnique);
       const blocklySvg = document.querySelector('svg.blocklySvg');
       const workspaceGroup = blocklySvg?.querySelector('g.blocklyWorkspace');
@@ -196,7 +196,7 @@ export function setupInput() {
       const activeElement = document.activeElement;
 
       // Let workspace search handle tabs when focussed
-      if (activeElement?.closest?.('.blockly-ws-search')) {
+      if (activeElement?.closest?.('.blockly-ws-search, .ws-search-mobile-bar')) {
         return;
       }
 

--- a/main/input.js
+++ b/main/input.js
@@ -142,7 +142,7 @@ export function setupInput() {
         shortcutsPanel.querySelectorAll('a[href], button:not([disabled])').forEach(pushUnique);
       }
 
-      ['#undoBtn', '#redoBtn', '#zoomOutBtn', '#zoomInBtn'].forEach((sel) =>
+      ['#workspaceSearchBtn', '#undoBtn', '#redoBtn', '#zoomOutBtn', '#zoomInBtn'].forEach((sel) =>
         pushUnique(document.querySelector(sel))
       );
 

--- a/main/main.js
+++ b/main/main.js
@@ -821,6 +821,9 @@ function initializeApp() {
     zoomInBtn.addEventListener("click", () => workspace.zoomCenter(1));
   if (zoomOutBtn)
     zoomOutBtn.addEventListener("click", () => workspace.zoomCenter(-1));
+  const workspaceSearchBtn = document.getElementById("workspaceSearchBtn");
+  if (workspaceSearchBtn)
+    workspaceSearchBtn.addEventListener("click", () => window.flockWorkspaceSearch?.open());
   if (undoBtn) undoBtn.addEventListener("click", () => workspace.undo(false));
   if (redoBtn) redoBtn.addEventListener("click", () => workspace.undo(true));
   const shortcutsBtn = document.getElementById("shortcutsBtn");

--- a/main/translation.js
+++ b/main/translation.js
@@ -113,8 +113,14 @@ export async function setLanguage(language) {
     window.flockColorPicker.refreshTranslations();
   }
 
-  // Update workspace search placeholder
+  // Update workspace search placeholder and toolbar button
   window.flockWorkspaceSearch?.setSearchPlaceholder?.(translate("workspace_search_placeholder"));
+  const wsSearchBtn = document.getElementById("workspaceSearchBtn");
+  if (wsSearchBtn) {
+    const label = translate("workspace_search_placeholder");
+    wsSearchBtn.setAttribute("aria-label", label);
+    wsSearchBtn.title = label;
+  }
 
   // Update shortcuts panel if open
   if (window.flockShortcutsPanel?.refreshTranslations) {

--- a/style.css
+++ b/style.css
@@ -503,7 +503,8 @@ button {
 }
 
 @media (min-width: 769px) {
-  #workspaceSearchBtn {
+  #workspaceSearchBtn,
+  #workspaceSearchBtn + .toolbar-divider {
     display: none;
   }
 }

--- a/style.css
+++ b/style.css
@@ -502,6 +502,12 @@ button {
   position: relative;
 }
 
+@media (min-width: 769px) {
+  #workspaceSearchBtn {
+    display: none;
+  }
+}
+
 #blocklyZoomControls {
   position: absolute;
   bottom: 0;

--- a/style/blockly.css
+++ b/style/blockly.css
@@ -258,9 +258,11 @@ body[data-theme='low-vision'] {
   transition: opacity 0.15s ease;
 }
 
-/* Non-current matches get a pale yellow background */
-#blocklyDiv.blockly-search-active .ws-search-match:not(.ws-search-current) > path.blocklyPath {
-  fill: rgba(255, 242, 0, 0.3) !important;
+/* Non-current matches get a pale yellow background (desktop only) */
+@media (min-width: 769px) {
+  #blocklyDiv.blockly-search-active .ws-search-match:not(.ws-search-current) > path.blocklyPath {
+    fill: rgba(255, 242, 0, 0.3) !important;
+  }
 }
 
 /* Low-vision: replace fill with a dashed white stroke for better contrast */

--- a/style/blockly.css
+++ b/style/blockly.css
@@ -954,6 +954,80 @@ body[data-theme='low-vision'] .blocklyField text.blocklyText.blocklyFieldText.bl
   }
 }
 
+@media (max-width: 768px) {
+  .ws-search-mobile-bar::before {
+    content: '';
+    position: absolute;
+    bottom: 100%;
+    left: 0;
+    right: 0;
+    height: calc(var(--dynamic-offset, 65px) - 50px);
+    background: var(--color-bg);
+  }
+
+  .ws-search-mobile-bar {
+    position: fixed;
+    top: var(--dynamic-offset, 65px);
+    left: 0;
+    right: 0;
+    z-index: 10000;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 8px;
+    background: var(--color-bg);
+    box-shadow: 0 2px 12px var(--color-shadow);
+  }
+
+  .ws-search-mobile-input {
+    flex: 1;
+    height: 40px;
+    font-size: 16px;
+    box-sizing: border-box;
+    min-width: 0;
+    border: 1px solid #888;
+    border-radius: 4px;
+    outline: none;
+    padding: 0 8px;
+    color: var(--color-text);
+    background: var(--color-bg);
+  }
+
+  .ws-search-mobile-input:focus-visible {
+    outline: 3px solid var(--color-outline-focus);
+    outline-offset: 2px;
+  }
+
+  .ws-search-mobile-count {
+    font-size: 13px;
+    color: var(--color-text);
+    opacity: 0.7;
+    min-width: 36px;
+    text-align: center;
+    flex-shrink: 0;
+  }
+
+  .ws-search-mobile-btn {
+    flex-shrink: 0;
+    background: none;
+    border: none;
+    color: var(--color-text-primary);
+    font-size: 18px;
+    line-height: 1;
+    width: 44px;
+    height: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    border-radius: 4px;
+  }
+
+  .ws-search-mobile-close {
+    font-size: 30px;
+  }
+}
+
 /* Keyboard focus for image BUTTON fields only (e.g. plus/minus/toggle icons) */
 .blocklyKeyboardNavigation .blocklyActiveFocus.blocklyImageField {
   outline: 5px solid var(--block-outline-focus);


### PR DESCRIPTION
# Summary
Addresses #636 

<img width="585" height="1266" alt="Screenshot 2026-06-01 at 10 15 01" src="https://github.com/user-attachments/assets/677abd98-41c7-4273-a3d0-bdf64fcd2a73" />

- Workspace search now reachable via the context menu (right-click)
- Search button appears on mobile/tablet view next to undo
- Workspace search bar now expands across top of screen and next/prev/cancel buttons much larger
- Removed yellow background highlight for search results on mobile for clarity 

### AI usage
A fairly straightforward PR which was written by Claude Sonnet 4.6 with changes approved by a human. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added a "Find in workspace" button to the code editor toolbar for searching and highlighting blocks within your workspace
* Introduced a responsive mobile search bar for tablet and mobile devices, featuring match count, previous/next navigation, and a touch-friendly interface
* Added "Find in workspace" to the workspace context menu for quick access

<!-- end of auto-generated comment: release notes by coderabbit.ai -->