### PR TITLE
Skip redundant keyboard nav in string blocks

### DIFF
--- a/main/blocklyinit.js
+++ b/main/blocklyinit.js
@@ -1348,6 +1348,110 @@ export function initializeWorkspace() {
   return workspace;
 }
 
+// Patch the workspace Navigator so keyboard navigation skips shadow value
+// blocks (e.g. the " " text block inside print_text's TEXT input) and lands
+// directly on their editable field.
+//
+// Right-arrow skips the shadow block and focuses the field.
+// Left/up/down from that field act as if the shadow block itself were focused,
+// so the rest of the parent block's inputs remain reachable.
+function installShadowNavigationPatch(ws) {
+  const nav = ws.getNavigator?.();
+  if (!nav) return;
+
+  // A shadow value block whose primary field is *separately* navigable, which
+  // creates a redundant block+field double-stop during keyboard navigation
+  // (e.g. the " " `text` block in print_text's TEXT input).
+  //
+  // Simple reporters (single field + output, e.g. `math_number`) are excluded:
+  // Blockly already makes their full-block field non-navigable and treats the
+  // block itself as the single stop (Enter edits it directly), so there is no
+  // redundant stop to skip — and redirecting to their non-navigable field
+  // would break navigation.
+  const isSkippableShadow = (node) =>
+    typeof node?.isShadow === 'function' &&
+    node.isShadow() &&
+    !!node.outputConnection &&
+    !(typeof node.isSimpleReporter === 'function' && node.isSimpleReporter());
+
+  // First field in a block that a keyboard user can interact with.
+  const getPrimaryEditableField = (block) => {
+    for (const input of block.inputList) {
+      for (const field of input.fieldRow) {
+        if (field.canBeFocused?.() &&
+            field.isVisible?.() &&
+            (field.isClickable?.() || field.isCurrentlyEditable?.()) &&
+            field.getParentInput?.()?.isVisible?.()) {
+          return field;
+        }
+      }
+    }
+    return null;
+  };
+
+  // If node is a skippable shadow block, return its primary field instead.
+  const skipShadow = (node) => {
+    if (!isSkippableShadow(node)) return node;
+    return getPrimaryEditableField(node) ?? node;
+  };
+
+  // The shortcut handler calls getInNode/getOutNode/getNextNode/getPreviousNode
+  // with no arguments, relying on the focused node. A skippable shadow's
+  // full-block field resolves back to its block via getFocusedNode(), so we
+  // read document.activeElement to recover the field that actually owns focus.
+  const getFocusedShadowField = () => {
+    const el = document.activeElement;
+    if (!el?.id) return null;
+    const sep = el.id.indexOf('_field_');
+    if (sep === -1) return null;
+    const block = ws.getBlockById(el.id.substring(0, sep));
+    if (!isSkippableShadow(block)) return null;
+    for (const input of block.inputList) {
+      for (const field of input.fieldRow) {
+        if (field.getFocusableElement?.()?.id === el.id) return field;
+      }
+    }
+    return null;
+  };
+
+  const origIn   = nav.getInNode.bind(nav);
+  const origOut  = nav.getOutNode.bind(nav);
+  const origNext = nav.getNextNode.bind(nav);
+  const origPrev = nav.getPreviousNode.bind(nav);
+
+  // Right-arrow (getInNode moves to the next element in the same visual row).
+  //  - On a normal block: if the target is a skippable shadow, land on its
+  //    field instead of the redundant shadow block.
+  //  - On a shadow block's field: pass the field explicitly so the traversal
+  //    bubbles up to the next inline sibling (text field -> next input).
+  nav.getInNode = function(node) {
+    const field = getFocusedShadowField();
+    return skipShadow(field ? origIn(field) : origIn(node));
+  };
+
+  // Left-arrow: from a skipped shadow field, go to the shadow block's parent
+  // (skip the shadow block itself).
+  nav.getOutNode = function(node) {
+    const field = getFocusedShadowField();
+    if (field) return skipShadow(origOut(field.getSourceBlock()));
+    return origOut(node);
+  };
+
+  // Down-arrow: navigate as if standing on the shadow block itself.
+  nav.getNextNode = function(node) {
+    const field = getFocusedShadowField();
+    if (field) return skipShadow(origNext(field.getSourceBlock()));
+    return skipShadow(origNext(node));
+  };
+
+  // Up-arrow: same idea.
+  nav.getPreviousNode = function(node) {
+    const field = getFocusedShadowField();
+    if (field) return skipShadow(origPrev(field.getSourceBlock()));
+    return skipShadow(origPrev(node));
+  };
+}
+
 export function createBlocklyWorkspace() {
   // Register the custom renderer
   Blockly.registry.register(
@@ -2395,6 +2499,8 @@ export function createBlocklyWorkspace() {
 
   // Register comment options for workspace comments
   Blockly.ContextMenuItems.registerCommentOptions();
+
+  installShadowNavigationPatch(workspace);
 
   window.mainWorkspace = workspace;
 


### PR DESCRIPTION
# Summary
There is now no redundant double-right keyboard navigation for a string block 🎉 

<img width="570" height="138" alt="no-redundant-tap" src="https://github.com/user-attachments/assets/262cc326-357e-4b08-ba4a-3986630cbaab" />


### AI usage
After a lengthy back and forth about how this should work, and failure to implement it correctly, I had to get the big guns out. Claude Opus 4.8 wrote all of the code. I debugged and made suggestions. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard navigation in the block editor. Arrow key navigation now moves directly to editable fields instead of stopping at intermediate shadow blocks, providing a more intuitive and efficient editing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->