### PR TITLE
Enable all axis controls simultaneously

### DIFF
--- a/api/ui.js
+++ b/api/ui.js
@@ -893,4 +893,13 @@ export const flockUI = {
       console.warn("Unable to print text:", error);
     }
   },
+
+  clearText() {
+    if (!flock.stackPanel) return;
+    const toRemove = flock.stackPanel.children.filter(c => c.name === "textBackground");
+    for (const bg of toRemove) {
+      flock.stackPanel.removeControl(bg);
+      bg.dispose();
+    }
+  },
 };

--- a/main/keyboardDispatcher.js
+++ b/main/keyboardDispatcher.js
@@ -1,13 +1,13 @@
-import { ContextManager } from "./context.js";
+import { ContextManager } from './context.js';
 
 // Work out what key combo was pressed (e.g. Ctrl+Shift+KeyA)
 function _keyCombo(event) {
   const mods = [
-    (event.ctrlKey || event.metaKey) && "Mod",
-    event.altKey && "Alt",
-    event.shiftKey && "Shift",
+    (event.ctrlKey || event.metaKey) && 'Mod',
+    event.altKey && 'Alt',
+    event.shiftKey && 'Shift',
   ].filter(Boolean);
-  return mods.length ? `${mods.join("+")}+${event.code}` : event.code;
+  return mods.length ? `${mods.join('+')}+${event.code}` : event.code;
 }
 
 const KeyboardDispatcher = {
@@ -22,7 +22,7 @@ const KeyboardDispatcher = {
     delete this._registry[`${context}:${code}`];
   },
 
-  pushMode(handler, name = "modal") {
+  pushMode(handler, name = 'modal') {
     this._modeStack.push({ handler, name });
   },
 
@@ -37,7 +37,7 @@ const KeyboardDispatcher = {
   _dispatch(event) {
     const context = ContextManager.getCurrentContext();
     if (this._modeStack.length > 0) {
-      if (context === "TYPING" || context === "OVERLAY") return;
+      if (context === 'TYPING' || context === 'OVERLAY') return;
       const mode = this._modeStack[this._modeStack.length - 1];
       mode.handler(event);
       if (event.cancelBubble) {
@@ -51,7 +51,7 @@ const KeyboardDispatcher = {
       this._registry[`*:${combo}`] ||
       this._registry[`${context}:${event.code}`] ||
       this._registry[`*:${event.code}`]; // Wildcard context *
-    _debugShow(combo, handler ? `${context}:${combo}` : "external");
+    _debugShow(combo, handler ? `${context}:${combo}` : 'external');
     if (handler) handler(event);
   },
 };
@@ -59,12 +59,12 @@ const KeyboardDispatcher = {
 // Print debug info for all key presses
 let _debugTimer = null;
 function _debugShow(code, label) {
-  const el = document.getElementById("input-debug-value");
+  const el = document.getElementById('input-debug-value');
   if (!el) return;
   el.textContent = `${code} → ${label}`;
   clearTimeout(_debugTimer);
   _debugTimer = setTimeout(() => {
-    el.textContent = "-";
+    el.textContent = '-';
   }, 2000);
 }
 

--- a/ui/axis-keyboard.js
+++ b/ui/axis-keyboard.js
@@ -38,7 +38,7 @@ export function createAxisKeyboardHandler({
       case "X":
         axis = axis === "x" ? null : "x";
         flock.printText({
-          text: axis ? translate("axis_x") : translate("axis_free"),
+          text: axis ? `🔒 ${translate("axis_x")}` : translate("axis_free"),
           duration: 10,
           color: "black",
         });
@@ -50,7 +50,7 @@ export function createAxisKeyboardHandler({
       case "Y":
         axis = axis === "y" ? null : "y";
         flock.printText({
-          text: axis ? translate("axis_y") : translate("axis_free"),
+          text: axis ? `🔒 ${translate("axis_y")}` : translate("axis_free"),
           duration: 10,
           color: "black",
         });
@@ -62,7 +62,7 @@ export function createAxisKeyboardHandler({
       case "Z":
         axis = axis === "z" ? null : "z";
         flock.printText({
-          text: axis ? translate("axis_z") : translate("axis_free"),
+          text: axis ? `🔒 ${translate("axis_z")}` : translate("axis_free"),
           duration: 10,
           color: "black",
         });
@@ -74,7 +74,7 @@ export function createAxisKeyboardHandler({
       case "U":
         axis = axis === "all" ? null : "all";
         flock.printText({
-          text: axis ? `★ ${translate("axis_all")}` : translate("axis_free"),
+          text: axis ? `🔒 ★ ${translate("axis_all")}` : translate("axis_free"),
           duration: 10,
           color: "black",
         });
@@ -152,6 +152,7 @@ export function createAxisKeyboardHandler({
     if (stopped) return;
     stopped = true;
     axis = null;
+    flock.clearText?.();
     KeyboardDispatcher.popMode();
   }
   stop.getAxis = () => axis;

--- a/ui/axis-keyboard.js
+++ b/ui/axis-keyboard.js
@@ -10,6 +10,7 @@ export function createAxisKeyboardHandler({
   onCancel,
   stepNormal = 0.1,
   stepFast = 1,
+  onAxisChange,
 }) {
   let axis = null;
 
@@ -40,6 +41,7 @@ export function createAxisKeyboardHandler({
           duration: 10,
           color: "black",
         });
+        onAxisChange?.(axis);
         event.preventDefault();
         break;
 
@@ -51,6 +53,7 @@ export function createAxisKeyboardHandler({
           duration: 10,
           color: "black",
         });
+        onAxisChange?.(axis);
         event.preventDefault();
         break;
 
@@ -62,6 +65,7 @@ export function createAxisKeyboardHandler({
           duration: 10,
           color: "black",
         });
+        onAxisChange?.(axis);
         event.preventDefault();
         break;
 
@@ -73,6 +77,7 @@ export function createAxisKeyboardHandler({
           duration: 10,
           color: "black",
         });
+        onAxisChange?.(axis);
         event.preventDefault();
         break;
 
@@ -93,10 +98,10 @@ export function createAxisKeyboardHandler({
             axis === "z" ? step * sign : 0,
           );
         } else {
-          if (event.key === "ArrowRight") onMove(step, 0, 0);
-          else if (event.key === "ArrowLeft") onMove(-step, 0, 0);
-          else if (event.key === "ArrowUp") onMove(0, 0, step);
-          else if (event.key === "ArrowDown") onMove(0, 0, -step);
+          if (event.key === "ArrowRight") { onMove(step, 0, 0); onAxisChange?.("x"); }
+          else if (event.key === "ArrowLeft") { onMove(-step, 0, 0); onAxisChange?.("x"); }
+          else if (event.key === "ArrowUp") { onMove(0, 0, step); onAxisChange?.("z"); }
+          else if (event.key === "ArrowDown") { onMove(0, 0, -step); onAxisChange?.("z"); }
         }
         break;
       }
@@ -105,14 +110,14 @@ export function createAxisKeyboardHandler({
         event.preventDefault();
         event.stopPropagation();
         if (axis === "all") onMove(step, step, step);
-        else if (!axis) onMove(0, step, 0);
+        else if (!axis) { onMove(0, step, 0); onAxisChange?.("y"); }
         break;
 
       case "PageDown":
         event.preventDefault();
         event.stopPropagation();
         if (axis === "all") onMove(-step, -step, -step);
-        else if (!axis) onMove(0, -step, 0);
+        else if (!axis) { onMove(0, -step, 0); onAxisChange?.("y"); }
         break;
 
       case "Enter":

--- a/ui/axis-keyboard.js
+++ b/ui/axis-keyboard.js
@@ -73,7 +73,7 @@ export function createAxisKeyboardHandler({
       case "U":
         axis = axis === "all" ? null : "all";
         flock.printText({
-          text: axis ? translate("axis_all") : translate("axis_free"),
+          text: axis ? `★ ${translate("axis_all")}` : translate("axis_free"),
           duration: 10,
           color: "black",
         });

--- a/ui/axis-keyboard.js
+++ b/ui/axis-keyboard.js
@@ -11,8 +11,9 @@ export function createAxisKeyboardHandler({
   stepNormal = 0.1,
   stepFast = 1,
   onAxisChange,
+  initialAxis = null,
 }) {
-  let axis = null;
+  let axis = initialAxis;
 
   function handler(event) {
     const t = event.target;
@@ -153,6 +154,7 @@ export function createAxisKeyboardHandler({
     axis = null;
     KeyboardDispatcher.popMode();
   }
+  stop.getAxis = () => axis;
 
   return stop;
 }

--- a/ui/axis-keyboard.js
+++ b/ui/axis-keyboard.js
@@ -29,6 +29,8 @@ export function createAxisKeyboardHandler({
 
     const step = event.shiftKey ? stepNormal : stepFast;
 
+    if (event.ctrlKey || event.metaKey || event.altKey) return;
+
     switch (event.key) {
       case "x":
       case "X":

--- a/ui/axis-keyboard.js
+++ b/ui/axis-keyboard.js
@@ -155,6 +155,7 @@ export function createAxisKeyboardHandler({
     KeyboardDispatcher.popMode();
   }
   stop.getAxis = () => axis;
+  stop.setAxis = (newAxis) => { axis = newAxis; };
 
   return stop;
 }

--- a/ui/gizmo-mobile-hud.js
+++ b/ui/gizmo-mobile-hud.js
@@ -320,12 +320,18 @@ export function createGizmoMobileHud({
 
   // ── Stop / cleanup ────────────────────────────────────────────────────────
   let stopped = false;
-  return function stop() {
+  function stop() {
     if (stopped) return;
     stopped = true;
     cleanups.forEach((fn) => fn());
     hudTexture.dispose();
     if (savedControls) savedControls.rootContainer.isVisible = true;
     if (flock._joystickSource) flock._joystickSource.resume();
+  }
+  stop.setAxis = (newAxis) => {
+    if (stopped) return;
+    const def = AXIS_DEFS.find(d => d.key === newAxis);
+    if (def) { axis = newAxis; updateAxisButtons(); }
   };
+  return stop;
 }

--- a/ui/gizmo-mobile-hud.js
+++ b/ui/gizmo-mobile-hud.js
@@ -1,5 +1,4 @@
 import { flock } from '../flock.js';
-import { translate } from '../main/translation.js';
 
 const fontFamily = 'Atkinson Hyperlegible Next';
 
@@ -35,7 +34,7 @@ export function createGizmoMobileHud({
     { key: 'x', label: 'X', color: '#0072B2' },
     { key: 'y', label: 'Y', color: '#009E73' },
     { key: 'z', label: 'Z', color: '#D55E00' },
-    ...(showUniform ? [{ key: 'all', label: '*', color: '#aaaaaa' }] : []),
+    ...(showUniform ? [{ key: 'all', label: '★', color: '#aaaaaa' }] : []),
   ];
   const numAxes = AXIS_DEFS.length;
 
@@ -102,11 +101,6 @@ export function createGizmoMobileHud({
     axisButtons[key].onPointerUpObservable.add(() => {
       if (axis !== key) {
         axis = key;
-        flock.printText({
-          text: translate(key === 'all' ? 'axis_all' : `axis_${key}`),
-          duration: 10,
-          color: 'black',
-        });
         updateAxisButtons();
       }
     });

--- a/ui/gizmo-mobile-hud.js
+++ b/ui/gizmo-mobile-hud.js
@@ -83,7 +83,7 @@ export function createGizmoMobileHud({
   let arrowNegBtn = null;
   let arrowPosBtn = null;
 
-  function updateAxisButtons() {
+  function refreshAxisVisuals() {
     for (const { key, color } of AXIS_DEFS) {
       const selected = axis === key || axis === 'all';
       axisButtons[key].background = color;
@@ -94,9 +94,12 @@ export function createGizmoMobileHud({
       arrowNegBtn.textBlock.text = labels[0];
       arrowPosBtn.textBlock.text = labels[1];
     }
+  }
+  function updateAxisButtons() {
+    refreshAxisVisuals();
     onAxisChange?.(axis);
   }
-  updateAxisButtons();
+  refreshAxisVisuals();
 
   AXIS_DEFS.forEach(({ key }) => {
     axisButtons[key].onPointerUpObservable.add(() => {
@@ -177,7 +180,7 @@ export function createGizmoMobileHud({
 
     arrowNegBtn = makeArrowButton(stepLabels[0], -1, 0);
     arrowPosBtn = makeArrowButton(stepLabels[1], +1, 1);
-    updateAxisButtons();
+    refreshAxisVisuals();
   } else {
     // ── Slider (delta-drag) ───────────────────────────────────────────────
     const THUMB_R = Math.floor(BTN_SIZE / 2) - 2 * s;
@@ -326,7 +329,7 @@ export function createGizmoMobileHud({
   stop.setAxis = (newAxis) => {
     if (stopped) return;
     const def = AXIS_DEFS.find(d => d.key === newAxis);
-    if (def) { axis = newAxis; updateAxisButtons(); }
+    if (def) { axis = newAxis; refreshAxisVisuals(); }
   };
   return stop;
 }

--- a/ui/gizmo-mobile-hud.js
+++ b/ui/gizmo-mobile-hud.js
@@ -11,6 +11,7 @@ export function createGizmoMobileHud({
   stepLabels = ['◁', '▷'],
   onAxisChange = null,
   stepLabelsByAxis = null,
+  initialAxis = null,
 }) {
   if (!flock.scene || !flock.canvas || !flock.GUI) return null;
 
@@ -28,14 +29,14 @@ export function createGizmoMobileHud({
   );
 
   // ── Axis state ────────────────────────────────────────────────────────────
-  let axis = 'x';
-
   const AXIS_DEFS = [
     { key: 'x', label: 'X', color: '#0072B2' },
     { key: 'y', label: 'Y', color: '#009E73' },
     { key: 'z', label: 'Z', color: '#D55E00' },
     ...(showUniform ? [{ key: 'all', label: '★', color: '#aaaaaa' }] : []),
   ];
+  const firstAxis = AXIS_DEFS[0]?.key ?? 'x';
+  let axis = (initialAxis && AXIS_DEFS.find(d => d.key === initialAxis)) ? initialAxis : firstAxis;
   const numAxes = AXIS_DEFS.length;
 
   // ── Layout ────────────────────────────────────────────────────────────────

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -77,56 +77,28 @@ const cleanupFns = [];
 // Track DO sections and their associated blocks for cleanup
 const gizmoCreatedBlocks = new Map(); // blockId -> { parentId, createdDoSection, timestamp }
 
-const AXIS_SWITCH_KEYS = new Set([
-  "ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown",
-  "PageUp", "PageDown",
-  "x", "X", "y", "Y", "z", "Z", "u", "U",
-]);
+function createAdaptiveInput({ onMove, onConfirm, onCancel, stepNormal, stepFast, mode, showUniform, stepLabels, onHudHide, onAxisChange, stepLabelsByAxis }) {
+  let hud = null;
+  let keyboard = null;
 
-function createAdaptiveInput({ onMove, onConfirm, onCancel, stepNormal, stepFast, mode, showUniform, stepLabels, onHudShow, onHudHide, onAxisChange, stepLabelsByAxis }) {
-  let stopHud = null;
-  let stopKeyboard = null;
-  const canvas = flock.canvas;
-
-  function switchToTouch() {
-    if (stopKeyboard) { stopKeyboard(); stopKeyboard = null; }
-    if (!stopHud) {
-      stopHud = createGizmoMobileHud({ onMove, stepNormal, stepFast, mode, showUniform, stepLabels, onAxisChange, stepLabelsByAxis });
-      onHudShow?.();
-    }
+  function onKbAxisChange(axis) {
+    if (axis) hud?.setAxis(axis);
+    onAxisChange?.(axis);
   }
 
-  function switchToKeyboard() {
-    if (stopHud) {
-      stopHud(); stopHud = null;
-      onHudHide?.();
-    }
-    if (!stopKeyboard) {
-      stopKeyboard = createAxisKeyboardHandler({ onMove, onConfirm, onCancel, stepNormal, stepFast });
-    }
+  hud = createGizmoMobileHud({ onMove, stepNormal, stepFast, mode, showUniform, stepLabels, onAxisChange, stepLabelsByAxis });
+  keyboard = createAxisKeyboardHandler({ onMove, onConfirm, onCancel, stepNormal, stepFast, onAxisChange: onKbAxisChange });
+
+  function stop() {
+    onHudHide?.();
+    hud?.();
+    keyboard?.();
   }
-
-  function onCanvasPointer(e) {
-    if (e.pointerType === "touch") switchToTouch();
-  }
-
-  function onRawKey(e) {
-    if (e.cancelBubble) return;
-    if (e.target?.closest?.("#shapes-dropdown, .custom-color-picker")) return;
-    if (AXIS_SWITCH_KEYS.has(e.key)) switchToKeyboard();
-  }
-
-  canvas.addEventListener("pointerdown", onCanvasPointer);
-  const rawKeyObserver = flock.inputManager.onRawKeyDownObservable.add(onRawKey);
-
-  if (navigator.maxTouchPoints > 0) switchToTouch();
-
-  return function stop() {
-    canvas.removeEventListener("pointerdown", onCanvasPointer);
-    flock.inputManager.onRawKeyDownObservable.remove(rawKeyObserver);
-    if (stopHud) { onHudHide?.(); stopHud(); stopHud = null; }
-    if (stopKeyboard) { stopKeyboard(); stopKeyboard = null; }
+  stop.setAxis = (axis) => {
+    if (axis) hud?.setAxis(axis);
+    onAxisChange?.(axis);
   };
+  return stop;
 }
 
 // Register input handlers for gizmo actions
@@ -838,29 +810,7 @@ function startRotateKeyboardHandler(mesh) {
     stepNormal: DEFAULT_ROTATION,
     stepFast: FAST_ROTATION,
     mode: 'slider',
-    onHudShow: () => {
-      const rg = gizmoManager.gizmos?.rotationGizmo;
-      if (!rg) return;
-      rg.updateGizmoRotationToMatchAttachedMesh = true;
-      // Override validateDrag to block rotation while keeping dragBehavior enabled
-      // (disabling it causes Babylon.js to permanently grey out the arcs)
-      [rg.xGizmo, rg.yGizmo, rg.zGizmo].forEach((g) => {
-        if (!g?.dragBehavior) return;
-        g.dragBehavior._savedValidateDrag = g.dragBehavior.validateDrag;
-        g.dragBehavior.validateDrag = () => false;
-      });
-    },
-    onHudHide: () => {
-      const rg = gizmoManager.gizmos?.rotationGizmo;
-      if (!rg) return;
-      rg.updateGizmoRotationToMatchAttachedMesh = false;
-      [rg.xGizmo, rg.yGizmo, rg.zGizmo].forEach((g) => {
-        if (!g?.dragBehavior) return;
-        g.dragBehavior.validateDrag = g.dragBehavior._savedValidateDrag ?? (() => true);
-        delete g.dragBehavior._savedValidateDrag;
-      });
-      highlightGizmoAxis(rg, null);
-    },
+    onHudHide: () => highlightGizmoAxis(gizmoManager.gizmos?.rotationGizmo, null),
     onAxisChange: (axis) => highlightGizmoAxis(gizmoManager.gizmos?.rotationGizmo, axis),
   });
 }
@@ -1530,6 +1480,18 @@ export function toggleGizmo(gizmoType) {
 // Scale: Allow the user to scale the mesh by dragging it
 function handleScaleGizmo() {
   configureScaleGizmo(gizmoManager);
+  observeDragAxis(gizmoManager.gizmos.scaleGizmo);
+  {
+    const usg = gizmoManager.gizmos.scaleGizmo.uniformScaleGizmo;
+    if (usg?.dragBehavior) {
+      const startObs = usg.dragBehavior.onDragStartObservable.add(() => stopAxisKeyboard?.setAxis('all'));
+      const endObs = usg.dragBehavior.onDragEndObservable.add(() => stopAxisKeyboard?.setAxis(null));
+      onExit(() => {
+        usg.dragBehavior.onDragStartObservable.remove(startObs);
+        usg.dragBehavior.onDragEndObservable.remove(endObs);
+      });
+    }
+  }
   {
     const sg = gizmoManager.gizmos.scaleGizmo;
     if (!sg._textAxisObserversRegistered) {
@@ -1677,9 +1639,24 @@ function highlightGizmoAxis(gizmo, axis) {
   });
 }
 
+// Highlight the HUD and gizmo handles while a drag handle is active.
+function observeDragAxis(gizmo) {
+  for (const axisKey of ['x', 'y', 'z']) {
+    const g = gizmo?.[`${axisKey}Gizmo`];
+    if (!g?.dragBehavior) continue;
+    const startObs = g.dragBehavior.onDragStartObservable.add(() => stopAxisKeyboard?.setAxis(axisKey));
+    const endObs = g.dragBehavior.onDragEndObservable.add(() => stopAxisKeyboard?.setAxis(null));
+    onExit(() => {
+      g.dragBehavior.onDragStartObservable.remove(startObs);
+      g.dragBehavior.onDragEndObservable.remove(endObs);
+    });
+  }
+}
+
 // Rotation: Allow the user to rotate the mesh by dragging it
 function handleRotationGizmo() {
   configureRotationGizmo(gizmoManager);
+  observeDragAxis(gizmoManager.gizmos.rotationGizmo);
 
   // Show that rotation is active
   const rotationButton = document.getElementById('rotationButton');
@@ -1757,6 +1734,7 @@ function handleRotationGizmo() {
 // Position: Allow the user to move the mesh by dragging it
 function handlePositionGizmo() {
   configurePositionGizmo(gizmoManager);
+  observeDragAxis(gizmoManager.gizmos.positionGizmo);
 
   // Highlight the move button
   const positionButton = document.getElementById('positionButton');

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -95,6 +95,7 @@ function createAdaptiveInput({ onMove, onConfirm, onCancel, stepNormal, stepFast
       flock.printText({ text: translate('axis_free'), duration: 10, color: 'black' });
     }
     keyboard?.setAxis?.(null);
+    lastReportedAxis = axis;
     onAxisChange?.(axis);
   }
 
@@ -111,6 +112,7 @@ function createAdaptiveInput({ onMove, onConfirm, onCancel, stepNormal, stepFast
   }
   stop.setAxis = (axis) => {
     if (axis) hud?.setAxis(axis);
+    lastReportedAxis = axis;
     onAxisChange?.(axis);
   };
   stop.getAxis = () => keyboard?.getAxis?.() ?? null;

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -77,7 +77,7 @@ const cleanupFns = [];
 // Track DO sections and their associated blocks for cleanup
 const gizmoCreatedBlocks = new Map(); // blockId -> { parentId, createdDoSection, timestamp }
 
-function createAdaptiveInput({ onMove, onConfirm, onCancel, stepNormal, stepFast, mode, showUniform, stepLabels, onHudHide, onAxisChange, stepLabelsByAxis }) {
+function createAdaptiveInput({ onMove, onConfirm, onCancel, stepNormal, stepFast, mode, showUniform, stepLabels, onHudHide, onAxisChange, stepLabelsByAxis, initialKeyboardAxis = null, initialHudAxis = null }) {
   let hud = null;
   let keyboard = null;
 
@@ -86,8 +86,10 @@ function createAdaptiveInput({ onMove, onConfirm, onCancel, stepNormal, stepFast
     onAxisChange?.(axis);
   }
 
-  hud = createGizmoMobileHud({ onMove, stepNormal, stepFast, mode, showUniform, stepLabels, onAxisChange, stepLabelsByAxis });
-  keyboard = createAxisKeyboardHandler({ onMove, onConfirm, onCancel, stepNormal, stepFast, onAxisChange: onKbAxisChange });
+  hud = createGizmoMobileHud({ onMove, stepNormal, stepFast, mode, showUniform, stepLabels, onAxisChange, stepLabelsByAxis, initialAxis: initialHudAxis ?? initialKeyboardAxis });
+  keyboard = createAxisKeyboardHandler({ onMove, onConfirm, onCancel, stepNormal, stepFast, onAxisChange: onKbAxisChange, initialAxis: initialKeyboardAxis });
+  const startAxis = initialKeyboardAxis ?? initialHudAxis;
+  if (startAxis) onAxisChange?.(startAxis);
   flock.canvas?.focus();
 
   function stop() {
@@ -99,6 +101,7 @@ function createAdaptiveInput({ onMove, onConfirm, onCancel, stepNormal, stepFast
     if (axis) hud?.setAxis(axis);
     onAxisChange?.(axis);
   };
+  stop.getAxis = () => keyboard?.getAxis?.() ?? null;
   return stop;
 }
 
@@ -720,7 +723,8 @@ export function exitGizmoState() {
 }
 
 // Start the keyboard handler for moving a mesh
-function startMoveKeyboardHandler(mesh) {
+function startMoveKeyboardHandler(mesh, savedHudAxis = null, onHudAxisSaved = null) {
+  const initialKeyboardAxis = stopAxisKeyboard?.getAxis?.() ?? null;
   document.body.style.cursor = 'default';
   cleanupScenePick();
   stopAxisKeyboard?.();
@@ -756,13 +760,16 @@ function startMoveKeyboardHandler(mesh) {
     stepFast: FAST_CURSOR,
     mode: 'arrows',
     stepLabelsByAxis: { x: ['◁', '▷'], y: ['▽', '△'], z: ['▽', '△'], all: ['◁', '▷'] },
-    onAxisChange: (axis) => highlightGizmoAxis(gizmoManager.gizmos?.positionGizmo, axis),
+    onAxisChange: (axis) => { onHudAxisSaved?.(axis); highlightGizmoAxis(gizmoManager.gizmos?.positionGizmo, axis); },
     onHudHide: () => highlightGizmoAxis(gizmoManager.gizmos?.positionGizmo, null),
+    initialKeyboardAxis,
+    initialHudAxis: savedHudAxis,
   });
 }
 
 // Rotate a mesh using the keyboard
-function startRotateKeyboardHandler(mesh) {
+function startRotateKeyboardHandler(mesh, savedHudAxis = null, onHudAxisSaved = null) {
+  const initialKeyboardAxis = stopAxisKeyboard?.getAxis?.() ?? null;
   document.body.style.cursor = 'default';
   cleanupScenePick();
   stopAxisKeyboard?.();
@@ -814,12 +821,15 @@ function startRotateKeyboardHandler(mesh) {
     stepFast: FAST_ROTATION,
     mode: 'slider',
     onHudHide: () => highlightGizmoAxis(gizmoManager.gizmos?.rotationGizmo, null),
-    onAxisChange: (axis) => highlightGizmoAxis(gizmoManager.gizmos?.rotationGizmo, axis),
+    onAxisChange: (axis) => { onHudAxisSaved?.(axis); highlightGizmoAxis(gizmoManager.gizmos?.rotationGizmo, axis); },
+    initialKeyboardAxis,
+    initialHudAxis: savedHudAxis,
   });
 }
 
 // Scale a mesh using the keyboard
-function startScaleKeyboardHandler(mesh) {
+function startScaleKeyboardHandler(mesh, savedHudAxis = null, onHudAxisSaved = null) {
+  const initialKeyboardAxis = stopAxisKeyboard?.getAxis?.() ?? null;
   document.body.style.cursor = 'default';
   cleanupScenePick();
   stopAxisKeyboard?.();
@@ -873,8 +883,10 @@ function startScaleKeyboardHandler(mesh) {
     mode: 'arrows',
     showUniform: true,
     stepLabels: ['-', '+'],
-    onAxisChange: (axis) => highlightGizmoAxis(gizmoManager.gizmos?.scaleGizmo, axis),
+    onAxisChange: (axis) => { onHudAxisSaved?.(axis); highlightGizmoAxis(gizmoManager.gizmos?.scaleGizmo, axis); },
     onHudHide: () => highlightGizmoAxis(gizmoManager.gizmos?.scaleGizmo, null),
+    initialKeyboardAxis,
+    initialHudAxis: savedHudAxis,
   });
 }
 
@@ -1513,9 +1525,10 @@ function handleScaleGizmo() {
   const scaleButton = document.getElementById('scaleButton');
   scaleButton.classList.add('active');
 
+  let savedHudAxis = null;
   const mesh = gizmoManager.attachedMesh;
   if (mesh) {
-    startScaleKeyboardHandler(mesh);
+    startScaleKeyboardHandler(mesh, savedHudAxis, (axis) => { savedHudAxis = axis; });
   } else {
     pickMeshFromScene((pickedMesh) => {
       if (!pickedMesh || pickedMesh.name === 'ground') {
@@ -1536,7 +1549,7 @@ function handleScaleGizmo() {
     }
 
     lastScaledMesh = mesh;
-    startScaleKeyboardHandler(mesh);
+    startScaleKeyboardHandler(mesh, savedHudAxis, (axis) => { savedHudAxis = axis; });
   });
 
   onExit(() => gizmoManager.onAttachedToMeshObservable.remove(scaleObs));
@@ -1666,9 +1679,10 @@ function handleRotationGizmo() {
   const rotationButton = document.getElementById('rotationButton');
   rotationButton.classList.add('active');
 
+  let savedHudAxis = null;
   const mesh = gizmoManager.attachedMesh;
   if (mesh) {
-    startRotateKeyboardHandler(mesh);
+    startRotateKeyboardHandler(mesh, savedHudAxis, (axis) => { savedHudAxis = axis; });
   } else {
     pickMeshFromScene((pickedMesh) => {
       if (!pickedMesh || pickedMesh.name === 'ground') {
@@ -1691,7 +1705,7 @@ function handleRotationGizmo() {
 
     lastRotatedMesh = mesh;
 
-    startRotateKeyboardHandler(mesh);
+    startRotateKeyboardHandler(mesh, savedHudAxis, (axis) => { savedHudAxis = axis; });
   });
 
   onExit(() => gizmoManager.onAttachedToMeshObservable.remove(rotateObs));
@@ -1745,6 +1759,7 @@ function handlePositionGizmo() {
   positionButton.classList.add('active');
 
   let keyboardAttachedMesh = null;
+  let savedHudAxis = null;
   const activatePositionKeyboardForMesh = (mesh) => {
     if (!mesh) {
       exitGizmoState();
@@ -1754,7 +1769,7 @@ function handlePositionGizmo() {
     if (keyboardAttachedMesh === mesh) return;
     keyboardAttachedMesh = mesh;
 
-    startMoveKeyboardHandler(mesh);
+    startMoveKeyboardHandler(mesh, savedHudAxis, (axis) => { savedHudAxis = axis; });
 
     const blockKey = mesh?.metadata?.blockKey;
     const blockId = blockKey ? meshMap[blockKey] : null;

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -88,6 +88,7 @@ function createAdaptiveInput({ onMove, onConfirm, onCancel, stepNormal, stepFast
 
   hud = createGizmoMobileHud({ onMove, stepNormal, stepFast, mode, showUniform, stepLabels, onAxisChange, stepLabelsByAxis });
   keyboard = createAxisKeyboardHandler({ onMove, onConfirm, onCancel, stepNormal, stepFast, onAxisChange: onKbAxisChange });
+  flock.canvas?.focus();
 
   function stop() {
     onHudHide?.();
@@ -721,6 +722,7 @@ export function exitGizmoState() {
 // Start the keyboard handler for moving a mesh
 function startMoveKeyboardHandler(mesh) {
   document.body.style.cursor = 'default';
+  cleanupScenePick();
   stopAxisKeyboard?.();
   stopAxisKeyboard = null;
 
@@ -762,6 +764,7 @@ function startMoveKeyboardHandler(mesh) {
 // Rotate a mesh using the keyboard
 function startRotateKeyboardHandler(mesh) {
   document.body.style.cursor = 'default';
+  cleanupScenePick();
   stopAxisKeyboard?.();
   stopAxisKeyboard = null;
 
@@ -818,6 +821,7 @@ function startRotateKeyboardHandler(mesh) {
 // Scale a mesh using the keyboard
 function startScaleKeyboardHandler(mesh) {
   document.body.style.cursor = 'default';
+  cleanupScenePick();
   stopAxisKeyboard?.();
   stopAxisKeyboard = null;
 

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -81,9 +81,13 @@ function createAdaptiveInput({ onMove, onConfirm, onCancel, stepNormal, stepFast
   let hud = null;
   let keyboard = null;
 
+  let lastReportedAxis = initialKeyboardAxis ?? null;
   function onKbAxisChange(axis) {
     if (axis) hud?.setAxis(axis);
-    onAxisChange?.(axis);
+    if (axis !== lastReportedAxis) {
+      lastReportedAxis = axis;
+      onAxisChange?.(axis);
+    }
   }
 
   function onHudAxisChange(axis) {
@@ -1536,7 +1540,7 @@ function handleScaleGizmo() {
   let savedHudAxis = null;
   const mesh = gizmoManager.attachedMesh;
   if (mesh) {
-    startScaleKeyboardHandler(mesh, savedHudAxis, (axis) => { savedHudAxis = axis; });
+    startScaleKeyboardHandler(mesh, savedHudAxis, (axis) => { if (axis) savedHudAxis = axis; });
   } else {
     pickMeshFromScene((pickedMesh) => {
       if (!pickedMesh || pickedMesh.name === 'ground') {
@@ -1557,7 +1561,7 @@ function handleScaleGizmo() {
     }
 
     lastScaledMesh = mesh;
-    startScaleKeyboardHandler(mesh, savedHudAxis, (axis) => { savedHudAxis = axis; });
+    startScaleKeyboardHandler(mesh, savedHudAxis, (axis) => { if (axis) savedHudAxis = axis; });
   });
 
   onExit(() => gizmoManager.onAttachedToMeshObservable.remove(scaleObs));
@@ -1690,7 +1694,7 @@ function handleRotationGizmo() {
   let savedHudAxis = null;
   const mesh = gizmoManager.attachedMesh;
   if (mesh) {
-    startRotateKeyboardHandler(mesh, savedHudAxis, (axis) => { savedHudAxis = axis; });
+    startRotateKeyboardHandler(mesh, savedHudAxis, (axis) => { if (axis) savedHudAxis = axis; });
   } else {
     pickMeshFromScene((pickedMesh) => {
       if (!pickedMesh || pickedMesh.name === 'ground') {
@@ -1713,7 +1717,7 @@ function handleRotationGizmo() {
 
     lastRotatedMesh = mesh;
 
-    startRotateKeyboardHandler(mesh, savedHudAxis, (axis) => { savedHudAxis = axis; });
+    startRotateKeyboardHandler(mesh, savedHudAxis, (axis) => { if (axis) savedHudAxis = axis; });
   });
 
   onExit(() => gizmoManager.onAttachedToMeshObservable.remove(rotateObs));
@@ -1777,7 +1781,7 @@ function handlePositionGizmo() {
     if (keyboardAttachedMesh === mesh) return;
     keyboardAttachedMesh = mesh;
 
-    startMoveKeyboardHandler(mesh, savedHudAxis, (axis) => { savedHudAxis = axis; });
+    startMoveKeyboardHandler(mesh, savedHudAxis, (axis) => { if (axis) savedHudAxis = axis; });
 
     const blockKey = mesh?.metadata?.blockKey;
     const blockId = blockKey ? meshMap[blockKey] : null;

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -86,7 +86,15 @@ function createAdaptiveInput({ onMove, onConfirm, onCancel, stepNormal, stepFast
     onAxisChange?.(axis);
   }
 
-  hud = createGizmoMobileHud({ onMove, stepNormal, stepFast, mode, showUniform, stepLabels, onAxisChange, stepLabelsByAxis, initialAxis: initialHudAxis ?? initialKeyboardAxis });
+  function onHudAxisChange(axis) {
+    if (keyboard?.getAxis?.()) {
+      flock.printText({ text: translate('axis_free'), duration: 10, color: 'black' });
+    }
+    keyboard?.setAxis?.(null);
+    onAxisChange?.(axis);
+  }
+
+  hud = createGizmoMobileHud({ onMove, stepNormal, stepFast, mode, showUniform, stepLabels, onAxisChange: onHudAxisChange, stepLabelsByAxis, initialAxis: initialHudAxis ?? initialKeyboardAxis });
   keyboard = createAxisKeyboardHandler({ onMove, onConfirm, onCancel, stepNormal, stepFast, onAxisChange: onKbAxisChange, initialAxis: initialKeyboardAxis });
   const startAxis = initialKeyboardAxis ?? initialHudAxis;
   if (startAxis) onAxisChange?.(startAxis);


### PR DESCRIPTION
# Summary
All axis control methods - keyboard, drag and HUD - should be usable interchangeably on all platforms.

<img width="507" height="380" alt="image" src="https://github.com/user-attachments/assets/6b4f924c-e7ba-4e4e-accf-15be73a3c6c5" />


- Show HUD on desktop
- HUD display reflects active keyboard key or drag handle, i.e. if you're dragging the X axis, the HUD displays X
- Free mode for keyboard controls is the default. If a HUD button is pressed while a keyboard axis lock is active, the axis lock clears. If a different gizmo is selected while a keyboard axis lock is active, the Flock message in the top left is cleared to avoid confusion. 
- Don't trigger axis locks (x/y/z) when a modifier is held, i.e. Ctrl + Z should not trigger an axis lock
- Retain the previously selected axis if you switch to a different mesh

### AI usage
Claude Sonnet 4.6 used interactively, plans and alterations by a human. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced keyboard axis selection to persist across interaction mode changes and coordinate with gizmo drag interactions.
  * Added initial axis configuration option for keyboard and UI controls.

* **Bug Fixes**
  * Improved keyboard input tracking and debug output display for better diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->