### PR TITLE
Mobile UX for switching between canvas and code

### DIFF
--- a/index.html
+++ b/index.html
@@ -1418,13 +1418,10 @@
         </div>
       </main>
       <div id="bottomBar" role="toolbar" aria-label="View switching controls">
-        <button
-          id="switchViews"
-          aria-label="Switch between code and canvas views"
-          aria-describedby="switch-desc"
-        >
-          Code >>
-        </button>
+        <div id="viewToggle" role="group" aria-label="Switch between code and canvas views">
+          <button id="canvasToggleBtn" class="view-toggle-btn" aria-pressed="true">Canvas</button>
+          <button id="codeToggleBtn" class="view-toggle-btn" aria-pressed="false">Code</button>
+        </div>
         <div id="switch-desc" class="sr-only">
           Toggle between coding view and 3D scene view
         </div>

--- a/main/input.js
+++ b/main/input.js
@@ -74,6 +74,18 @@ export function setupInput() {
         shortcutsTabPanel.querySelectorAll('a[href], button:not([disabled])').forEach(pushUnique);
       }
       pushUnique(document.querySelector('#info-panel-link'));
+
+      // View toggle in canvas mode — after the logo link, before the resizer
+      const bottomBar = document.getElementById('bottomBar');
+      const inNarrowMode = bottomBar && getComputedStyle(bottomBar).display !== 'none';
+      const codePanel = document.getElementById('codePanel');
+      const inCodeMode = inNarrowMode && codePanel && getComputedStyle(codePanel).display !== 'none';
+      if (inNarrowMode && !inCodeMode) {
+        ['#canvasToggleBtn', '#codeToggleBtn'].forEach((sel) =>
+          pushUnique(document.querySelector(sel))
+        );
+      }
+
       pushUnique(document.querySelector('#resizer'));
 
       // 5) Search inputs (toolbox flyout etc.)
@@ -112,7 +124,9 @@ export function setupInput() {
 
       // 6) Blockly MAIN WORKSPACE
       document
-        .querySelectorAll('.blockly-ws-search input, .blockly-ws-search button, .ws-search-mobile-bar input, .ws-search-mobile-bar button')
+        .querySelectorAll(
+          '.blockly-ws-search input, .blockly-ws-search button, .ws-search-mobile-bar input, .ws-search-mobile-bar button'
+        )
         .forEach(pushUnique);
       const blocklySvg = document.querySelector('svg.blocklySvg');
       const workspaceGroup = blocklySvg?.querySelector('g.blocklyWorkspace');
@@ -145,6 +159,13 @@ export function setupInput() {
       ['#workspaceSearchBtn', '#undoBtn', '#redoBtn', '#zoomOutBtn', '#zoomInBtn'].forEach((sel) =>
         pushUnique(document.querySelector(sel))
       );
+
+      // View toggle in code mode — right after zoomInBtn
+      if (inCodeMode) {
+        ['#canvasToggleBtn', '#codeToggleBtn'].forEach((sel) =>
+          pushUnique(document.querySelector(sel))
+        );
+      }
 
       // 7) Main UI controls (in natural order)
       [

--- a/main/view.js
+++ b/main/view.js
@@ -297,12 +297,7 @@ const codeToggleBtn = document.getElementById("codeToggleBtn");
 
 let savedView = "canvas";
 
-// Function to add the button event listener (narrow screens only)
 function addButtonListener() {
-  // Only add button listener on narrow screens
-  if (!isNarrowScreen()) {
-    return;
-  }
   if (canvasToggleBtn) canvasToggleBtn.addEventListener("click", showCanvasView);
   if (codeToggleBtn) codeToggleBtn.addEventListener("click", showCodeView);
 }
@@ -371,9 +366,6 @@ export function showCanvasView() {
 
 // Updated swipe handling to work with DOM-based switching
 function addSwipeListeners() {
-  if (!isNarrowScreen()) {
-    return;
-  }
   if (!bottomBar) return;
 
   let startX = 0;
@@ -467,6 +459,27 @@ export function initializeUI() {
     }
   }
 }
+
+// Handle transitions between narrow and wide layouts on resize
+window.matchMedia("(max-width: 1024px)").addEventListener("change", (e) => {
+  const blocklyArea = document.getElementById("codePanel");
+  const canvasArea = document.getElementById("canvasArea");
+  if (!blocklyArea || !canvasArea) return;
+
+  if (e.matches) {
+    // Crossed into narrow: set up single-panel view
+    showCanvasView();
+  } else {
+    // Crossed into wide: restore both panels, clear inline styles set by mobile view
+    blocklyArea.style.display = "block";
+    blocklyArea.style.width = "";
+    blocklyArea.style.flex = "";
+    canvasArea.style.display = "";
+    canvasArea.style.width = "";
+    canvasArea.style.flex = "";
+    onResize();
+  }
+});
 
 // Modified toggle function to work with new approach
 function togglePanels() {

--- a/main/view.js
+++ b/main/view.js
@@ -292,7 +292,8 @@ export { currentView, switchView, codeMode, showCodeView };
 
 const container = document.getElementById("maincontent");
 const bottomBar = document.getElementById("bottomBar");
-const switchViewsBtn = document.getElementById("switchViews");
+const canvasToggleBtn = document.getElementById("canvasToggleBtn");
+const codeToggleBtn = document.getElementById("codeToggleBtn");
 
 let savedView = "canvas";
 
@@ -302,17 +303,8 @@ function addButtonListener() {
   if (!isNarrowScreen()) {
     return;
   }
-  if (!switchViewsBtn) return;
-
-  switchViewsBtn.addEventListener("click", togglePanels);
-  switchViewsBtn.addEventListener(
-    "touchend",
-    (e) => {
-      e.preventDefault();
-      togglePanels();
-    },
-    { passive: false },
-  );
+  if (canvasToggleBtn) canvasToggleBtn.addEventListener("click", showCanvasView);
+  if (codeToggleBtn) codeToggleBtn.addEventListener("click", showCodeView);
 }
 
 // Alternative approach: Instead of CSS transforms, actually reposition elements in DOM
@@ -335,7 +327,8 @@ function showCodeView() {
     blocklyArea.style.width = "100%";
     blocklyArea.style.flex = "1 1 100%";
 
-    if (switchViewsBtn) switchViewsBtn.textContent = "<< Canvas";
+    if (canvasToggleBtn) canvasToggleBtn.setAttribute("aria-pressed", "false");
+    if (codeToggleBtn) codeToggleBtn.setAttribute("aria-pressed", "true");
 
     // Blockly resize after DOM changes
     requestAnimationFrame(() => {
@@ -369,7 +362,8 @@ export function showCanvasView() {
     canvasArea.style.width = "100%";
     canvasArea.style.flex = "1 1 100%";
 
-    if (switchViewsBtn) switchViewsBtn.textContent = "Code >>";
+    if (canvasToggleBtn) canvasToggleBtn.setAttribute("aria-pressed", "true");
+    if (codeToggleBtn) codeToggleBtn.setAttribute("aria-pressed", "false");
   }
 
   onResize();
@@ -479,10 +473,7 @@ function togglePanels() {
   if (!isNarrowScreen()) {
     return;
   }
-  if (!switchViewsBtn) return;
-
-  // Check button text instead of currentView to avoid state mismatch
-  if (switchViewsBtn.textContent === "Code >>") {
+  if (currentView === "canvas") {
     showCodeView();
   } else {
     showCanvasView();

--- a/style.css
+++ b/style.css
@@ -884,6 +884,7 @@ button {
     color: var(--color-primary);
   }
 
+  /* Inherit colour from theme */
   [data-theme='dark'] #bottomBar,
   [data-theme='dark-contrast'] #bottomBar,
   [data-theme='contrast'] #bottomBar,

--- a/style.css
+++ b/style.css
@@ -857,6 +857,7 @@ button {
 
   #viewToggle {
     display: flex;
+    gap: 6px;
     background-color: var(--color-primary);
     border-radius: 999px;
     padding: 4px;

--- a/style.css
+++ b/style.css
@@ -884,6 +884,23 @@ button {
     color: var(--color-primary);
   }
 
+  [data-theme='dark'] #bottomBar,
+  [data-theme='dark-contrast'] #bottomBar,
+  [data-theme='contrast'] #bottomBar,
+  [data-theme='low-vision'] #bottomBar,
+  [data-theme='dark'] #viewToggle,
+  [data-theme='dark-contrast'] #viewToggle,
+  [data-theme='contrast'] #viewToggle,
+  [data-theme='low-vision'] #viewToggle {
+    background-color: var(--color-bg);
+  }
+
+  [data-theme='dark'] .view-toggle-btn[aria-pressed='true'],
+  [data-theme='dark-contrast'] .view-toggle-btn[aria-pressed='true'],
+  [data-theme='low-vision'] .view-toggle-btn[aria-pressed='true'] {
+    color: #000;
+  }
+
   #blocklyZoomControls {
     bottom: calc(35px + max(0px, env(safe-area-inset-bottom, 0px)));
   }

--- a/style.css
+++ b/style.css
@@ -1,5 +1,5 @@
-@import url("./style/blockly.css");
-@import url("./ui/colourpicker.css");
+@import url('./style/blockly.css');
+@import url('./ui/colourpicker.css');
 
 :root {
   --app-height: 100vh;
@@ -62,7 +62,7 @@
 }
 
 /* Dark theme */
-[data-theme="dark"] {
+[data-theme='dark'] {
   /* Core colours */
   --color-bg: #2c2c2c;
   --color-bg-alt: #2a2a2a;
@@ -103,10 +103,7 @@
   --color-menu-item-text: var(--color-text);
   --color-dropdown-menu-bg: var(--color-bg);
   --color-dropdown-menu-hover: rgba(0, 0, 0, 0.05);
-  --color-dropdown-menu-border: var(
-    --color-dropdown-menu-border,
-    1px solid rgba(0, 0, 0, 0.1)
-  );
+  --color-dropdown-menu-border: var(--color-dropdown-menu-border, 1px solid rgba(0, 0, 0, 0.1));
 
   --color-dropdown-bg: #333333;
   --color-dropdown-hover: #555555;
@@ -129,7 +126,7 @@
 }
 
 /* Dark high-contrast theme */
-[data-theme="dark-contrast"] {
+[data-theme='dark-contrast'] {
   /* Core colours */
   --color-bg: #090909;
   --color-bg-alt: #2a2a2a;
@@ -170,10 +167,7 @@
   --color-menu-item-text: var(--color-text);
   --color-dropdown-menu-bg: var(--color-bg);
   --color-dropdown-menu-hover: rgba(0, 0, 0, 0.05);
-  --color-dropdown-menu-border: var(
-    --color-dropdown-menu-border,
-    1px solid rgba(0, 0, 0, 0.1)
-  );
+  --color-dropdown-menu-border: var(--color-dropdown-menu-border, 1px solid rgba(0, 0, 0, 0.1));
 
   --color-dropdown-bg: #333333;
   --color-dropdown-hover: #555555;
@@ -196,7 +190,7 @@
 }
 
 /* High‑contrast theme */
-[data-theme="contrast"] {
+[data-theme='contrast'] {
   /* Primary Brand Colors */
   --color-primary: #511d91;
   --color-primary-light: #fc3;
@@ -255,7 +249,7 @@
 }
 
 /* Low-vision theme */
-[data-theme="low-vision"] {
+[data-theme='low-vision'] {
   --color-bg: #121212;
   --color-bg-alt: #1e1e1e;
   --color-text: #f0f0f0;
@@ -283,23 +277,22 @@
   --color-error-border: #ffb4ab;
 }
 
-
 ::placeholder {
   color: var(--color-text-primary);
 }
 
-[data-theme="contrast"] #exampleSelect {
+[data-theme='contrast'] #exampleSelect {
   color: white !important;
   background-color: var(--color-bg) !important;
   border-style: solid;
   border-width: 1px;
 }
 
-[data-theme="dark"] #exampleSelect {
+[data-theme='dark'] #exampleSelect {
   background-color: var(--color-bg) !important;
 }
 
-[data-theme="dark-contrast"] #exampleSelect {
+[data-theme='dark-contrast'] #exampleSelect {
   background-color: var(--color-bg) !important;
 }
 
@@ -375,8 +368,7 @@
   font-size: 18px;
   font-weight: 500;
   margin: 0;
-  font-family:
-    "Atkinson Hyperlegible Next", "Asap", Helvetica, Arial, Lucida, sans-serif;
+  font-family: 'Atkinson Hyperlegible Next', 'Asap', Helvetica, Arial, Lucida, sans-serif;
   order: 4;
 }
 
@@ -438,7 +430,7 @@ body {
   gap: 0;
   box-sizing: border-box;
   font-family:
-    "Atkinson Hyperlegible Next", "Asap", Helvetica, Arial, Lucida, sans-serif !important;
+    'Atkinson Hyperlegible Next', 'Asap', Helvetica, Arial, Lucida, sans-serif !important;
   background: var(--color-bg);
   color: var(--color-text-primary);
 }
@@ -533,19 +525,19 @@ button {
   background-color: var(--color-border);
   margin: 0 4px;
 }
-[data-theme="dark"] #canvasArea {
+[data-theme='dark'] #canvasArea {
   background-color: #2c2c2c !important;
 }
 
-[data-theme="contrast"] #canvasArea {
+[data-theme='contrast'] #canvasArea {
   background-color: #000000 !important;
 }
 
-[data-theme="dark-contrast"] #canvasArea {
+[data-theme='dark-contrast'] #canvasArea {
   background-color: #090909 !important;
 }
 
-[data-theme="low-vision"] #canvasArea {
+[data-theme='low-vision'] #canvasArea {
   background-color: #121212 !important;
 }
 
@@ -607,8 +599,7 @@ button {
 
 /* Gizmo Buttons */
 .gizmo-buttons {
-  font-family:
-    "Atkinson Hyperlegible Next", "Asap", Helvetica, Arial, Lucida, sans-serif;
+  font-family: 'Atkinson Hyperlegible Next', 'Asap', Helvetica, Arial, Lucida, sans-serif;
   display: flex;
   flex-wrap: wrap;
   gap: 5px;
@@ -618,8 +609,7 @@ button {
 }
 
 .gizmo-button {
-  font-family:
-    "Atkinson Hyperlegible Next", "Asap", Helvetica, Arial, Lucida, sans-serif;
+  font-family: 'Atkinson Hyperlegible Next', 'Asap', Helvetica, Arial, Lucida, sans-serif;
   padding: 5px;
   font-size: 12px;
   cursor: pointer;
@@ -655,40 +645,40 @@ button {
   filter: none; /* light mode: normal */
 }
 /* Only apply to flock icons, not Babylon.js icons */
-[data-theme="dark"] #flockeditor .icon path {
+[data-theme='dark'] #flockeditor .icon path {
   fill: #bababa !important;
 }
 
-[data-theme="dark-contrast"] #flockeditor .icon path {
+[data-theme='dark-contrast'] #flockeditor .icon path {
   fill: #cdcdcd !important;
 }
 
-[data-theme="contrast"] #flockeditor .icon path {
+[data-theme='contrast'] #flockeditor .icon path {
   fill: #ffffff !important;
 }
 
-[data-theme="low-vision"] #flockeditor .icon path {
+[data-theme='low-vision'] #flockeditor .icon path {
   fill: #f0f0f0 !important;
 }
 
-[data-theme="contrast"] .gizmo-button img {
+[data-theme='contrast'] .gizmo-button img {
   color: #ffffff !important;
 }
 
-[data-theme="contrast"] .bigbutton svg {
+[data-theme='contrast'] .bigbutton svg {
   color: #ffffff !important;
 }
 
-[data-theme="low-vision"] .gizmo-button img,
-[data-theme="low-vision"] .bigbutton svg {
+[data-theme='low-vision'] .gizmo-button img,
+[data-theme='low-vision'] .bigbutton svg {
   color: #f0f0f0 !important;
 }
 
 /* Make links in 'About' modal visible in dark and contrast themes */
-[data-theme="dark"] .modal-content a,
-[data-theme="dark-contrast"] .modal-content a,
-[data-theme="contrast"] .modal-content a,
-[data-theme="low-vision"] .modal-content a {
+[data-theme='dark'] .modal-content a,
+[data-theme='dark-contrast'] .modal-content a,
+[data-theme='contrast'] .modal-content a,
+[data-theme='low-vision'] .modal-content a {
   color: var(--color-primary-light);
 }
 
@@ -790,7 +780,7 @@ button {
 #model-row::after,
 #object-row::after,
 #character-row::after {
-  content: "";
+  content: '';
   flex: 0 0 10px;
 }
 
@@ -853,16 +843,15 @@ button {
     bottom: 0;
     left: 0;
     width: 100vw;
-    height: calc(24px + max(8px, env(safe-area-inset-bottom, 0px)));
+    height: calc(52px + max(0px, env(safe-area-inset-bottom, 0px)));
     background-color: var(--color-primary);
     color: var(--color-text-on-primary);
-    text-align: center;
     display: flex;
     justify-content: center;
     align-items: flex-start;
     box-sizing: border-box;
     padding-top: 8px;
-    padding-bottom: max(8px, env(safe-area-inset-bottom, 0px));
+    padding-bottom: max(0px, env(safe-area-inset-bottom, 0px));
     z-index: 1000;
   }
 
@@ -884,16 +873,18 @@ button {
     cursor: pointer;
     border-radius: 999px;
     touch-action: manipulation;
-    transition: background-color 0.15s, color 0.15s;
+    transition:
+      background-color 0.15s,
+      color 0.15s;
   }
 
-  .view-toggle-btn[aria-pressed="true"] {
+  .view-toggle-btn[aria-pressed='true'] {
     background-color: white;
     color: var(--color-primary);
   }
 
   #blocklyZoomControls {
-    bottom: calc(9px + max(8px, env(safe-area-inset-bottom, 0px)));
+    bottom: calc(35px + max(0px, env(safe-area-inset-bottom, 0px)));
   }
 
   .keyboard-open #blocklyZoomControls {
@@ -905,13 +896,11 @@ button {
   }
 
   #info-panel-tabs {
-    margin-bottom: calc(9px + max(8px, env(safe-area-inset-bottom, 0px)));
+    margin-bottom: calc(35px + max(0px, env(safe-area-inset-bottom, 0px)));
   }
 
   #blocklyDiv {
-    height: calc(
-      100% - 59px - max(8px, env(safe-area-inset-bottom, 0px))
-    ) !important;
+    height: calc(100% - 59px - max(0px, env(safe-area-inset-bottom, 0px))) !important;
   }
 }
 
@@ -993,7 +982,7 @@ button {
   }
 
   .resizer::before {
-    content: "";
+    content: '';
     position: absolute;
     top: 50%;
     left: 50%;
@@ -1050,18 +1039,18 @@ button {
   display: inline-block;
 }
 
-[data-theme="dark-contrast"] #main-menu a,
-[data-theme="low-vision"] #main-menu a {
+[data-theme='dark-contrast'] #main-menu a,
+[data-theme='low-vision'] #main-menu a {
   color: var(--color-text-primary);
 }
 
-[data-theme="dark-contrast"] #menuDropdown .menu-item .menu-label,
-[data-theme="low-vision"] #menuDropdown .menu-item .menu-label {
+[data-theme='dark-contrast'] #menuDropdown .menu-item .menu-label,
+[data-theme='low-vision'] #menuDropdown .menu-item .menu-label {
   color: var(--color-text-primary);
 }
 
-[data-theme="dark-contrast"] #menuDropdown .menu-item .menu-icon svg,
-[data-theme="low-vision"] #menuDropdown .menu-item .menu-icon svg {
+[data-theme='dark-contrast'] #menuDropdown .menu-item .menu-icon svg,
+[data-theme='low-vision'] #menuDropdown .menu-item .menu-icon svg {
   color: var(--color-text-primary);
 }
 
@@ -1148,19 +1137,19 @@ button {
   cursor: pointer;
 }
 
-[data-theme="dark-contrast"] input {
+[data-theme='dark-contrast'] input {
   border-style: solid;
 }
 
-[data-theme="dark"] input {
+[data-theme='dark'] input {
   border-style: solid;
 }
 
-[data-theme="contrast"] input {
+[data-theme='contrast'] input {
   border-style: solid;
 }
 
-[data-theme="low-vision"] input {
+[data-theme='low-vision'] input {
   border-style: solid;
 }
 
@@ -1186,14 +1175,13 @@ button {
   border: 0;
 }
 
-
 /* Enhanced focus indicators */
 button:focus,
 input:focus,
 select:focus,
 .gizmo-button:focus,
 details summary:focus,
-#menuDropdown [role="menuitem"]:focus {
+#menuDropdown [role='menuitem']:focus {
   outline: 3px solid var(--color-focus);
   outline-offset: 2px;
   z-index: 20;
@@ -1324,7 +1312,7 @@ body.color-picker-open #renderCanvas {
 }
 
 /* Ensure interactive elements have proper focus order */
-[tabindex="-1"] {
+[tabindex='-1'] {
   outline: none;
 }
 
@@ -1411,14 +1399,14 @@ body.color-picker-open #renderCanvas {
   fill: var(--color-text-brand);
 }
 
-.menu-item[aria-haspopup="true"]::after {
-  content: "▶";
+.menu-item[aria-haspopup='true']::after {
+  content: '▶';
   color: var(--color-text-brand);
   font-size: 14px;
   margin-left: auto;
 }
 
-[data-theme="contrast"] .menu-item[aria-haspopup="true"]:hover::after {
+[data-theme='contrast'] .menu-item[aria-haspopup='true']:hover::after {
   color: black;
 }
 
@@ -1429,7 +1417,7 @@ body.color-picker-open #renderCanvas {
 }
 
 .menu-item,
-#menuDropdown [role="menuitem"] {
+#menuDropdown [role='menuitem'] {
   display: flex !important;
   align-items: center;
   padding: 8px 12px;
@@ -1446,15 +1434,15 @@ body.color-picker-open #renderCanvas {
   background-color: var(--color-menu-hover);
 }
 
-[data-theme="contrast"] .menu-item:hover .menu-label {
+[data-theme='contrast'] .menu-item:hover .menu-label {
   color: black;
 }
 
-[data-theme="contrast"] #main-menu a:hover {
+[data-theme='contrast'] #main-menu a:hover {
   color: black;
 }
 
-[data-theme="contrast"] .menu-item:hover .menu-icon svg {
+[data-theme='contrast'] .menu-item:hover .menu-icon svg {
   fill: black;
 }
 
@@ -1557,7 +1545,7 @@ body.color-picker-open #renderCanvas {
 
 /* Animate the invalid cursor when trying to place on an invalid target */
 .canvas-selector-circle--no-hit::before {
-  content: "";
+  content: '';
   position: absolute;
   top: 50%;
   left: 50%;
@@ -1665,7 +1653,6 @@ body.color-picker-open #renderCanvas {
   table-layout: fixed;
 }
 
-
 #shortcuts-table td {
   padding: 0.5em;
   vertical-align: top;
@@ -1719,7 +1706,6 @@ kbd {
 #info-panel-tabs #flocklink {
   order: 999;
 }
-
 
 #info-panel-body {
   background-color: inherit;
@@ -1801,7 +1787,7 @@ kbd {
   align-items: center;
   gap: 12px;
   padding: 12px 16px;
-  font-family: "Asap", sans-serif;
+  font-family: 'Asap', sans-serif;
   font-size: 16px;
   box-shadow: 0 2px 4px var(--color-shadow-medium);
 }

--- a/style.css
+++ b/style.css
@@ -859,21 +859,30 @@ button {
     z-index: 1000;
   }
 
-  #switchViews {
+  #viewToggle {
+    display: flex;
+    background-color: var(--color-primary);
+    border-radius: 999px;
+    padding: 4px;
+    border: 2px solid rgba(255, 255, 255, 0.3);
+  }
+
+  .view-toggle-btn {
     background-color: transparent;
     border: none;
     color: var(--color-text-on-primary);
-    width: 100%;
-    height: 100%;
-    padding: 0;
-    margin: 0;
+    padding: 2px 20px;
     font-size: 16px;
+    font-weight: 600;
     cursor: pointer;
-    border-radius: 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    border-radius: 999px;
     touch-action: manipulation;
+    transition: background-color 0.15s, color 0.15s;
+  }
+
+  .view-toggle-btn[aria-pressed="true"] {
+    background-color: white;
+    color: var(--color-primary);
   }
 
   #blocklyZoomControls {


### PR DESCRIPTION
# Summary
Adds a pill toggle to switch between canvas and code views in mobile layout 

<img width="736" height="1027" alt="image" src="https://github.com/user-attachments/assets/0e2dc203-2a16-4a0f-9994-cb470032cb74" />

- Pill toggle also now works in thin browser windows (previously unusable)
- Themes pick up colours properly to match their own background
- Pill toggle is correctly inserted in tab order for each view if it's being used in a browser

## AI usage
Claude Sonnet 4.6 used throughout, supervised by a human. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned view toggle interface with dedicated Canvas and Code buttons for clearer switching between modes.
  * Enhanced mobile support with safe-area inset adjustments to properly display content on notched devices.

* **Style & Accessibility**
  * Improved responsive behavior on screens 1024px or narrower.
  * Enhanced keyboard navigation and focus management for better usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->