### PR TITLE
Close add menu when Ctrl + G pressed

### DIFF
--- a/accessibility/keyboardui.js
+++ b/accessibility/keyboardui.js
@@ -251,7 +251,13 @@ const GizmoMenuManager = {
   toggle(show) {
     if (!this.overlay) return;
     if (show) {
-      this._closeHooks.forEach((fn) => fn());
+      this._closeHooks.forEach((fn) => {
+        try {
+          fn();
+        } catch (e) {
+          console.error('GizmoMenuManager close hook failed:', e);
+        }
+      });
       this.renderBadges();
 
       if (this._watchFocus) {

--- a/accessibility/keyboardui.js
+++ b/accessibility/keyboardui.js
@@ -210,6 +210,9 @@ const AreaManager = {
 /* Overlay for gizmo buttons */
 const GizmoMenuManager = {
   overlay: null,
+  // Other menus (e.g. the add-shape dropdown) that should close themselves
+  // when the gizmo overlay opens, so they don't sit on top of the gizmos.
+  _closeHooks: [],
   buttons: [
     { id: 'showShapesButton', label: '1' },
     { id: 'colorPickerButton', label: '2' },
@@ -241,9 +244,14 @@ const GizmoMenuManager = {
     return !this.overlay.classList.contains('hidden');
   },
 
+  registerCloseHook(fn) {
+    this._closeHooks.push(fn);
+  },
+
   toggle(show) {
     if (!this.overlay) return;
     if (show) {
+      this._closeHooks.forEach((fn) => fn());
       this.renderBadges();
 
       if (this._watchFocus) {

--- a/ui/addmenu.js
+++ b/ui/addmenu.js
@@ -925,6 +925,16 @@ function cancelPlacement() {
   cleanupPlacementMode();
 }
 
+// Close the add-shape dropdown when the gizmo overlay opens (e.g. Ctrl+G),
+// so it doesn't sit on top of the gizmo buttons it's meant to reveal.
+GizmoMenuManager.registerCloseHook(() => {
+  const dropdown = document.getElementById("shapes-dropdown");
+  if (!dropdown || dropdown.style.display === "none") return;
+  dropdown.style.display = "none";
+  removeKeyboardNavigation();
+  cancelPlacement();
+});
+
 // --- Keyboard Navigation ---
 
 let currentFocusedElement = null;


### PR DESCRIPTION
# Summary
Closes the add shape menu when Ctrl + G pressed so that you can see the gizmos you are selecting

Old behaviour: 
<img width="703" height="559" alt="image" src="https://github.com/user-attachments/assets/822ccc78-93c8-45cf-9001-d101788df93f" />


### AI usage
Claude Sonnet 4.6 wrote all of the code. Not a difficult fix. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Opening the gizmo overlay now automatically closes other open menus, preventing overlapping panels.
  * The shapes dropdown is now hidden and cleaned up when the overlay opens, reducing UI clutter and avoiding interrupted placement mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->