### PR TITLE
Fix safari issue #663

### DIFF
--- a/flock.js
+++ b/flock.js
@@ -1921,7 +1921,7 @@ export const flock = {
 
     flock.audioEnginePromise.then((audioEngine) => {
       flock.audioEngine = audioEngine;
-      flock.globalStartTime = flock.getAudioContext().currentTime;
+      flock.globalStartTime = flock.getAudioContext()?.currentTime ?? 0;
       if (flock.scene.activeCamera) {
         audioEngine.listener.attach(flock.scene.activeCamera);
       }

--- a/index.html
+++ b/index.html
@@ -47,6 +47,12 @@
       });
     </script>
 
+    <script>
+      if (window.webkitAudioContext && !window.AudioContext) {
+        window.AudioContext = window.webkitAudioContext;
+      }
+    </script>
+
     <!-- Duplicate CSS to prevent flash of unstyled content on load, rest of styles in style.css -->
     <link rel="stylesheet" href="style.css" />
     <style>


### PR DESCRIPTION
Fix bug where Flock would have an error on Safari due to missing AudioContext. Closes #663 

Verified on iPhone and iPad

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audio initialization to gracefully handle scenarios where the audio context is not immediately available, preventing potential errors.
  * Enhanced cross-browser compatibility for WebKit-based browsers, ensuring proper AudioContext functionality across different browser engines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->