### PR TITLE
Allow switching between touch, mouse and keyboard control for axis gizmos

### DIFF
--- a/api/physics.js
+++ b/api/physics.js
@@ -120,6 +120,9 @@ export const flockPhysics = {
   },
   updatePhysics(mesh, parent = null) {
     if (!parent) parent = mesh;
+    if (mesh.scaling.x < 0.01) mesh.scaling.x = Math.max(0.01, Math.abs(mesh.scaling.x));
+    if (mesh.scaling.y < 0.01) mesh.scaling.y = Math.max(0.01, Math.abs(mesh.scaling.y));
+    if (mesh.scaling.z < 0.01) mesh.scaling.z = Math.max(0.01, Math.abs(mesh.scaling.z));
     mesh.computeWorldMatrix(true);
     mesh.refreshBoundingInfo(true);
     if (!parent.physics) return;

--- a/api/transform.js
+++ b/api/transform.js
@@ -677,7 +677,11 @@ export const flockTransform = {
               : (oldMinWorld.z + oldMaxWorld.z) / 2
         );
 
-        mesh.scaling = new flock.BABYLON.Vector3(scaleX, scaleY, scaleZ);
+        mesh.scaling = new flock.BABYLON.Vector3(
+          Math.max(0.001, Math.abs(scaleX)),
+          Math.max(0.001, Math.abs(scaleY)),
+          Math.max(0.001, Math.abs(scaleZ))
+        );
 
         if (maintainTextureScale) {
           const allMeshes = [mesh, ...mesh.getChildMeshes()];

--- a/api/transform.js
+++ b/api/transform.js
@@ -33,7 +33,7 @@ function applyPositionWithCurrentBaseRule(
 
   mesh.position.set(nextX, useY ? nextY : mesh.position.y, nextZ);
 
-  if (useY && !isCamera && typeof mesh.getBoundingInfo === "function") {
+  if (useY && !isCamera && typeof mesh.getBoundingInfo === 'function') {
     mesh.computeWorldMatrix(true);
     mesh.refreshBoundingInfo?.();
     const bi = mesh.getBoundingInfo();
@@ -678,9 +678,9 @@ export const flockTransform = {
         );
 
         mesh.scaling = new flock.BABYLON.Vector3(
-          Math.max(0.001, Math.abs(scaleX)),
-          Math.max(0.001, Math.abs(scaleY)),
-          Math.max(0.001, Math.abs(scaleZ))
+          Math.max(0.01, Math.abs(scaleX)),
+          Math.max(0.01, Math.abs(scaleY)),
+          Math.max(0.01, Math.abs(scaleZ))
         );
 
         if (maintainTextureScale) {

--- a/ui/gizmo-mobile-hud.js
+++ b/ui/gizmo-mobile-hud.js
@@ -11,6 +11,7 @@ export function createGizmoMobileHud({
   showUniform = false,
   stepLabels = ["◁", "▷"],
   onAxisChange = null,
+  stepLabelsByAxis = null,
 }) {
   if (!flock.scene || !flock.canvas || !flock.GUI) return null;
 
@@ -79,11 +80,19 @@ export function createGizmoMobileHud({
     axisButtons[key] = btn;
   });
 
+  let arrowNegBtn = null;
+  let arrowPosBtn = null;
+
   function updateAxisButtons() {
     for (const { key, color } of AXIS_DEFS) {
       const selected = axis === key || axis === "all";
       axisButtons[key].background = color;
       axisButtons[key].thickness = selected ? 6 * s : 2 * s;
+    }
+    if (stepLabelsByAxis && arrowNegBtn && arrowPosBtn) {
+      const labels = stepLabelsByAxis[axis] ?? stepLabels;
+      arrowNegBtn.textBlock.text = labels[0];
+      arrowPosBtn.textBlock.text = labels[1];
     }
     onAxisChange?.(axis);
   }
@@ -168,10 +177,11 @@ export function createGizmoMobileHud({
       btn.onPointerOutObservable.add(stopRepeat);
 
       cleanups.push(stopRepeat);
+      return btn;
     }
 
-    makeArrowButton(stepLabels[0], -1, 0);
-    makeArrowButton(stepLabels[1], +1, 1);
+    arrowNegBtn = makeArrowButton(stepLabels[0], -1, 0);
+    arrowPosBtn = makeArrowButton(stepLabels[1], +1, 1);
 
   } else {
     // ── Slider (delta-drag) ───────────────────────────────────────────────

--- a/ui/gizmo-mobile-hud.js
+++ b/ui/gizmo-mobile-hud.js
@@ -3,10 +3,6 @@ import { translate } from "../main/translation.js";
 
 const fontFamily = "Atkinson Hyperlegible Next";
 
-function isTouchDevice() {
-  return window.matchMedia("(pointer: coarse)").matches;
-}
-
 export function createGizmoMobileHud({
   onMove,
   stepNormal,
@@ -15,7 +11,6 @@ export function createGizmoMobileHud({
   showUniform = false,
   stepLabels = ["◁", "▷"],
 }) {
-  if (!isTouchDevice()) return null;
   if (!flock.scene || !flock.canvas || !flock.GUI) return null;
 
   const s = flock.displayScale ?? 1;

--- a/ui/gizmo-mobile-hud.js
+++ b/ui/gizmo-mobile-hud.js
@@ -10,6 +10,7 @@ export function createGizmoMobileHud({
   mode = "slider",
   showUniform = false,
   stepLabels = ["◁", "▷"],
+  onAxisChange = null,
 }) {
   if (!flock.scene || !flock.canvas || !flock.GUI) return null;
 
@@ -84,6 +85,7 @@ export function createGizmoMobileHud({
       axisButtons[key].background = color;
       axisButtons[key].thickness = selected ? 6 * s : 2 * s;
     }
+    onAxisChange?.(axis);
   }
   updateAxisButtons();
 

--- a/ui/gizmo-mobile-hud.js
+++ b/ui/gizmo-mobile-hud.js
@@ -1,15 +1,15 @@
-import { flock } from "../flock.js";
-import { translate } from "../main/translation.js";
+import { flock } from '../flock.js';
+import { translate } from '../main/translation.js';
 
-const fontFamily = "Atkinson Hyperlegible Next";
+const fontFamily = 'Atkinson Hyperlegible Next';
 
 export function createGizmoMobileHud({
   onMove,
   stepNormal,
   stepFast,
-  mode = "slider",
+  mode = 'slider',
   showUniform = false,
-  stepLabels = ["◁", "▷"],
+  stepLabels = ['◁', '▷'],
   onAxisChange = null,
   stepLabelsByAxis = null,
 }) {
@@ -23,19 +23,19 @@ export function createGizmoMobileHud({
   if (flock._joystickSource) flock._joystickSource.pause();
 
   const hudTexture = flock.GUI.AdvancedDynamicTexture.CreateFullscreenUI(
-    "GizmoHUD",
+    'GizmoHUD',
     true,
-    flock.scene,
+    flock.scene
   );
 
   // ── Axis state ────────────────────────────────────────────────────────────
-  let axis = "x";
+  let axis = 'x';
 
   const AXIS_DEFS = [
-    { key: "x", label: "X", color: "#0072B2" },
-    { key: "y", label: "Y", color: "#009E73" },
-    { key: "z", label: "Z", color: "#D55E00" },
-    ...(showUniform ? [{ key: "all", label: "*", color: "#aaaaaa" }] : []),
+    { key: 'x', label: 'X', color: '#0072B2' },
+    { key: 'y', label: 'Y', color: '#009E73' },
+    { key: 'z', label: 'Z', color: '#D55E00' },
+    ...(showUniform ? [{ key: 'all', label: '*', color: '#aaaaaa' }] : []),
   ];
   const numAxes = AXIS_DEFS.length;
 
@@ -49,10 +49,10 @@ export function createGizmoMobileHud({
   const TOTAL_H = BTN_SIZE + 2 * GAP;
 
   // ── Transparent container ─────────────────────────────────────────────────
-  const container = new flock.GUI.Rectangle("gizmoHudContainer");
+  const container = new flock.GUI.Rectangle('gizmoHudContainer');
   container.width = `${canvas.width}px`;
   container.height = `${TOTAL_H}px`;
-  container.background = "transparent";
+  container.background = 'transparent';
   container.thickness = 0;
   container.horizontalAlignment = flock.GUI.Control.HORIZONTAL_ALIGNMENT_LEFT;
   container.verticalAlignment = flock.GUI.Control.VERTICAL_ALIGNMENT_BOTTOM;
@@ -69,7 +69,7 @@ export function createGizmoMobileHud({
     btn.fontSize = `${Math.min(40 * s, Math.floor(BTN_SIZE * 0.55))}px`;
     btn.fontFamily = fontFamily;
     btn.cornerRadius = 8 * s;
-    btn.color = "white";
+    btn.color = 'white';
     btn.thickness = 3 * s;
     btn.isPointerBlocker = true;
     btn.horizontalAlignment = flock.GUI.Control.HORIZONTAL_ALIGNMENT_LEFT;
@@ -85,7 +85,7 @@ export function createGizmoMobileHud({
 
   function updateAxisButtons() {
     for (const { key, color } of AXIS_DEFS) {
-      const selected = axis === key || axis === "all";
+      const selected = axis === key || axis === 'all';
       axisButtons[key].background = color;
       axisButtons[key].thickness = selected ? 6 * s : 2 * s;
     }
@@ -103,9 +103,9 @@ export function createGizmoMobileHud({
       if (axis !== key) {
         axis = key;
         flock.printText({
-          text: translate(key === "all" ? "axis_all" : `axis_${key}`),
+          text: translate(key === 'all' ? 'axis_all' : `axis_${key}`),
           duration: 10,
-          color: "black",
+          color: 'black',
         });
         updateAxisButtons();
       }
@@ -115,7 +115,7 @@ export function createGizmoMobileHud({
   // ── Left half: slider or arrow buttons ───────────────────────────────────
   const cleanups = [];
 
-  if (mode === "arrows") {
+  if (mode === 'arrows') {
     // ── Arrow buttons (◁ ▷) — square, centred in left half ───────────────
     const arrowTotalW = 2 * BTN_SIZE + 3 * GAP;
     const arrowOffsetX = (HALF - arrowTotalW) / 2;
@@ -128,8 +128,8 @@ export function createGizmoMobileHud({
       btn.fontSize = `${Math.min(40 * s, Math.floor(BTN_SIZE * 0.55))}px`;
       btn.fontFamily = fontFamily;
       btn.cornerRadius = 8 * s;
-      btn.background = "transparent";
-      btn.color = "white";
+      btn.background = 'transparent';
+      btn.color = 'white';
       btn.thickness = 3 * s;
       btn.isPointerBlocker = true;
       btn.horizontalAlignment = flock.GUI.Control.HORIZONTAL_ALIGNMENT_LEFT;
@@ -151,10 +151,10 @@ export function createGizmoMobileHud({
 
       function step() {
         const d = sign * currentStep();
-        if (axis === "all") onMove(d, d, d);
-        else if (axis === "x") onMove(d, 0, 0);
-        else if (axis === "y") onMove(0, d, 0);
-        else if (axis === "z") onMove(0, 0, d);
+        if (axis === 'all') onMove(d, d, d);
+        else if (axis === 'x') onMove(d, 0, 0);
+        else if (axis === 'y') onMove(0, d, 0);
+        else if (axis === 'z') onMove(0, 0, d);
       }
 
       function startRepeat() {
@@ -182,7 +182,7 @@ export function createGizmoMobileHud({
 
     arrowNegBtn = makeArrowButton(stepLabels[0], -1, 0);
     arrowPosBtn = makeArrowButton(stepLabels[1], +1, 1);
-
+    updateAxisButtons();
   } else {
     // ── Slider (delta-drag) ───────────────────────────────────────────────
     const THUMB_R = Math.floor(BTN_SIZE / 2) - 2 * s;
@@ -192,10 +192,10 @@ export function createGizmoMobileHud({
     const SPEED_FACTOR = stepFast / 10;
     const TRACK_CENTER_Y = TOTAL_H / 2;
 
-    const track = new flock.GUI.Rectangle("gizmoTrack");
+    const track = new flock.GUI.Rectangle('gizmoTrack');
     track.width = `${HALF - 2 * SLIDER_MARGIN}px`;
     track.height = `${TRACK_H}px`;
-    track.background = "rgba(255,255,255,0.3)";
+    track.background = 'rgba(255,255,255,0.3)';
     track.thickness = 0;
     track.cornerRadius = TRACK_H / 2;
     track.horizontalAlignment = flock.GUI.Control.HORIZONTAL_ALIGNMENT_LEFT;
@@ -204,10 +204,10 @@ export function createGizmoMobileHud({
     track.top = `${TRACK_CENTER_Y - TRACK_H / 2}px`;
     container.addControl(track);
 
-    const centerMark = new flock.GUI.Rectangle("gizmoCenterMark");
+    const centerMark = new flock.GUI.Rectangle('gizmoCenterMark');
     centerMark.width = `${4 * s}px`;
     centerMark.height = `${TRACK_H + 10 * s}px`;
-    centerMark.background = "rgba(255,255,255,0.55)";
+    centerMark.background = 'rgba(255,255,255,0.55)';
     centerMark.thickness = 0;
     centerMark.horizontalAlignment = flock.GUI.Control.HORIZONTAL_ALIGNMENT_LEFT;
     centerMark.verticalAlignment = flock.GUI.Control.VERTICAL_ALIGNMENT_TOP;
@@ -215,11 +215,11 @@ export function createGizmoMobileHud({
     centerMark.top = `${TRACK_CENTER_Y - (TRACK_H + 10 * s) / 2}px`;
     container.addControl(centerMark);
 
-    const thumb = new flock.GUI.Ellipse("gizmoThumb");
+    const thumb = new flock.GUI.Ellipse('gizmoThumb');
     thumb.width = `${THUMB_R * 2}px`;
     thumb.height = `${THUMB_R * 2}px`;
-    thumb.background = "rgba(255,255,255,0.85)";
-    thumb.color = "transparent";
+    thumb.background = 'rgba(255,255,255,0.85)';
+    thumb.color = 'transparent';
     thumb.thickness = 0;
     thumb.horizontalAlignment = flock.GUI.Control.HORIZONTAL_ALIGNMENT_LEFT;
     thumb.verticalAlignment = flock.GUI.Control.VERTICAL_ALIGNMENT_TOP;
@@ -255,7 +255,7 @@ export function createGizmoMobileHud({
       const clampedCSS = Math.max(-b.maxOffsetCSS, Math.min(b.maxOffsetCSS, e.clientX - b.centerX));
       thumbOffsetGUI = clampedCSS / b.scale;
       thumb.left = `${HALF / 2 - THUMB_R + thumbOffsetGUI}px`;
-      thumb.background = "rgba(255,220,50,0.95)";
+      thumb.background = 'rgba(255,220,50,0.95)';
     }
 
     function onPointerMove(e) {
@@ -264,15 +264,15 @@ export function createGizmoMobileHud({
       lastClientX = e.clientX;
 
       const delta = deltaCSS * SPEED_FACTOR;
-      if (axis === "all") onMove(delta, delta, delta);
-      else if (axis === "x") onMove(delta, 0, 0);
-      else if (axis === "y") onMove(0, delta, 0);
-      else if (axis === "z") onMove(0, 0, delta);
+      if (axis === 'all') onMove(delta, delta, delta);
+      else if (axis === 'x') onMove(delta, 0, 0);
+      else if (axis === 'y') onMove(0, delta, 0);
+      else if (axis === 'z') onMove(0, 0, delta);
 
       const b = sliderBounds();
       thumbOffsetGUI = Math.max(
         -MAX_OFFSET_GUI,
-        Math.min(MAX_OFFSET_GUI, thumbOffsetGUI + deltaCSS / b.scale),
+        Math.min(MAX_OFFSET_GUI, thumbOffsetGUI + deltaCSS / b.scale)
       );
       thumb.left = `${HALF / 2 - THUMB_R + thumbOffsetGUI}px`;
     }
@@ -280,13 +280,13 @@ export function createGizmoMobileHud({
     function onPointerUp(e) {
       if (e.pointerId !== activePointer) return;
       activePointer = null;
-      thumb.background = "rgba(255,255,255,0.85)";
+      thumb.background = 'rgba(255,255,255,0.85)';
     }
 
-    canvas.addEventListener("pointerdown", onPointerDown);
-    canvas.addEventListener("pointermove", onPointerMove);
-    canvas.addEventListener("pointerup", onPointerUp);
-    canvas.addEventListener("pointercancel", onPointerUp);
+    canvas.addEventListener('pointerdown', onPointerDown);
+    canvas.addEventListener('pointermove', onPointerMove);
+    canvas.addEventListener('pointerup', onPointerUp);
+    canvas.addEventListener('pointercancel', onPointerUp);
 
     // Block camera/scene for slider touches — including the initial pointerdown
     const prePointerObserver = flock.scene.onPrePointerObservable.add((info) => {
@@ -295,20 +295,24 @@ export function createGizmoMobileHud({
         info.skipOnPointerObservable = true;
         return;
       }
-      if (e.type === "pointerdown") {
+      if (e.type === 'pointerdown') {
         const b = sliderBounds();
-        if (e.clientY >= b.top && e.clientY <= b.bottom &&
-            e.clientX >= b.left && e.clientX <= b.right) {
+        if (
+          e.clientY >= b.top &&
+          e.clientY <= b.bottom &&
+          e.clientX >= b.left &&
+          e.clientX <= b.right
+        ) {
           info.skipOnPointerObservable = true;
         }
       }
     });
 
     cleanups.push(() => {
-      canvas.removeEventListener("pointerdown", onPointerDown);
-      canvas.removeEventListener("pointermove", onPointerMove);
-      canvas.removeEventListener("pointerup", onPointerUp);
-      canvas.removeEventListener("pointercancel", onPointerUp);
+      canvas.removeEventListener('pointerdown', onPointerDown);
+      canvas.removeEventListener('pointermove', onPointerMove);
+      canvas.removeEventListener('pointerup', onPointerUp);
+      canvas.removeEventListener('pointercancel', onPointerUp);
       flock.scene.onPrePointerObservable.remove(prePointerObserver);
     });
   }

--- a/ui/gizmo-mobile-hud.js
+++ b/ui/gizmo-mobile-hud.js
@@ -80,7 +80,9 @@ export function createGizmoMobileHud({
 
   function updateAxisButtons() {
     for (const { key, color } of AXIS_DEFS) {
-      axisButtons[key].background = (axis === key || axis === "all") ? color : "transparent";
+      const selected = axis === key || axis === "all";
+      axisButtons[key].background = color;
+      axisButtons[key].thickness = selected ? 6 * s : 2 * s;
     }
   }
   updateAxisButtons();

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -80,7 +80,7 @@ const AXIS_SWITCH_KEYS = new Set([
   "x", "X", "y", "Y", "z", "Z", "u", "U",
 ]);
 
-function createAdaptiveInput({ onMove, onConfirm, onCancel, stepNormal, stepFast, mode, showUniform, stepLabels, onHudShow, onHudHide, onAxisChange }) {
+function createAdaptiveInput({ onMove, onConfirm, onCancel, stepNormal, stepFast, mode, showUniform, stepLabels, onHudShow, onHudHide, onAxisChange, stepLabelsByAxis }) {
   let stopHud = null;
   let stopKeyboard = null;
   const canvas = flock.canvas;
@@ -88,7 +88,7 @@ function createAdaptiveInput({ onMove, onConfirm, onCancel, stepNormal, stepFast
   function switchToTouch() {
     if (stopKeyboard) { stopKeyboard(); stopKeyboard = null; }
     if (!stopHud) {
-      stopHud = createGizmoMobileHud({ onMove, stepNormal, stepFast, mode, showUniform, stepLabels, onAxisChange });
+      stopHud = createGizmoMobileHud({ onMove, stepNormal, stepFast, mode, showUniform, stepLabels, onAxisChange, stepLabelsByAxis });
       onHudShow?.();
     }
   }
@@ -666,6 +666,7 @@ function startMoveKeyboardHandler(mesh) {
     stepNormal: DEFAULT_CURSOR,
     stepFast: FAST_CURSOR,
     mode: 'arrows',
+    stepLabelsByAxis: { x: ['◁', '▷'], y: ['▽', '△'], z: ['▽', '△'], all: ['◁', '▷'] },
   });
 }
 

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -80,7 +80,7 @@ const AXIS_SWITCH_KEYS = new Set([
   "x", "X", "y", "Y", "z", "Z", "u", "U",
 ]);
 
-function createAdaptiveInput({ onMove, onConfirm, onCancel, stepNormal, stepFast, mode, showUniform, stepLabels }) {
+function createAdaptiveInput({ onMove, onConfirm, onCancel, stepNormal, stepFast, mode, showUniform, stepLabels, onHudShow, onHudHide, onAxisChange }) {
   let stopHud = null;
   let stopKeyboard = null;
   const canvas = flock.canvas;
@@ -88,12 +88,16 @@ function createAdaptiveInput({ onMove, onConfirm, onCancel, stepNormal, stepFast
   function switchToTouch() {
     if (stopKeyboard) { stopKeyboard(); stopKeyboard = null; }
     if (!stopHud) {
-      stopHud = createGizmoMobileHud({ onMove, stepNormal, stepFast, mode, showUniform, stepLabels });
+      stopHud = createGizmoMobileHud({ onMove, stepNormal, stepFast, mode, showUniform, stepLabels, onAxisChange });
+      onHudShow?.();
     }
   }
 
   function switchToKeyboard() {
-    if (stopHud) { stopHud(); stopHud = null; }
+    if (stopHud) {
+      stopHud(); stopHud = null;
+      onHudHide?.();
+    }
     if (!stopKeyboard) {
       stopKeyboard = createAxisKeyboardHandler({ onMove, onConfirm, onCancel, stepNormal, stepFast });
     }
@@ -113,7 +117,7 @@ function createAdaptiveInput({ onMove, onConfirm, onCancel, stepNormal, stepFast
   return function stop() {
     canvas.removeEventListener("pointerdown", onCanvasPointer);
     flock.inputManager.onRawKeyDownObservable.remove(rawKeyObserver);
-    stopHud?.();
+    if (stopHud) { onHudHide?.(); stopHud(); stopHud = null; }
     stopKeyboard?.();
   };
 }
@@ -716,6 +720,39 @@ function startRotateKeyboardHandler(mesh) {
     stepNormal: DEFAULT_ROTATION,
     stepFast: FAST_ROTATION,
     mode: 'slider',
+    onHudShow: () => {
+      const rg = gizmoManager.gizmos?.rotationGizmo;
+      if (!rg) return;
+      rg.updateGizmoRotationToMatchAttachedMesh = true;
+      // Override validateDrag to block rotation while keeping dragBehavior enabled
+      // (disabling it causes Babylon.js to permanently grey out the arcs)
+      [rg.xGizmo, rg.yGizmo, rg.zGizmo].forEach((g) => {
+        if (!g?.dragBehavior) return;
+        g.dragBehavior._savedValidateDrag = g.dragBehavior.validateDrag;
+        g.dragBehavior.validateDrag = () => false;
+      });
+    },
+    onHudHide: () => {
+      const rg = gizmoManager.gizmos?.rotationGizmo;
+      if (!rg) return;
+      rg.updateGizmoRotationToMatchAttachedMesh = false;
+      [rg.xGizmo, rg.yGizmo, rg.zGizmo].forEach((g) => {
+        if (!g?.dragBehavior) return;
+        g.dragBehavior.validateDrag = g.dragBehavior._savedValidateDrag ?? (() => true);
+        delete g.dragBehavior._savedValidateDrag;
+        if (g._coloredMaterial) g._coloredMaterial.alpha = 1;
+      });
+    },
+    onAxisChange: (axis) => {
+      const rg = gizmoManager.gizmos?.rotationGizmo;
+      if (!rg) return;
+      const map = { x: rg.xGizmo, y: rg.yGizmo, z: rg.zGizmo };
+      Object.entries(map).forEach(([key, g]) => {
+        if (g?._coloredMaterial) {
+          g._coloredMaterial.alpha = (axis === key || axis === 'all') ? 1 : 0.2;
+        }
+      });
+    },
   });
 }
 
@@ -2130,6 +2167,7 @@ export function configurePositionGizmo(
   if (pg.zGizmo?._coloredMaterial) pg.zGizmo._coloredMaterial.diffuseColor = zColor;
 
   pg.updateGizmoPositionToMatchAttachedMesh = updateToMatchAttachedMesh;
+  pg.updateGizmoRotationToMatchAttachedMesh = false;
 }
 
 export function configureRotationGizmo(
@@ -2139,7 +2177,7 @@ export function configureRotationGizmo(
     xColor = blueColor,
     yColor = greenColor,
     zColor = orangeColor,
-    updateToMatchAttachedMesh = true,
+    updateToMatchAttachedMesh = false,
   } = {}
 ) {
   if (!gizmoManager) return;

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -780,6 +780,9 @@ function startScaleKeyboardHandler(mesh) {
     mesh.position.y += bottomY - mesh.getBoundingInfo().boundingBox.minimumWorld.y;
 
     flock.updatePhysics(mesh);
+    mesh.scaling.x = Math.max(0.01, mesh.scaling.x);
+    mesh.scaling.y = Math.max(0.01, mesh.scaling.y);
+    mesh.scaling.z = Math.max(0.01, mesh.scaling.z);
     updateScaleBlock(mesh);
   };
   const onConfirm = () => {
@@ -1059,6 +1062,9 @@ function updateScaleBlock(mesh, originalBottomY = null) {
   if (!block) return;
 
   flock.updatePhysics(mesh);
+  mesh.scaling.x = Math.max(0.01, mesh.scaling.x);
+  mesh.scaling.y = Math.max(0.01, mesh.scaling.y);
+  mesh.scaling.z = Math.max(0.01, mesh.scaling.z);
 
   try {
     const ensureFreshBounds = (m) => {
@@ -1074,9 +1080,9 @@ function updateScaleBlock(mesh, originalBottomY = null) {
     }
 
     const sizeLocal = bbox.extendSize.scale(2);
-    const w = sizeLocal.x * mesh.scaling.x;
-    const h = sizeLocal.y * mesh.scaling.y;
-    const d = sizeLocal.z * mesh.scaling.z;
+    const w = sizeLocal.x * Math.abs(mesh.scaling.x);
+    const h = sizeLocal.y * Math.abs(mesh.scaling.y);
+    const d = sizeLocal.z * Math.abs(mesh.scaling.z);
 
     switch (block.type) {
       case 'create_plane':
@@ -1459,6 +1465,10 @@ function handleScaleGizmo() {
 
   const scaleDrag = gizmoManager.gizmos.scaleGizmo.onDragObservable.add(() => {
     const mesh = gizmoManager.attachedMesh;
+
+    mesh.scaling.x = Math.max(0.01, mesh.scaling.x);
+    mesh.scaling.y = Math.max(0.01, mesh.scaling.y);
+    mesh.scaling.z = Math.max(0.01, mesh.scaling.z);
 
     mesh.computeWorldMatrix(true);
     mesh.refreshBoundingInfo();

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -74,6 +74,50 @@ const cleanupFns = [];
 // Track DO sections and their associated blocks for cleanup
 const gizmoCreatedBlocks = new Map(); // blockId -> { parentId, createdDoSection, timestamp }
 
+const AXIS_SWITCH_KEYS = new Set([
+  "ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown",
+  "PageUp", "PageDown",
+  "x", "X", "y", "Y", "z", "Z", "u", "U",
+]);
+
+function createAdaptiveInput({ onMove, onConfirm, onCancel, stepNormal, stepFast, mode, showUniform, stepLabels }) {
+  let stopHud = null;
+  let stopKeyboard = null;
+  const canvas = flock.canvas;
+
+  function switchToTouch() {
+    if (stopKeyboard) { stopKeyboard(); stopKeyboard = null; }
+    if (!stopHud) {
+      stopHud = createGizmoMobileHud({ onMove, stepNormal, stepFast, mode, showUniform, stepLabels });
+    }
+  }
+
+  function switchToKeyboard() {
+    if (stopHud) { stopHud(); stopHud = null; }
+    if (!stopKeyboard) {
+      stopKeyboard = createAxisKeyboardHandler({ onMove, onConfirm, onCancel, stepNormal, stepFast });
+    }
+  }
+
+  function onCanvasPointer(e) {
+    if (e.pointerType === "touch") switchToTouch();
+  }
+
+  function onRawKey(e) {
+    if (AXIS_SWITCH_KEYS.has(e.key)) switchToKeyboard();
+  }
+
+  canvas.addEventListener("pointerdown", onCanvasPointer);
+  const rawKeyObserver = flock.inputManager.onRawKeyDownObservable.add(onRawKey);
+
+  return function stop() {
+    canvas.removeEventListener("pointerdown", onCanvasPointer);
+    flock.inputManager.onRawKeyDownObservable.remove(rawKeyObserver);
+    stopHud?.();
+    stopKeyboard?.();
+  };
+}
+
 // Register input handlers for gizmo actions
 function registerBindings() {
   const noMod = (fn) => (e) => {
@@ -611,27 +655,14 @@ function startMoveKeyboardHandler(mesh) {
     document.getElementById('positionButton')?.focus();
   };
 
-  const stopHud = createGizmoMobileHud({
+  stopAxisKeyboard = createAdaptiveInput({
     onMove,
+    onConfirm,
+    onCancel,
     stepNormal: DEFAULT_CURSOR,
     stepFast: FAST_CURSOR,
     mode: 'arrows',
   });
-  stopAxisKeyboard = () => stopHud?.();
-
-  setTimeout(() => {
-    const stopKeyboard = createAxisKeyboardHandler({
-      onMove,
-      onConfirm,
-      onCancel,
-      stepNormal: DEFAULT_CURSOR,
-      stepFast: FAST_CURSOR,
-    });
-    stopAxisKeyboard = () => {
-      stopKeyboard();
-      stopHud?.();
-    };
-  }, 0);
 }
 
 // Rotate a mesh using the keyboard
@@ -678,27 +709,14 @@ function startRotateKeyboardHandler(mesh) {
     document.getElementById('rotationButton')?.focus();
   };
 
-  const stopHud = createGizmoMobileHud({
+  stopAxisKeyboard = createAdaptiveInput({
     onMove,
+    onConfirm,
+    onCancel,
     stepNormal: DEFAULT_ROTATION,
     stepFast: FAST_ROTATION,
     mode: 'slider',
   });
-  stopAxisKeyboard = () => stopHud?.();
-
-  setTimeout(() => {
-    const stopKeyboard = createAxisKeyboardHandler({
-      onMove,
-      onConfirm,
-      onCancel,
-      stepNormal: DEFAULT_ROTATION,
-      stepFast: FAST_ROTATION,
-    });
-    stopAxisKeyboard = () => {
-      stopKeyboard();
-      stopHud?.();
-    };
-  }, 0);
 }
 
 // Scale a mesh using the keyboard
@@ -743,29 +761,16 @@ function startScaleKeyboardHandler(mesh) {
     document.getElementById('scaleButton')?.focus();
   };
 
-  const stopHud = createGizmoMobileHud({
+  stopAxisKeyboard = createAdaptiveInput({
     onMove,
+    onConfirm,
+    onCancel,
     stepNormal: DEFAULT_SCALE,
     stepFast: FAST_SCALE,
     mode: 'arrows',
     showUniform: true,
     stepLabels: ['-', '+'],
   });
-  stopAxisKeyboard = () => stopHud?.();
-
-  setTimeout(() => {
-    const stopKeyboard = createAxisKeyboardHandler({
-      onMove,
-      onConfirm,
-      onCancel,
-      stepNormal: DEFAULT_SCALE,
-      stepFast: FAST_SCALE,
-    });
-    stopAxisKeyboard = () => {
-      stopKeyboard();
-      stopHud?.();
-    };
-  }, 0);
 }
 
 // Set a single numeric axis input on a block (e.g. "X", "Y", or "Z")
@@ -2134,7 +2139,7 @@ export function configureRotationGizmo(
     xColor = blueColor,
     yColor = greenColor,
     zColor = orangeColor,
-    updateToMatchAttachedMesh = false,
+    updateToMatchAttachedMesh = true,
   } = {}
 ) {
   if (!gizmoManager) return;

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -667,6 +667,8 @@ function startMoveKeyboardHandler(mesh) {
     stepFast: FAST_CURSOR,
     mode: 'arrows',
     stepLabelsByAxis: { x: ['◁', '▷'], y: ['▽', '△'], z: ['▽', '△'], all: ['◁', '▷'] },
+    onAxisChange: (axis) => highlightGizmoAxis(gizmoManager.gizmos?.positionGizmo, axis),
+    onHudHide: () => highlightGizmoAxis(gizmoManager.gizmos?.positionGizmo, null),
   });
 }
 
@@ -741,19 +743,10 @@ function startRotateKeyboardHandler(mesh) {
         if (!g?.dragBehavior) return;
         g.dragBehavior.validateDrag = g.dragBehavior._savedValidateDrag ?? (() => true);
         delete g.dragBehavior._savedValidateDrag;
-        if (g._coloredMaterial) g._coloredMaterial.alpha = 1;
       });
+      highlightGizmoAxis(rg, null);
     },
-    onAxisChange: (axis) => {
-      const rg = gizmoManager.gizmos?.rotationGizmo;
-      if (!rg) return;
-      const map = { x: rg.xGizmo, y: rg.yGizmo, z: rg.zGizmo };
-      Object.entries(map).forEach(([key, g]) => {
-        if (g?._coloredMaterial) {
-          g._coloredMaterial.alpha = (axis === key || axis === 'all') ? 1 : 0.2;
-        }
-      });
-    },
+    onAxisChange: (axis) => highlightGizmoAxis(gizmoManager.gizmos?.rotationGizmo, axis),
   });
 }
 
@@ -808,6 +801,8 @@ function startScaleKeyboardHandler(mesh) {
     mode: 'arrows',
     showUniform: true,
     stepLabels: ['-', '+'],
+    onAxisChange: (axis) => highlightGizmoAxis(gizmoManager.gizmos?.scaleGizmo, axis),
+    onHudHide: () => highlightGizmoAxis(gizmoManager.gizmos?.scaleGizmo, null),
   });
 }
 
@@ -1545,6 +1540,16 @@ function handleScaleGizmo() {
   });
 
   onExit(() => gizmoManager.gizmos.scaleGizmo.onDragEndObservable.remove(scaleDragEnd));
+}
+
+// Dim non-selected axis gizmo handles; pass axis=null to restore all to full opacity.
+function highlightGizmoAxis(gizmo, axis) {
+  const map = { x: gizmo?.xGizmo, y: gizmo?.yGizmo, z: gizmo?.zGizmo };
+  Object.entries(map).forEach(([key, g]) => {
+    if (g?._coloredMaterial) {
+      g._coloredMaterial.alpha = (!axis || axis === key || axis === 'all') ? 1 : 0.2;
+    }
+  });
 }
 
 // Rotation: Allow the user to rotate the mesh by dragging it


### PR DESCRIPTION
# Summary
- Allows switching between input modes for axis gizmos
- Recolours mobile HUD buttons to be clearer
- Babylon.js controls disabled when rotation gizmo is in use in mobile HUD mode due to odd behaviour
- Move gizmo now behaves properly with World axes not object. Mobile HUD buttons now reflect the direction of movement.
- Only the axis in use is highlighted in all axis gizmos
- Fixes a bug where you could resize an object to a negative size and it would go black and become unselectable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Object scaling values now clamped to prevent near-zero dimensions that could cause rendering and physics issues.

* **New Features**
  * Mobile gizmo control now supports customizable axis labels and callback functions.
  * Adaptive input system intelligently switches between touch and keyboard controls based on user activity.
  * Added visual axis highlighting on gizmo for clearer control feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->