### PR TITLE
Mobile bugfixes 

### DIFF
--- a/main/blocklyinit.js
+++ b/main/blocklyinit.js
@@ -926,6 +926,10 @@ export function initializeWorkspace() {
 
     const attachInputListeners = (input) => {
       input.setAttribute('autocomplete', 'one-time-code');
+      let pointerDownOnSearch = false;
+      input.addEventListener('pointerdown', () => {
+        pointerDownOnSearch = true;
+      });
       input.addEventListener('keydown', (e) => {
         if (e.key === 'Enter') {
           e.preventDefault();
@@ -959,7 +963,9 @@ export function initializeWorkspace() {
       input.addEventListener('focus', () => {
         clearTimeout(blurTimeout);
         blurTimeout = null;
-        if (!overlay.isConnected && isMobile()) openOverlay();
+        const fromDirectTap = pointerDownOnSearch;
+        pointerDownOnSearch = false;
+        if (!overlay.isConnected && isMobile() && fromDirectTap) openOverlay();
       });
       input.addEventListener('input', () => {
         if (resultsPanel.isConnected) updateResults();

--- a/main/blocklyinit.js
+++ b/main/blocklyinit.js
@@ -926,10 +926,6 @@ export function initializeWorkspace() {
 
     const attachInputListeners = (input) => {
       input.setAttribute('autocomplete', 'one-time-code');
-      let pointerDownOnSearch = false;
-      input.addEventListener('pointerdown', () => {
-        pointerDownOnSearch = true;
-      });
       input.addEventListener('keydown', (e) => {
         if (e.key === 'Enter') {
           e.preventDefault();
@@ -963,9 +959,7 @@ export function initializeWorkspace() {
       input.addEventListener('focus', () => {
         clearTimeout(blurTimeout);
         blurTimeout = null;
-        const fromDirectTap = pointerDownOnSearch;
-        pointerDownOnSearch = false;
-        if (!overlay.isConnected && isMobile() && fromDirectTap) openOverlay();
+        if (!overlay.isConnected && isMobile()) openOverlay();
       });
       input.addEventListener('input', () => {
         if (resultsPanel.isConnected) updateResults();

--- a/main/main.js
+++ b/main/main.js
@@ -1020,7 +1020,18 @@ function initializeApp() {
   runCodeButton.removeAttribute("disabled");
   if (exampleSelect) exampleSelect.removeAttribute("disabled");
 
-  if (fullscreenToggle) fullscreenToggle.removeAttribute("disabled");
+  if (fullscreenToggle) {
+    const fullscreenSupported =
+      document.documentElement.requestFullscreen ||
+      document.documentElement.mozRequestFullScreen ||
+      document.documentElement.webkitRequestFullscreen ||
+      document.documentElement.msRequestFullscreen;
+    if (fullscreenSupported) {
+      fullscreenToggle.removeAttribute("disabled");
+    } else {
+      fullscreenToggle.style.display = "none";
+    }
+  }
 
   // Add event listeners for buttons and controls
   /*toolboxControl.addEventListener("mouseover", function () {

--- a/main/view.js
+++ b/main/view.js
@@ -531,7 +531,7 @@ export function togglePlayMode() {
     blocklyArea.style.display = "block";
     canvasArea.style.display = "";
     gizmoButtons.style.display = "block";
-    bottomBar.style.display = "block";
+    bottomBar.style.display = "";
     flockLink.style.display = "block";
     if (resizer) resizer.style.display = "block";
     document.documentElement.style.setProperty("--dynamic-offset", "65px");

--- a/main/view.js
+++ b/main/view.js
@@ -337,6 +337,8 @@ function showCodeView() {
 }
 
 export function showCanvasView() {
+  window.flockWorkspaceSearch?.close();
+
   const gizmoButtons = document.getElementById("gizmoButtons");
   const flockLink = document.getElementById("flocklink");
   if (!gizmoButtons || !flockLink) return;

--- a/main/view.js
+++ b/main/view.js
@@ -500,6 +500,7 @@ export function togglePlayMode() {
   const gizmoButtons = document.getElementById("gizmoButtons");
   const bottomBar = document.getElementById("bottomBar");
   const flockLink = document.getElementById("flocklink");
+  const infoPanel = document.getElementById("info-panel");
   const resizer = document.getElementById("resizer");
   if (!blocklyArea || !canvasArea || !gizmoButtons || !bottomBar || !flockLink) {
     return;
@@ -520,10 +521,12 @@ export function togglePlayMode() {
 
     showCanvasView();
     if (flock.scene) flock.scene.debugLayer.hide();
+    window.flockShortcutsPanel?.hide();
     blocklyArea.style.display = "none";
     gizmoButtons.style.display = "none";
     bottomBar.style.display = "none";
     flockLink.style.display = "none";
+    if (infoPanel) infoPanel.style.display = "none";
     if (resizer) resizer.style.display = "none";
     document.documentElement.style.setProperty("--dynamic-offset", "40px");
   } else {
@@ -533,6 +536,7 @@ export function togglePlayMode() {
     gizmoButtons.style.display = "block";
     bottomBar.style.display = "";
     flockLink.style.display = "block";
+    if (infoPanel) infoPanel.style.display = "";
     if (resizer) resizer.style.display = "block";
     document.documentElement.style.setProperty("--dynamic-offset", "65px");
 

--- a/main/view.js
+++ b/main/view.js
@@ -296,6 +296,7 @@ const canvasToggleBtn = document.getElementById("canvasToggleBtn");
 const codeToggleBtn = document.getElementById("codeToggleBtn");
 
 let savedView = "canvas";
+let savedShortcutsVisible = false;
 
 function addButtonListener() {
   if (canvasToggleBtn) canvasToggleBtn.addEventListener("click", showCanvasView);
@@ -523,6 +524,7 @@ export function togglePlayMode() {
 
     showCanvasView();
     if (flock.scene) flock.scene.debugLayer.hide();
+    savedShortcutsVisible = !(window.flockShortcutsPanel?.panel?.classList.contains("hidden") ?? true);
     window.flockShortcutsPanel?.hide();
     blocklyArea.style.display = "none";
     gizmoButtons.style.display = "none";
@@ -540,6 +542,10 @@ export function togglePlayMode() {
     flockLink.style.display = "block";
     if (infoPanel) infoPanel.style.display = "";
     if (resizer) resizer.style.display = "block";
+    if (savedShortcutsVisible) {
+      window.flockShortcutsPanel?.show();
+      savedShortcutsVisible = false;
+    }
     document.documentElement.style.setProperty("--dynamic-offset", "65px");
 
     // On narrow screens, restore the saved view

--- a/style.css
+++ b/style.css
@@ -494,12 +494,6 @@ button {
   position: relative;
 }
 
-@media (min-width: 769px) {
-  #workspaceSearchBtn,
-  #workspaceSearchBtn + .toolbar-divider {
-    display: none;
-  }
-}
 
 #blocklyZoomControls {
   position: absolute;

--- a/style.css
+++ b/style.css
@@ -913,7 +913,7 @@ button {
   }
 
   #blocklyDiv {
-    height: calc(100% - 59px - max(0px, env(safe-area-inset-bottom, 0px))) !important;
+    height: calc(100% - 85px - max(0px, env(safe-area-inset-bottom, 0px))) !important;
   }
 }
 

--- a/style/blockly.css
+++ b/style/blockly.css
@@ -284,6 +284,11 @@ body[data-theme='low-vision'] {
   paint-order: stroke fill;
 }
 
+/* Suppress the Zelos selection glow path when the search outline is already showing */
+#blocklyDiv.blockly-search-active .ws-search-current > path.blocklyPathSelected {
+  display: none;
+}
+
 @media (min-width: 769px) {
   .blocklyTreeRow {
     flex-direction: row;


### PR DESCRIPTION
# Summary
Fix a lot of annoying bugs arising on mobile/tablet.

- Workspace search button now visible in desktop mode too because it's useful 🎉 
- Fullscreen button is hidden if fullscreen is not supported (on mobile)
- When in the 'play' mode (the gamepad button) the UI is suppressed except for the top bar
- If you're mid workspace search and switch to canvas, close the workspace search bar
- If you're mid workspace search and you click on the block that is the current result, there is no longer a duplicate outline

### AI usage
Claude Sonnet 4.6 was used throughout, and also for some other bits which didn't end up working so I reverted. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fullscreen button now intelligently enables/disables based on browser Fullscreen API support.
  * Fixed visual conflict where search result highlight and selection indicator displayed simultaneously.
  * Mobile workspace layout height calculations adjusted for improved display accuracy.
  * Search panel automatically closes when entering canvas view; info panel visibility now properly toggles with play mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->