### PR TITLE
Bug fix - keep selection

### DIFF
--- a/main/view.js
+++ b/main/view.js
@@ -1,7 +1,7 @@
 import * as Blockly from 'blockly';
 import { workspace } from './blocklyinit.js';
 import { flock } from '../flock.js';
-import { scrollToBlockTopParentLeft } from '../ui/blocklyutil.js';
+import { restoreBlockFocus, getLastHighlightedBlockId } from '../ui/blocklyutil.js';
 
 export const isNarrowScreen = () => {
   return window.innerWidth <= 1024;
@@ -33,8 +33,11 @@ export function onResize(mode) {
       Blockly.svgResize(workspace);
       if (mode === 'reset') workspace.scroll(scrollX, scrollY);
       if (mode === 'reset' && pendingScrollBlockId) {
-        scrollToBlockTopParentLeft(workspace, pendingScrollBlockId);
+        const blockId = pendingScrollBlockId;
         pendingScrollBlockId = null;
+        requestAnimationFrame(() => {
+          restoreBlockFocus(workspace, blockId);
+        });
       }
     }
   });
@@ -344,8 +347,10 @@ export function showCanvasView() {
   currentView = 'canvas';
 
   if (isNarrowScreen()) {
-    // Save the current block before hiding the panel — currentBlock may be cleared on hide.
-    pendingScrollBlockId = window.currentBlock?.id || null;
+    // Blockly.common.getSelected() is synchronous — reflects the click before the SELECTED
+    // event fires. window.currentBlock lags by one async event tick, so use getSelected() first.
+    const blockToRestore = Blockly.common.getSelected() ?? window.currentBlock;
+    pendingScrollBlockId = blockToRestore?.id || getLastHighlightedBlockId(workspace) || null;
 
     // Instead of CSS transform, change the layout directly
     const canvasArea = document.getElementById('canvasArea');

--- a/main/view.js
+++ b/main/view.js
@@ -349,7 +349,10 @@ export function showCanvasView() {
   if (isNarrowScreen()) {
     // Blockly.common.getSelected() is synchronous — reflects the click before the SELECTED
     // event fires. window.currentBlock lags by one async event tick, so use getSelected() first.
-    const blockToRestore = Blockly.common.getSelected() ?? window.currentBlock;
+    // getSelected() may return non-Block selectables; verify via getBlockById before using .id.
+    const selected = Blockly.common.getSelected();
+    const selectedBlock = selected ? workspace.getBlockById(selected.id) : null;
+    const blockToRestore = selectedBlock ?? window.currentBlock;
     pendingScrollBlockId = blockToRestore?.id || getLastHighlightedBlockId(workspace) || null;
 
     // Instead of CSS transform, change the layout directly

--- a/ui/blocklyutil.js
+++ b/ui/blocklyutil.js
@@ -63,6 +63,23 @@ export function appendWithUndo(spec, ws, groupId) {
   return block;
 }
 
+export function getLastHighlightedBlockId(workspace) {
+  return lastAddMenuHighlighted?.workspace === workspace
+    ? lastAddMenuHighlighted.blockId
+    : null;
+}
+
+export function restoreBlockFocus(workspace, blockId) {
+  if (!workspace || !blockId) return;
+  const block = workspace.getBlockById(blockId);
+  if (!block) return;
+
+  ensureAddMenuSelectionCleanup(workspace);
+  clearAddMenuHighlight(workspace, blockId);
+  trackBlockHighlight(workspace, blockId);
+  scrollToBlockTopParentLeft(workspace, blockId);
+}
+
 export function highlightBlockById(workspace, block) {
   if (!workspace || !block || block.workspace !== workspace) return;
 


### PR DESCRIPTION
# Summary

Fix a bug which was causing the selected block to not be kept on tablet properly all of the time. 

### AI usage
Claude Sonnet 4.6 found the bug (with a bit of help from me testing various scenarios). 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined block selection and focus management to ensure that previously selected blocks remain properly highlighted and positioned when resizing the window to narrow screen widths or switching between normal and canvas-only view modes, delivering a more seamless user experience during layout changes and view transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->