### PR TITLE
Ctrl + P shortcut works when overlay visible

### DIFF
--- a/main/main.js
+++ b/main/main.js
@@ -828,6 +828,14 @@ function initializeApp() {
   });
   KeyboardDispatcher.on('*', 'Mod+KeyP', (e) => {
     e.preventDefault();
+    const stoppedOverlay = document.getElementById('canvasStoppedOverlay');
+    if (stoppedOverlay && !stoppedOverlay.hidden) {
+      // The render canvas is inert while this overlay is showing, so focusing
+      // it would silently no-op. Start the scene instead, same as the play button;
+      // executeCode focuses the canvas itself once it's no longer inert.
+      void executeCode();
+      return;
+    }
     document.getElementById('renderCanvas')?.focus({ preventScroll: true });
   });
   KeyboardDispatcher.on('*', 'Mod+Slash', (e) => {

--- a/main/main.js
+++ b/main/main.js
@@ -827,16 +827,10 @@ function initializeApp() {
     exportCode(workspace);
   });
   KeyboardDispatcher.on('*', 'Mod+KeyP', (e) => {
+    // Documented in the Shortcuts panel as Play (accessibility/keyboardui.js);
+    // match the visible Play button exactly, including restarting a running scene.
     e.preventDefault();
-    const stoppedOverlay = document.getElementById('canvasStoppedOverlay');
-    if (stoppedOverlay && !stoppedOverlay.hidden) {
-      // The render canvas is inert while this overlay is showing, so focusing
-      // it would silently no-op. Start the scene instead, same as the play button;
-      // executeCode focuses the canvas itself once it's no longer inert.
-      void executeCode();
-      return;
-    }
-    document.getElementById('renderCanvas')?.focus({ preventScroll: true });
+    void executeCode();
   });
   KeyboardDispatcher.on('*', 'Mod+Slash', (e) => {
     e.preventDefault();

--- a/style.css
+++ b/style.css
@@ -552,6 +552,12 @@ button {
   display: block;
 }
 
+/* Override the generic .icon brand colour so this icon stays white,
+   matching the button's own colour, on the dark translucent backdrop. */
+.canvas-stopped-overlay__play .icon {
+  color: inherit;
+}
+
 .canvas-stopped-overlay__play:hover,
 .canvas-stopped-overlay__play:focus-visible {
   transform: scale(1.08);


### PR DESCRIPTION
# Summary
When the scene was stopped and the play overlay visible, previously the `Ctrl + P` shortcut to play did not work.

<img width="632" height="389" alt="image" src="https://github.com/user-attachments/assets/64033b03-521a-4fb5-86c2-4d90908ff335" />

This shortcut now works when the overlay is present, and consistently both starts the scene AND focuses the canvas. Also fixed a bug where the play button was showing up as purple and not white.

### AI usage
Claude Sonnet 4.6 used throughout, approved individually by hand. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The `Mod+KeyP` shortcut now starts scene execution directly.
- **Bug Fixes**
  - Improved the stopped-state play button icon so it matches the button’s text color on the overlay.
  - Removed an extra canvas focus step after using the shortcut for smoother interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->