### PR TITLE
Block context menu improvements for keyboard users

### DIFF
--- a/accessibility/keyboardui.js
+++ b/accessibility/keyboardui.js
@@ -518,6 +518,11 @@ function getShortcuts() {
       category: translate('shortcut_category_editor'),
     },
     {
+      label: translate('shortcut_toggle_block_toolbar'),
+      keys: `H`,
+      category: translate('shortcut_category_editor'),
+    },
+    {
       label: translate('shortcut_duplicate_block'),
       keys: `D`,
       category: translate('shortcut_category_editor'),

--- a/locale/de.js
+++ b/locale/de.js
@@ -1238,6 +1238,7 @@ export default {
   shortcut_toolbox_typing: 'Zur Kategorie springen',
   shortcut_toolbox_typing_hint: 'Namen eintippen',
   shortcut_context_menu: 'Kontextmenü öffnen',
+  shortcut_toggle_block_toolbar: 'Block-Hinweisleiste ein-/ausblenden',
   shortcut_duplicate_block: 'Block duplizieren',
   shortcut_detach_block: 'Block trennen',
   shortcut_comment_block: 'Kommentar ein-/ausblenden',

--- a/locale/en.js
+++ b/locale/en.js
@@ -1357,6 +1357,7 @@ export default {
   shortcut_toolbox_typing: 'Skip to category',
   shortcut_toolbox_typing_hint: 'Start typing its name',
   shortcut_context_menu: 'Open context menu',
+  shortcut_toggle_block_toolbar: 'Show/hide block hint toolbar',
   shortcut_duplicate_block: 'Duplicate block',
   shortcut_detach_block: 'Detach block',
   shortcut_comment_block: 'Show/hide comment',

--- a/locale/es.js
+++ b/locale/es.js
@@ -1308,6 +1308,7 @@ export default {
   shortcut_toolbox_typing: 'Ir a la categoría',
   shortcut_toolbox_typing_hint: 'Empieza a escribir su nombre',
   shortcut_context_menu: 'Abrir menú contextual',
+  shortcut_toggle_block_toolbar: 'Mostrar/ocultar la barra de sugerencias del bloque',
   shortcut_duplicate_block: 'Duplicar bloque',
   shortcut_detach_block: 'Desconectar bloque',
   shortcut_comment_block: 'Mostrar/ocultar comentario',

--- a/locale/fr.js
+++ b/locale/fr.js
@@ -1245,6 +1245,7 @@ export default {
   shortcut_toolbox_typing: 'Aller à la catégorie',
   shortcut_toolbox_typing_hint: 'Commencez à taper son nom',
   shortcut_context_menu: 'Ouvrir le menu contextuel',
+  shortcut_toggle_block_toolbar: "Afficher/masquer la barre d'astuces du bloc",
   shortcut_duplicate_block: 'Dupliquer le bloc',
   shortcut_detach_block: 'Détacher le bloc',
   shortcut_comment_block: 'Afficher/masquer le commentaire',

--- a/locale/it.js
+++ b/locale/it.js
@@ -1246,6 +1246,7 @@ export default {
   shortcut_toolbox_typing: 'Vai alla categoria',
   shortcut_toolbox_typing_hint: 'Inizia a digitare il nome',
   shortcut_context_menu: 'Apri menu contestuale',
+  shortcut_toggle_block_toolbar: 'Mostra/nascondi la barra dei suggerimenti del blocco',
   shortcut_duplicate_block: 'Duplica blocco',
   shortcut_detach_block: 'Stacca blocco',
   shortcut_comment_block: 'Mostra/nascondi commento',

--- a/locale/pl.js
+++ b/locale/pl.js
@@ -1238,6 +1238,7 @@ export default {
   shortcut_toolbox_typing: 'Przejdź do kategorii',
   shortcut_toolbox_typing_hint: 'Zacznij wpisywać jej nazwę',
   shortcut_context_menu: 'Otwórz menu kontekstowe',
+  shortcut_toggle_block_toolbar: 'Pokaż/ukryj pasek podpowiedzi bloku',
   shortcut_duplicate_block: 'Duplikuj blok',
   shortcut_detach_block: 'Odłącz blok',
   shortcut_comment_block: 'Pokaż/ukryj komentarz',

--- a/locale/pt.js
+++ b/locale/pt.js
@@ -1248,6 +1248,7 @@ export default {
   shortcut_toolbox_typing: 'Ir para a categoria',
   shortcut_toolbox_typing_hint: 'Comece a digitar o nome',
   shortcut_context_menu: 'Abrir menu de contexto',
+  shortcut_toggle_block_toolbar: 'Mostrar/ocultar a barra de dicas do bloco',
   shortcut_duplicate_block: 'Duplicar bloco',
   shortcut_detach_block: 'Desconectar bloco',
   shortcut_comment_block: 'Mostrar/ocultar comentário',

--- a/locale/sv.js
+++ b/locale/sv.js
@@ -1226,6 +1226,7 @@ export default {
   shortcut_toolbox_typing: 'Hoppa till kategori',
   shortcut_toolbox_typing_hint: 'Börja skriva dess namn',
   shortcut_context_menu: 'Öppna snabbmeny',
+  shortcut_toggle_block_toolbar: 'Visa/dölj blockets tipsfält',
   shortcut_duplicate_block: 'Duplicera block',
   shortcut_detach_block: 'Koppla loss block',
   shortcut_comment_block: 'Visa/dölj kommentar',

--- a/style.css
+++ b/style.css
@@ -2394,6 +2394,13 @@ svg.blocklyTrashcanFlyout {
   opacity: 0.3;
 }
 
+/* Passive keyboard hint in the block toolbar (the "press M to move" icon).
+   Styled like a button so it lines up with its badge, but inert. */
+.fc-block-toolbar-hint {
+  pointer-events: none;
+  cursor: default;
+}
+
 .fc-block-toolbar-btn--delete {
   color: #c0392b;
 }

--- a/ui/contextmenu.js
+++ b/ui/contextmenu.js
@@ -769,6 +769,11 @@ export function initContextMenus(workspace) {
     let lastSelectionWasPointer = false;
     let dismissedBlock = null; // block whose toolbar was just dismissed via toggle; suppress re-show for it only
     let toolbarKeyboardMode = false; // toolbar was opened via keyboard → show badge overlay
+    // Block whose toolbar we hid because a keyboard move (M) just started on
+    // it. Starting a move fires a deselect+reselect SELECTED pair for that
+    // same block (Blockly refocusing it), which would otherwise immediately
+    // reshow the toolbar we just hid; this suppresses exactly that one echo.
+    let suppressReshowBlock = null;
 
     function clearBadges() {
       badgeOverlay.replaceChildren();
@@ -847,18 +852,19 @@ export function initContextMenus(workspace) {
       if (toolbarKeyboardMode) renderBadges();
     }
 
-    // The move hint only appears when the toolbar was opened via keyboard
-    // navigation and the block is loose (unattached), movable and not locked —
-    // i.e. exactly when pressing M is the way to put it somewhere.
-    function updateMoveHint() {
+    // A block that is loose (unattached), movable and not locked is "in
+    // transit" — duplicate/comment don't apply until it's placed somewhere, so
+    // the toolbar simplifies down to just Move (as a keyboard-only hint) and
+    // Delete.
+    const isLooseAndMovable = (block) =>
+      !!block && !isBlockLocked(block) && !isDetachable(block) && !!block.isMovable?.();
+
+    function updateSimplifiedToolbar() {
       const block = toolbarBlock;
-      const show =
-        toolbarKeyboardMode &&
-        !!block &&
-        !isBlockLocked(block) &&
-        !isDetachable(block) &&
-        block.isMovable?.();
-      moveHint.style.display = show ? '' : 'none';
+      const simplified = isLooseAndMovable(block);
+      duplicateBtn.style.display = simplified ? 'none' : '';
+      commentBtn.style.display = isBlockLocked(block) || simplified ? 'none' : '';
+      moveHint.style.display = toolbarKeyboardMode && simplified ? '' : 'none';
     }
 
     // Sync the comment button's icon + label to whether the block has a comment:
@@ -882,9 +888,8 @@ export function initContextMenus(workspace) {
       // comment, delete), leaving duplicate and view-in-canvas available.
       const locked = isBlockLocked(block);
       detachBtn.style.display = !locked && isDetachable(block) ? '' : 'none';
-      updateMoveHint();
-      commentBtn.style.display = locked ? 'none' : '';
       deleteBtn.style.display = locked ? 'none' : '';
+      updateSimplifiedToolbar();
       updateCommentButton(block);
       let mesh = null;
       try {
@@ -934,6 +939,8 @@ export function initContextMenus(workspace) {
           const wasPointer = lastSelectionWasPointer;
           const wasDismissed = block === dismissedBlock;
           dismissedBlock = null;
+          const wasSuppressed = block === suppressReshowBlock;
+          suppressReshowBlock = null;
           if (isToolbarBlock(block)) {
             selectedBlock = block;
 
@@ -944,8 +951,11 @@ export function initContextMenus(workspace) {
               } else {
                 hideBlockToolbar();
               }
-            } else {
+            } else if (!wasSuppressed) {
               // Keyboard navigation: show immediately with the shortcut overlay.
+              // (Suppressed case: this is the reselect echo from starting a
+              // keyboard move — stay hidden so the block is visible while
+              // it's being dragged.)
               showBlockToolbar(block, { keyboard: true });
             }
           } else {
@@ -971,8 +981,9 @@ export function initContextMenus(workspace) {
         toolbarBlock
       ) {
         // A move can attach/detach the block (e.g. X detaches it while the
-        // toolbar is up), so refresh the M hint before re-rendering badges.
-        if (e.type === Blockly.Events.BLOCK_MOVE) updateMoveHint();
+        // toolbar is up), so refresh the simplified-toolbar state before
+        // re-rendering badges.
+        if (e.type === Blockly.Events.BLOCK_MOVE) updateSimplifiedToolbar();
         positionBlockToolbar();
       } else if (
         e.type === Blockly.Events.BLOCK_CHANGE &&
@@ -985,6 +996,12 @@ export function initContextMenus(workspace) {
         updateCommentButton(toolbarBlock);
         if (toolbarKeyboardMode) renderBadges();
       } else if (e.type === Blockly.Events.BLOCK_DRAG && e.isStart) {
+        // A keyboard-initiated move (M) fires this the same as a pointer
+        // drag; flag the block so the SELECTED handler above ignores the
+        // reselect echo that follows and doesn't immediately undo this hide.
+        if (toolbarBlock && toolbarKeyboardMode) {
+          suppressReshowBlock = toolbarBlock;
+        }
         hideBlockToolbar();
       }
     });

--- a/ui/contextmenu.js
+++ b/ui/contextmenu.js
@@ -827,11 +827,36 @@ export function initContextMenus(workspace) {
       !!block?.previousConnection?.targetConnection ||
       !!block?.outputConnection?.targetConnection;
 
+    // A block's own SVG group nests any blocks connected below it (via next
+    // connection), so getBoundingClientRect() on it spans the whole stack —
+    // for a hat block with a long stack underneath, that puts the toolbar way
+    // off to the right of the (narrow) hat itself. getBoundingRectangleWithoutChildren()
+    // returns just this block's own extent, in workspace units; convert that
+    // to screen pixels instead.
+    function getOwnBlockScreenRect(block) {
+      if (!block.getBoundingRectangleWithoutChildren) return null;
+      const wsRect = block.getBoundingRectangleWithoutChildren();
+      const topLeft = Blockly.utils.svgMath.wsToScreenCoordinates(
+        workspace,
+        new Blockly.utils.Coordinate(wsRect.left, wsRect.top)
+      );
+      const bottomRight = Blockly.utils.svgMath.wsToScreenCoordinates(
+        workspace,
+        new Blockly.utils.Coordinate(wsRect.right, wsRect.bottom)
+      );
+      return {
+        left: topLeft.x,
+        top: topLeft.y,
+        width: bottomRight.x - topLeft.x,
+        height: bottomRight.y - topLeft.y,
+      };
+    }
+
     function positionBlockToolbar() {
       if (!toolbarBlock) return;
       const svgRoot = toolbarBlock.getSvgRoot?.();
       if (!svgRoot) return;
-      const rect = svgRoot.getBoundingClientRect();
+      const rect = getOwnBlockScreenRect(toolbarBlock) ?? svgRoot.getBoundingClientRect();
       const blockCenterX = Math.round(rect.left + rect.width / 2);
       blockToolbar.style.left = `${blockCenterX}px`;
       blockToolbar.style.top = `${Math.round(rect.top)}px`;

--- a/ui/contextmenu.js
+++ b/ui/contextmenu.js
@@ -767,6 +767,8 @@ export function initContextMenus(workspace) {
     let selectedBlock = null; // block currently selected (regardless of toolbar visibility)
     let toolbarShowTimer = null;
     let lastSelectionWasPointer = false;
+    let pointerIsDown = false; // a pointer button is currently held — the hover-reveal timer must not fire while true
+    let pendingHoverBlock = null; // block whose hover-reveal was deferred because the pointer was still down when the timer fired
     let dismissedBlock = null; // block whose toolbar was just dismissed via toggle; suppress re-show for it only
     let toolbarKeyboardMode = false; // toolbar was opened via keyboard → show badge overlay
     // Block whose toolbar we hid because a keyboard move (M) just started on
@@ -805,6 +807,30 @@ export function initContextMenus(workspace) {
       'pointerdown',
       () => {
         lastSelectionWasPointer = true;
+        pointerIsDown = true;
+      },
+      { capture: true }
+    );
+    document.addEventListener(
+      'pointerup',
+      () => {
+        pointerIsDown = false;
+        // The hover timer bailed (still held, no drag recognized) rather than
+        // showing — now that the button's up with no drag having intervened,
+        // it's a plain click: reveal now instead of leaving it stuck hidden.
+        if (pendingHoverBlock) {
+          const block = pendingHoverBlock;
+          pendingHoverBlock = null;
+          if (block === selectedBlock && !toolbarBlock) showBlockToolbar(block);
+        }
+      },
+      { capture: true }
+    );
+    document.addEventListener(
+      'pointercancel',
+      () => {
+        pointerIsDown = false;
+        pendingHoverBlock = null;
       },
       { capture: true }
     );
@@ -952,6 +978,7 @@ export function initContextMenus(workspace) {
     function hideBlockToolbar() {
       clearTimeout(toolbarShowTimer);
       toolbarShowTimer = null;
+      pendingHoverBlock = null;
       toolbarBlock = null;
       toolbarKeyboardMode = false;
       blockToolbar.classList.remove('visible');
@@ -980,7 +1007,18 @@ export function initContextMenus(workspace) {
             if (wasPointer) {
               // Pointer selection: reveal after a short hover, no badges.
               if (!wasDismissed) {
-                toolbarShowTimer = setTimeout(() => showBlockToolbar(block), 400);
+                toolbarShowTimer = setTimeout(() => {
+                  toolbarShowTimer = null;
+                  if (pointerIsDown) {
+                    // Button still held with no drag recognized yet — a real
+                    // drag would already have cancelled this timer via
+                    // hideBlockToolbar(). Defer to the pointerup handler
+                    // above: reveal once released, unless a drag starts first.
+                    pendingHoverBlock = block;
+                    return;
+                  }
+                  showBlockToolbar(block);
+                }, 400);
               } else {
                 hideBlockToolbar();
               }

--- a/ui/contextmenu.js
+++ b/ui/contextmenu.js
@@ -852,12 +852,20 @@ export function initContextMenus(workspace) {
       if (toolbarKeyboardMode) renderBadges();
     }
 
-    // A block that is loose (unattached), movable and not locked is "in
-    // transit" — duplicate/comment don't apply until it's placed somewhere, so
-    // the toolbar simplifies down to just Move (as a keyboard-only hint) and
-    // Delete.
+    // A block that COULD attach to something (has a previous/output
+    // connection) but currently isn't — freshly duplicated, just detached,
+    // etc. — is "in transit": duplicate/comment don't apply until it's placed
+    // somewhere, so the toolbar simplifies down to just Move (as a
+    // keyboard-only hint) and Delete. Hat/event blocks (e.g. "start") have
+    // neither connection, so they're always "unattached" without ever being
+    // in transit — exclude them, or every hat block would permanently show
+    // the simplified toolbar.
     const isLooseAndMovable = (block) =>
-      !!block && !isBlockLocked(block) && !isDetachable(block) && !!block.isMovable?.();
+      !!block &&
+      !isBlockLocked(block) &&
+      !isDetachable(block) &&
+      !!block.isMovable?.() &&
+      (!!block.previousConnection || !!block.outputConnection);
 
     function updateSimplifiedToolbar() {
       const block = toolbarBlock;
@@ -1028,25 +1036,21 @@ export function initContextMenus(workspace) {
       { capture: true }
     );
 
-    // Keyboard equivalent of the click-to-toggle above: Enter toggles the
-    // toolbar for the currently selected block. Bare Enter is free while a
-    // canvas block is focused — it's only otherwise bound inside the toolbox
-    // flyout ("add block") and the search box/results, both of which are
-    // excluded here since focus sits on an <input> at that point. The
-    // containment check guards against `selectedBlock` being a stale
-    // reference while focus has actually moved elsewhere (e.g. the toolbox).
+    // Keyboard equivalent of the click-to-toggle above: H toggles the
+    // toolbar for the currently selected block. Unbound elsewhere in this
+    // context, and unlike Enter it doesn't collide with finishing a keyboard
+    // move (M) or any other existing shortcut. The containment check guards
+    // against `selectedBlock` being a stale reference while focus has
+    // actually moved elsewhere (e.g. the toolbox).
     document.addEventListener(
       'keydown',
       (e) => {
-        if (e.key !== 'Enter') return;
+        if (e.key.toLowerCase() !== 'h') return;
         if (isTypingInInput()) return;
         if (e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) return;
         if (!selectedBlock) return;
         const svgRoot = selectedBlock.getSvgRoot?.();
         if (!svgRoot || !svgRoot.contains(document.activeElement)) return;
-        // Stop this from also reaching Blockly's own Enter handling, which
-        // otherwise treats it as "activate" on a block with nothing to
-        // activate and shows a "use arrow keys to navigate inside" hint.
         e.preventDefault();
         e.stopPropagation();
         if (toolbarBlock) {

--- a/ui/contextmenu.js
+++ b/ui/contextmenu.js
@@ -1028,6 +1028,38 @@ export function initContextMenus(workspace) {
       { capture: true }
     );
 
+    // Keyboard equivalent of the click-to-toggle above: Enter toggles the
+    // toolbar for the currently selected block. Bare Enter is free while a
+    // canvas block is focused — it's only otherwise bound inside the toolbox
+    // flyout ("add block") and the search box/results, both of which are
+    // excluded here since focus sits on an <input> at that point. The
+    // containment check guards against `selectedBlock` being a stale
+    // reference while focus has actually moved elsewhere (e.g. the toolbox).
+    document.addEventListener(
+      'keydown',
+      (e) => {
+        if (e.key !== 'Enter') return;
+        if (isTypingInInput()) return;
+        if (e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) return;
+        if (!selectedBlock) return;
+        const svgRoot = selectedBlock.getSvgRoot?.();
+        if (!svgRoot || !svgRoot.contains(document.activeElement)) return;
+        // Stop this from also reaching Blockly's own Enter handling, which
+        // otherwise treats it as "activate" on a block with nothing to
+        // activate and shows a "use arrow keys to navigate inside" hint.
+        e.preventDefault();
+        e.stopPropagation();
+        if (toolbarBlock) {
+          dismissedBlock = selectedBlock;
+          hideBlockToolbar();
+        } else {
+          dismissedBlock = null;
+          showBlockToolbar(selectedBlock, { keyboard: true });
+        }
+      },
+      { capture: true }
+    );
+
     duplicateBtn.addEventListener('pointerdown', (e) => {
       e.preventDefault();
       e.stopPropagation();

--- a/ui/contextmenu.js
+++ b/ui/contextmenu.js
@@ -776,6 +776,12 @@ export function initContextMenus(workspace) {
     // same block (Blockly refocusing it), which would otherwise immediately
     // reshow the toolbar we just hid; this suppresses exactly that one echo.
     let suppressReshowBlock = null;
+    // Mesh availability for a block changes with attach state (code
+    // re-executes on attach/detach, creating/destroying the mesh), but that
+    // re-execution is debounced — it may not have landed yet at the instant
+    // a BLOCK_MOVE event fires. This re-checks shortly after, so viewBtn
+    // catches up once the mesh actually appears/disappears.
+    let viewMeshRecheckTimer = null;
 
     function clearBadges() {
       badgeOverlay.replaceChildren();
@@ -920,10 +926,24 @@ export function initContextMenus(workspace) {
 
     function updateSimplifiedToolbar() {
       const block = toolbarBlock;
+      if (!block) return;
       const simplified = isLooseAndMovable(block);
       duplicateBtn.style.display = simplified ? 'none' : '';
       commentBtn.style.display = isBlockLocked(block) || simplified ? 'none' : '';
       moveHint.style.display = toolbarKeyboardMode && simplified ? '' : 'none';
+      // Loose blocks never show View, regardless of mesh state — no point
+      // waiting on a mesh check for a block that isn't placed anywhere yet.
+      if (simplified) {
+        viewBtn.style.display = 'none';
+        return;
+      }
+      let mesh = null;
+      try {
+        mesh = getMeshFromBlock(block);
+      } catch {
+        /* scene not ready */
+      }
+      viewBtn.style.display = !mesh || mesh.name === 'ground' ? 'none' : '';
     }
 
     // Sync the comment button's icon + label to whether the block has a comment:
@@ -956,7 +976,6 @@ export function initContextMenus(workspace) {
       } catch {
         /* scene not ready */
       }
-      viewBtn.style.display = !mesh || mesh.name === 'ground' ? 'none' : '';
       let meshRoot = mesh;
       while (meshRoot?.parent) meshRoot = meshRoot.parent;
       const exitMode = !!window.orbitViewActive && (window.orbitBlock === block || (meshRoot && window.orbitMesh === meshRoot));
@@ -979,6 +998,8 @@ export function initContextMenus(workspace) {
       clearTimeout(toolbarShowTimer);
       toolbarShowTimer = null;
       pendingHoverBlock = null;
+      clearTimeout(viewMeshRecheckTimer);
+      viewMeshRecheckTimer = null;
       toolbarBlock = null;
       toolbarKeyboardMode = false;
       blockToolbar.classList.remove('visible');
@@ -1054,7 +1075,22 @@ export function initContextMenus(workspace) {
         // A move can attach/detach the block (e.g. X detaches it while the
         // toolbar is up), so refresh the simplified-toolbar state before
         // re-rendering badges.
-        if (e.type === Blockly.Events.BLOCK_MOVE) updateSimplifiedToolbar();
+        if (e.type === Blockly.Events.BLOCK_MOVE) {
+          updateSimplifiedToolbar();
+          // Reattaching can create a mesh (detaching destroys one), but that
+          // happens via debounced code re-execution — it may not have landed
+          // yet. Check again shortly after so View catches up.
+          clearTimeout(viewMeshRecheckTimer);
+          const recheckBlock = toolbarBlock;
+          viewMeshRecheckTimer = setTimeout(() => {
+            viewMeshRecheckTimer = null;
+            if (toolbarBlock !== recheckBlock) return;
+            updateSimplifiedToolbar();
+            // viewBtn's visibility may have just changed; the badge overlay
+            // was last drawn against the old state, so refresh it too.
+            if (toolbarKeyboardMode) renderBadges();
+          }, 400);
+        }
         positionBlockToolbar();
       } else if (
         e.type === Blockly.Events.BLOCK_CHANGE &&

--- a/ui/contextmenu.js
+++ b/ui/contextmenu.js
@@ -657,7 +657,7 @@ export function initContextMenus(workspace) {
 
   // ---- Floating block toolbar ----
   // Pointer selection shows it after a short hover; keyboard navigation shows it
-  // immediately with a shortcut-letter overlay (D/X/K/V/Del) above each button.
+  // immediately with a shortcut-letter overlay (D/X/M/K/V/Del) above each button.
   {
     const blockToolbar = document.createElement('div');
     blockToolbar.className = 'fc-block-toolbar';
@@ -705,6 +705,17 @@ export function initContextMenus(workspace) {
       '0 0 640 512'
     );
 
+    // Passive "press M to move" hint. Looks like a toolbar button but is inert
+    // (pointer-events: none): it exists purely so keyboard users see the move
+    // icon with an M badge when they land on a loose block.
+    const moveHint = document.createElement('span');
+    moveHint.className = 'fc-block-toolbar-btn fc-block-toolbar-hint';
+    moveHint.setAttribute('aria-hidden', 'true');
+    moveHint.innerHTML = mkFaSvg(
+      '<path d="M278.6 9.4c-12.5-12.5-32.8-12.5-45.3 0l-64 64c-9.2 9.2-11.9 22.9-6.9 34.9s16.6 19.8 29.6 19.8l32 0 0 96-96 0 0-32c0-12.9-7.8-24.6-19.8-29.6s-25.7-2.2-34.9 6.9l-64 64c-12.5 12.5-12.5 32.8 0 45.3l64 64c9.2 9.2 22.9 11.9 34.9 6.9s19.8-16.6 19.8-29.6l0-32 96 0 0 96-32 0c-12.9 0-24.6 7.8-29.6 19.8s-2.2 25.7 6.9 34.9l64 64c12.5 12.5 32.8 12.5 45.3 0l64-64c9.2-9.2 11.9-22.9 6.9-34.9s-16.6-19.8-29.6-19.8l-32 0 0-96 96 0 0 32c0 12.9 7.8 24.6 19.8 29.6s25.7 2.2 34.9-6.9l64-64c12.5-12.5 12.5-32.8 0-45.3l-64-64c-9.2-9.2-22.9-11.9-34.9-6.9s-19.8 16.6-19.8 29.6l0 32-96 0 0-96 32 0c12.9 0 24.6-7.8 29.6-19.8s2.2-25.7-6.9-34.9l-64-64z"/>',
+      '0 0 512 512'
+    );
+
     const commentBtn = document.createElement('button');
     commentBtn.type = 'button';
     commentBtn.className = 'fc-block-toolbar-btn';
@@ -734,7 +745,7 @@ export function initContextMenus(workspace) {
     viewBtn.setAttribute('aria-label', getToolbarLabel('view_in_canvas', 'View in canvas'));
     viewBtn.innerHTML = viewEnterSvg;
 
-    blockToolbar.append(duplicateBtn, detachBtn, commentBtn, viewBtn, deleteBtn);
+    blockToolbar.append(duplicateBtn, detachBtn, moveHint, commentBtn, viewBtn, deleteBtn);
 
     // The keyboard shortcut that each toolbar button mirrors. The overlay shows
     // these as a passive legend — the keys themselves are bound elsewhere
@@ -744,6 +755,7 @@ export function initContextMenus(workspace) {
     const buttonShortcuts = [
       [duplicateBtn, 'D'],
       [detachBtn, 'X'],
+      [moveHint, 'M'],
       // Match the comment button's icon: '⇧K' (Shift+K, delete) when the block
       // already has a comment, 'K' (show/hide) when it doesn't.
       [commentBtn, () => (toolbarBlock?.getCommentText?.() != null ? '⇧K' : 'K')],
@@ -835,6 +847,20 @@ export function initContextMenus(workspace) {
       if (toolbarKeyboardMode) renderBadges();
     }
 
+    // The move hint only appears when the toolbar was opened via keyboard
+    // navigation and the block is loose (unattached), movable and not locked —
+    // i.e. exactly when pressing M is the way to put it somewhere.
+    function updateMoveHint() {
+      const block = toolbarBlock;
+      const show =
+        toolbarKeyboardMode &&
+        !!block &&
+        !isBlockLocked(block) &&
+        !isDetachable(block) &&
+        block.isMovable?.();
+      moveHint.style.display = show ? '' : 'none';
+    }
+
     // Sync the comment button's icon + label to whether the block has a comment:
     // crossed-out "delete" icon when it does, plain "add" icon when it doesn't.
     function updateCommentButton(block) {
@@ -856,6 +882,7 @@ export function initContextMenus(workspace) {
       // comment, delete), leaving duplicate and view-in-canvas available.
       const locked = isBlockLocked(block);
       detachBtn.style.display = !locked && isDetachable(block) ? '' : 'none';
+      updateMoveHint();
       commentBtn.style.display = locked ? 'none' : '';
       deleteBtn.style.display = locked ? 'none' : '';
       updateCommentButton(block);
@@ -943,6 +970,9 @@ export function initContextMenus(workspace) {
         (e.type === Blockly.Events.BLOCK_MOVE || e.type === Blockly.Events.VIEWPORT_CHANGE) &&
         toolbarBlock
       ) {
+        // A move can attach/detach the block (e.g. X detaches it while the
+        // toolbar is up), so refresh the M hint before re-rendering badges.
+        if (e.type === Blockly.Events.BLOCK_MOVE) updateMoveHint();
         positionBlockToolbar();
       } else if (
         e.type === Blockly.Events.BLOCK_CHANGE &&


### PR DESCRIPTION
# Summary

## When keyboard controls are in use
- When a block is detached (and could be attached, i.e. is not a hat block), show a context menu with keyboard shortcut hints for move (`M`) and delete (`Del`). The eye button should NOT show when the block is unattached.
<img width="147" height="109" alt="Screenshot 2026-07-09 144844" src="https://github.com/user-attachments/assets/18fc83f0-e22f-4630-8183-70f44ac89432" />

- If you then press `M` to move the block, the toolbar hides so you can see what you are doing
- Keyboard users can toggle the block context menu on and off with `H` (for **h**int) - the same as clicking on the block with a mouse

<img width="182" height="65" alt="Screenshot 2026-07-09 151633" src="https://github.com/user-attachments/assets/75efb09e-ec86-49a1-b15f-d9895b7c4a1d" />

## In all modes
- Block context menu on hat blocks is situated properly at the horizontal center of the hat block rather than at the center of the whole chunk of code
<img width="197" height="155" alt="Screenshot 2026-07-09 151617" src="https://github.com/user-attachments/assets/9a8a267a-fdd2-423b-a7cd-0542141b8e31" />

- The context menu should hide when you're dragging a block (because in that situation, you can't click it!) 

### AI usage
Claude Sonnet 4.6 was used throughout, everything planned checked and individually approved by a human. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a keyboard shortcut to show or hide the block toolbar for the selected block.
  * Expanded shortcut help and added localized labels in multiple languages.
  * Improved the block toolbar so it can show a simpler, more focused set of actions in some cases.

* **Bug Fixes**
  * Made toolbar behavior more reliable during pointer use and keyboard-driven block moves.
  * Improved toolbar positioning for stacked blocks to prevent awkward shifting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->