### PR TITLE
Bugfix - rotation gizmo slider 

### DIFF
--- a/ui/gizmo-mobile-hud.js
+++ b/ui/gizmo-mobile-hud.js
@@ -256,6 +256,11 @@ export function createGizmoMobileHud({
       thumbOffsetGUI = clampedCSS / b.scale;
       thumb.left = `${HALF / 2 - THUMB_R + thumbOffsetGUI}px`;
       thumb.background = 'rgba(255,220,50,0.95)';
+      const delta = clampedCSS * SPEED_FACTOR;
+      if (axis === 'all') onMove(delta, delta, delta);
+      else if (axis === 'x') onMove(delta, 0, 0);
+      else if (axis === 'y') onMove(0, delta, 0);
+      else if (axis === 'z') onMove(0, 0, delta);
     }
 
     function onPointerMove(e) {

--- a/ui/gizmo-mobile-hud.js
+++ b/ui/gizmo-mobile-hud.js
@@ -304,7 +304,15 @@ export function createGizmoMobileHud({
       const clampedCSS = Math.max(-b.maxOffsetCSS, Math.min(b.maxOffsetCSS, e.clientX - b.centerX));
       rawOffsetGUI = clampedCSS / b.scale;
       const newThumbOffsetGUI = snapGUI(rawOffsetGUI);
-      applyMove(thumbOffsetGUI, newThumbOffsetGUI);
+      const targetDeg = (newThumbOffsetGUI / MAX_OFFSET_GUI) * MAX_DEG;
+      const deltaDeg = targetDeg - getAxisDeg();
+      if (deltaDeg !== 0) {
+        const delta = flock.BABYLON.Tools.ToRadians(deltaDeg);
+        if (axis === 'all') onMove(delta, delta, delta);
+        else if (axis === 'x') onMove(delta, 0, 0);
+        else if (axis === 'y') onMove(0, delta, 0);
+        else if (axis === 'z') onMove(0, 0, delta);
+      }
       thumbOffsetGUI = newThumbOffsetGUI;
       thumb.left = `${HALF / 2 - THUMB_R + thumbOffsetGUI}px`;
       thumb.background = 'rgba(255,220,50,0.95)';

--- a/ui/gizmo-mobile-hud.js
+++ b/ui/gizmo-mobile-hud.js
@@ -37,7 +37,7 @@ export function createGizmoMobileHud({
     ...(showUniform ? [{ key: 'all', label: '★', color: '#aaaaaa' }] : []),
   ];
   const firstAxis = AXIS_DEFS[0]?.key ?? 'x';
-  let axis = (initialAxis && AXIS_DEFS.find(d => d.key === initialAxis)) ? initialAxis : firstAxis;
+  let axis = initialAxis && AXIS_DEFS.find((d) => d.key === initialAxis) ? initialAxis : firstAxis;
   const numAxes = AXIS_DEFS.length;
 
   // ── Layout ────────────────────────────────────────────────────────────────
@@ -205,16 +205,24 @@ export function createGizmoMobileHud({
     track.top = `${TRACK_CENTER_Y - TRACK_H / 2}px`;
     container.addControl(track);
 
-    const centerMark = new flock.GUI.Rectangle('gizmoCenterMark');
-    centerMark.width = `${4 * s}px`;
-    centerMark.height = `${TRACK_H + 10 * s}px`;
-    centerMark.background = 'rgba(255,255,255,0.55)';
-    centerMark.thickness = 0;
-    centerMark.horizontalAlignment = flock.GUI.Control.HORIZONTAL_ALIGNMENT_LEFT;
-    centerMark.verticalAlignment = flock.GUI.Control.VERTICAL_ALIGNMENT_TOP;
-    centerMark.left = `${HALF / 2 - 2 * s}px`;
-    centerMark.top = `${TRACK_CENTER_Y - (TRACK_H + 10 * s) / 2}px`;
-    container.addControl(centerMark);
+    const SNAP_DEGS = [-180, -90, 0, 90, 180];
+    const SNAP_THRESHOLD_GUI = (8 / MAX_DEG) * MAX_OFFSET_GUI;
+
+    const tickW = 4 * s;
+    const tickH = TRACK_H + 10 * s;
+    for (const deg of SNAP_DEGS) {
+      const guiOffset = (deg / MAX_DEG) * MAX_OFFSET_GUI;
+      const tick = new flock.GUI.Rectangle(`gizmoTick${deg}`);
+      tick.width = `${tickW}px`;
+      tick.height = `${tickH}px`;
+      tick.background = 'rgba(255,255,255,0.55)';
+      tick.thickness = 0;
+      tick.horizontalAlignment = flock.GUI.Control.HORIZONTAL_ALIGNMENT_LEFT;
+      tick.verticalAlignment = flock.GUI.Control.VERTICAL_ALIGNMENT_TOP;
+      tick.left = `${HALF / 2 + guiOffset - tickW / 2}px`;
+      tick.top = `${TRACK_CENTER_Y - tickH / 2}px`;
+      container.addControl(tick);
+    }
 
     const thumb = new flock.GUI.Ellipse('gizmoThumb');
     thumb.width = `${THUMB_R * 2}px`;
@@ -227,22 +235,33 @@ export function createGizmoMobileHud({
     thumb.top = `${TRACK_CENTER_Y - THUMB_R}px`;
     container.addControl(thumb);
 
-    let thumbOffsetGUI = 0;
+    let rawOffsetGUI = 0; // follows finger exactly
+    let thumbOffsetGUI = 0; // snapped display position
     let lastClientX = 0;
     let activePointer = null;
     let activeScale = 1;
 
     // Normalize any degree value into [-180, 180)
     function normalizeDeg(deg) {
-      return ((deg % 360) + 540) % 360 - 180;
+      return (((deg % 360) + 540) % 360) - 180;
     }
     function degToGUI(deg) {
-      return Math.max(-MAX_OFFSET_GUI, Math.min(MAX_OFFSET_GUI, (normalizeDeg(deg) / MAX_DEG) * MAX_OFFSET_GUI));
+      return Math.max(
+        -MAX_OFFSET_GUI,
+        Math.min(MAX_OFFSET_GUI, (normalizeDeg(deg) / MAX_DEG) * MAX_OFFSET_GUI)
+      );
     }
     function getAxisDeg() {
       if (!getValues) return 0;
       const vals = getValues();
       return axis === 'all' ? 0 : (vals[axis] ?? 0);
+    }
+    function snapGUI(offsetGUI) {
+      for (const deg of SNAP_DEGS) {
+        const sp = (deg / MAX_DEG) * MAX_OFFSET_GUI;
+        if (Math.abs(offsetGUI - sp) <= SNAP_THRESHOLD_GUI) return sp;
+      }
+      return offsetGUI;
     }
     function applyMove(prevGUI, newGUI) {
       const deltaDeg = ((newGUI - prevGUI) / MAX_OFFSET_GUI) * MAX_DEG;
@@ -254,7 +273,8 @@ export function createGizmoMobileHud({
     }
 
     refreshThumb = () => {
-      thumbOffsetGUI = degToGUI(getAxisDeg());
+      rawOffsetGUI = degToGUI(getAxisDeg());
+      thumbOffsetGUI = snapGUI(rawOffsetGUI);
       thumb.left = `${HALF / 2 - THUMB_R + thumbOffsetGUI}px`;
     };
     refreshThumb();
@@ -282,7 +302,8 @@ export function createGizmoMobileHud({
       activeScale = b.scale;
       lastClientX = e.clientX;
       const clampedCSS = Math.max(-b.maxOffsetCSS, Math.min(b.maxOffsetCSS, e.clientX - b.centerX));
-      const newThumbOffsetGUI = clampedCSS / b.scale;
+      rawOffsetGUI = clampedCSS / b.scale;
+      const newThumbOffsetGUI = snapGUI(rawOffsetGUI);
       applyMove(thumbOffsetGUI, newThumbOffsetGUI);
       thumbOffsetGUI = newThumbOffsetGUI;
       thumb.left = `${HALF / 2 - THUMB_R + thumbOffsetGUI}px`;
@@ -294,7 +315,11 @@ export function createGizmoMobileHud({
       const deltaCSS = e.clientX - lastClientX;
       lastClientX = e.clientX;
       if (deltaCSS === 0) return;
-      const newThumbOffsetGUI = Math.max(-MAX_OFFSET_GUI, Math.min(MAX_OFFSET_GUI, thumbOffsetGUI + deltaCSS / activeScale));
+      rawOffsetGUI = Math.max(
+        -MAX_OFFSET_GUI,
+        Math.min(MAX_OFFSET_GUI, rawOffsetGUI + deltaCSS / activeScale)
+      );
+      const newThumbOffsetGUI = snapGUI(rawOffsetGUI);
       applyMove(thumbOffsetGUI, newThumbOffsetGUI);
       thumbOffsetGUI = newThumbOffsetGUI;
       thumb.left = `${HALF / 2 - THUMB_R + thumbOffsetGUI}px`;
@@ -352,8 +377,11 @@ export function createGizmoMobileHud({
   }
   stop.setAxis = (newAxis) => {
     if (stopped) return;
-    const def = AXIS_DEFS.find(d => d.key === newAxis);
-    if (def) { axis = newAxis; refreshAxisVisuals(); }
+    const def = AXIS_DEFS.find((d) => d.key === newAxis);
+    if (def) {
+      axis = newAxis;
+      refreshAxisVisuals();
+    }
   };
   return stop;
 }

--- a/ui/gizmo-mobile-hud.js
+++ b/ui/gizmo-mobile-hud.js
@@ -11,6 +11,7 @@ export function createGizmoMobileHud({
   stepLabels = ['◁', '▷'],
   onAxisChange = null,
   stepLabelsByAxis = null,
+  getValues = null,
   initialAxis = null,
 }) {
   if (!flock.scene || !flock.canvas || !flock.GUI) return null;
@@ -82,6 +83,7 @@ export function createGizmoMobileHud({
 
   let arrowNegBtn = null;
   let arrowPosBtn = null;
+  let refreshThumb = null;
 
   function refreshAxisVisuals() {
     for (const { key, color } of AXIS_DEFS) {
@@ -98,6 +100,7 @@ export function createGizmoMobileHud({
   function updateAxisButtons() {
     refreshAxisVisuals();
     onAxisChange?.(axis);
+    refreshThumb?.();
   }
   refreshAxisVisuals();
 
@@ -182,12 +185,12 @@ export function createGizmoMobileHud({
     arrowPosBtn = makeArrowButton(stepLabels[1], +1, 1);
     refreshAxisVisuals();
   } else {
-    // ── Slider (delta-drag) ───────────────────────────────────────────────
+    // ── Slider (absolute -180…+180) ───────────────────────────────────────
     const THUMB_R = Math.floor(BTN_SIZE / 2) - 2 * s;
     const TRACK_H = 8 * s;
     const SLIDER_MARGIN = THUMB_R + GAP;
     const MAX_OFFSET_GUI = HALF / 2 - SLIDER_MARGIN;
-    const SPEED_FACTOR = stepFast / 10;
+    const MAX_DEG = 180;
     const TRACK_CENTER_Y = TOTAL_H / 2;
 
     const track = new flock.GUI.Rectangle('gizmoTrack');
@@ -221,7 +224,6 @@ export function createGizmoMobileHud({
     thumb.thickness = 0;
     thumb.horizontalAlignment = flock.GUI.Control.HORIZONTAL_ALIGNMENT_LEFT;
     thumb.verticalAlignment = flock.GUI.Control.VERTICAL_ALIGNMENT_TOP;
-    thumb.left = `${HALF / 2 - THUMB_R}px`;
     thumb.top = `${TRACK_CENTER_Y - THUMB_R}px`;
     container.addControl(thumb);
 
@@ -229,6 +231,33 @@ export function createGizmoMobileHud({
     let lastClientX = 0;
     let activePointer = null;
     let activeScale = 1;
+
+    // Normalize any degree value into [-180, 180)
+    function normalizeDeg(deg) {
+      return ((deg % 360) + 540) % 360 - 180;
+    }
+    function degToGUI(deg) {
+      return Math.max(-MAX_OFFSET_GUI, Math.min(MAX_OFFSET_GUI, (normalizeDeg(deg) / MAX_DEG) * MAX_OFFSET_GUI));
+    }
+    function getAxisDeg() {
+      if (!getValues) return 0;
+      const vals = getValues();
+      return axis === 'all' ? 0 : (vals[axis] ?? 0);
+    }
+    function applyMove(prevGUI, newGUI) {
+      const deltaDeg = ((newGUI - prevGUI) / MAX_OFFSET_GUI) * MAX_DEG;
+      const delta = flock.BABYLON.Tools.ToRadians(deltaDeg);
+      if (axis === 'all') onMove(delta, delta, delta);
+      else if (axis === 'x') onMove(delta, 0, 0);
+      else if (axis === 'y') onMove(0, delta, 0);
+      else if (axis === 'z') onMove(0, 0, delta);
+    }
+
+    refreshThumb = () => {
+      thumbOffsetGUI = degToGUI(getAxisDeg());
+      thumb.left = `${HALF / 2 - THUMB_R + thumbOffsetGUI}px`;
+    };
+    refreshThumb();
 
     function sliderBounds() {
       const rect = canvas.getBoundingClientRect();
@@ -253,31 +282,21 @@ export function createGizmoMobileHud({
       activeScale = b.scale;
       lastClientX = e.clientX;
       const clampedCSS = Math.max(-b.maxOffsetCSS, Math.min(b.maxOffsetCSS, e.clientX - b.centerX));
-      thumbOffsetGUI = clampedCSS / b.scale;
+      const newThumbOffsetGUI = clampedCSS / b.scale;
+      applyMove(thumbOffsetGUI, newThumbOffsetGUI);
+      thumbOffsetGUI = newThumbOffsetGUI;
       thumb.left = `${HALF / 2 - THUMB_R + thumbOffsetGUI}px`;
       thumb.background = 'rgba(255,220,50,0.95)';
-      const delta = clampedCSS * SPEED_FACTOR;
-      if (axis === 'all') onMove(delta, delta, delta);
-      else if (axis === 'x') onMove(delta, 0, 0);
-      else if (axis === 'y') onMove(0, delta, 0);
-      else if (axis === 'z') onMove(0, 0, delta);
     }
 
     function onPointerMove(e) {
       if (e.pointerId !== activePointer) return;
       const deltaCSS = e.clientX - lastClientX;
       lastClientX = e.clientX;
-
-      const delta = deltaCSS * SPEED_FACTOR;
-      if (axis === 'all') onMove(delta, delta, delta);
-      else if (axis === 'x') onMove(delta, 0, 0);
-      else if (axis === 'y') onMove(0, delta, 0);
-      else if (axis === 'z') onMove(0, 0, delta);
-
-      thumbOffsetGUI = Math.max(
-        -MAX_OFFSET_GUI,
-        Math.min(MAX_OFFSET_GUI, thumbOffsetGUI + deltaCSS / activeScale)
-      );
+      if (deltaCSS === 0) return;
+      const newThumbOffsetGUI = Math.max(-MAX_OFFSET_GUI, Math.min(MAX_OFFSET_GUI, thumbOffsetGUI + deltaCSS / activeScale));
+      applyMove(thumbOffsetGUI, newThumbOffsetGUI);
+      thumbOffsetGUI = newThumbOffsetGUI;
       thumb.left = `${HALF / 2 - THUMB_R + thumbOffsetGUI}px`;
     }
 

--- a/ui/gizmo-mobile-hud.js
+++ b/ui/gizmo-mobile-hud.js
@@ -241,9 +241,10 @@ export function createGizmoMobileHud({
     let activePointer = null;
     let activeScale = 1;
 
-    // Normalize any degree value into [-180, 180)
+    // Normalize any degree value into (-180, 180]
     function normalizeDeg(deg) {
-      return (((deg % 360) + 540) % 360) - 180;
+      const n = (((deg % 360) + 540) % 360) - 180;
+      return n === -180 ? 180 : n;
     }
     function degToGUI(deg) {
       return Math.max(
@@ -389,6 +390,7 @@ export function createGizmoMobileHud({
     if (def) {
       axis = newAxis;
       refreshAxisVisuals();
+      refreshThumb?.();
     }
   };
   return stop;

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -90,6 +90,7 @@ function createAdaptiveInput({
   onHudHide,
   onAxisChange,
   stepLabelsByAxis,
+  getValues = null,
   initialKeyboardAxis = null,
   initialHudAxis = null,
 }) {
@@ -114,7 +115,7 @@ function createAdaptiveInput({
     onAxisChange?.(axis);
   }
 
-  hud = createGizmoMobileHud({ onMove, stepNormal, stepFast, mode, showUniform, stepLabels, onAxisChange: onHudAxisChange, stepLabelsByAxis, initialAxis: initialHudAxis ?? initialKeyboardAxis });
+  hud = createGizmoMobileHud({ onMove, stepNormal, stepFast, mode, showUniform, stepLabels, onAxisChange: onHudAxisChange, stepLabelsByAxis, getValues, initialAxis: initialHudAxis ?? initialKeyboardAxis });
   keyboard = createAxisKeyboardHandler({ onMove, onConfirm, onCancel, stepNormal, stepFast, onAxisChange: onKbAxisChange, initialAxis: initialKeyboardAxis, allowUniform: showUniform });
   const startAxis = initialKeyboardAxis ?? initialHudAxis;
   if (startAxis) onAxisChange?.(startAxis);
@@ -967,6 +968,7 @@ function startRotateKeyboardHandler(mesh, savedHudAxis = null, onHudAxisSaved = 
     document.getElementById('rotationButton')?.focus();
   };
 
+  const getValues = () => ({ ...working });
   stopAxisKeyboard = createAdaptiveInput({
     onMove,
     onConfirm,
@@ -974,6 +976,7 @@ function startRotateKeyboardHandler(mesh, savedHudAxis = null, onHudAxisSaved = 
     stepNormal: DEFAULT_ROTATION,
     stepFast: FAST_ROTATION,
     mode: 'slider',
+    getValues,
     onHudHide: () => highlightGizmoAxis(gizmoManager.gizmos?.rotationGizmo, null),
     onAxisChange: (axis) => {
       onHudAxisSaved?.(axis);


### PR DESCRIPTION
# Summary

- Rotation slider bar now updates block value and slider position correctly when bar is clicked
- Rotation is from -180 to 180, the slider now reflects the initial position correctly
-  Snap marks at 90 degree angles have been added to aid positionining

<img width="460" height="214" alt="image" src="https://github.com/user-attachments/assets/a90e7f8c-9d4f-4143-9e1b-f7e29701aad1" />



### AI usage
Claude Sonnet 4.6 used throughout, guided by a human. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved mobile gizmo sliders with snapping and tick marks for more precise angle control.
  * Slider controls now stay in sync with the currently selected axis and update visually when switching axes.

* **Bug Fixes**
  * Dragging slider thumbs now uses the current value more reliably, reducing jumpy or inaccurate movement.
  * Rotation input on mobile now updates more consistently when applying adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->