### PR TITLE
Bugfixes 140726

### DIFF
--- a/index.html
+++ b/index.html
@@ -1162,6 +1162,7 @@
                 data-i18n="color_picker_button"
                 aria-label="Choose a color"
                 title="Choose a color"
+                aria-pressed="false"
               >
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
                   <!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->
@@ -1178,6 +1179,7 @@
                 disabled
                 aria-label="Position mesh"
                 title="Position mesh"
+                aria-pressed="false"
               >
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
                   <!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->
@@ -1194,6 +1196,7 @@
                 disabled
                 aria-label="Rotate mesh"
                 title="Rotate mesh"
+                aria-pressed="false"
               >
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
                   <!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->
@@ -1210,6 +1213,7 @@
                 disabled
                 aria-label="Scale mesh size"
                 title="Scale mesh size"
+                aria-pressed="false"
               >
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
                   <!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->
@@ -1226,6 +1230,7 @@
                 disabled
                 aria-label="Select object"
                 title="Select object"
+                aria-pressed="false"
               >
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512">
                   <!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->
@@ -1242,6 +1247,7 @@
                 disabled
                 aria-label="Duplicate mesh"
                 title="Duplicate selected mesh"
+                aria-pressed="false"
               >
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
                   <!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->
@@ -1258,6 +1264,7 @@
                 disabled
                 aria-label="Delete mesh"
                 title="Delete selected mesh"
+                aria-pressed="false"
               >
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
                   <!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->
@@ -1274,6 +1281,7 @@
                 disabled
                 aria-label="Camera controls"
                 title="Camera controls"
+                aria-pressed="false"
               >
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512">
                   <!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->
@@ -1290,6 +1298,7 @@
                 disabled
                 aria-label="Orbit view"
                 title="Orbit around selected mesh"
+                aria-pressed="false"
               >
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512">
                   <!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->

--- a/ui/blocklyutil.js
+++ b/ui/blocklyutil.js
@@ -239,8 +239,13 @@ export function restoreBlockFocus(workspace, blockId) {
 export function highlightBlockById(workspace, block) {
   if (!workspace || !block || block.workspace !== workspace) return;
 
-  // Select and scroll only when the code view is visible
-  if (window.codeMode === "both") {
+  // Select and scroll only when the code view is actually visible. `window.codeMode`
+  // only tracks the wide-screen split-view toggle (switchView) — the narrow-screen
+  // canvas/code tab toggle (showCanvasView/showCodeView) hides #codePanel via
+  // style.display without ever updating codeMode, so check the DOM directly.
+  const codePanel = document.getElementById("codePanel");
+  const codeVisible = !codePanel || codePanel.style.display !== "none";
+  if (codeVisible) {
     ensureAddMenuSelectionCleanup(workspace);
 
     clearAddMenuHighlight(workspace, block.id);

--- a/ui/colourpicker.css
+++ b/ui/colourpicker.css
@@ -120,6 +120,7 @@ body.color-picker-open #blocklyDiv * {
   background: linear-gradient(to bottom, #ffffff 0%, #808080 50%, #000000 100%);
   background-size: 100% 100%;
   background-repeat: no-repeat;
+  touch-action: none;
 }
 
 .lightness-slider:focus {
@@ -160,6 +161,7 @@ body.color-picker-open #blocklyDiv * {
   cursor: crosshair;
   width: 120px;
   height: 120px;
+  touch-action: none;
 }
 
 .current-color-strip {
@@ -383,6 +385,7 @@ body.color-picker-open #blocklyDiv * {
   height: 20px;
   padding: 8px 0;
   margin: 4px 0;
+  touch-action: none;
 }
 
 .hue-slider-canvas {
@@ -394,6 +397,7 @@ body.color-picker-open #blocklyDiv * {
   position: absolute;
   top: 8px;
   left: 0;
+  touch-action: none;
 }
 .hue-slider-handle {
   position: absolute;
@@ -406,6 +410,7 @@ body.color-picker-open #blocklyDiv * {
   cursor: grab;
   pointer-events: auto;
   transition: box-shadow 0.2s ease;
+  touch-action: none;
 }
 
 .hue-slider-handle:active {

--- a/ui/colourpicker.js
+++ b/ui/colourpicker.js
@@ -1,5 +1,5 @@
 import { translate } from "../main/translation.js";
-import { exitGizmoState } from "./gizmos.js";
+import { exitGizmoState, setGizmoButtonActive } from "./gizmos.js";
 import { KeyboardDispatcher } from "../main/keyboardDispatcher.js";
 import { ContextManager } from "../main/context.js";
 
@@ -1879,7 +1879,7 @@ class CustomColorPicker {
     this.container.style.pointerEvents = "auto";
     this.isOpen = true;
     document.body.classList.add("color-picker-open");
-    document.getElementById("colorPickerButton")?.classList.add("active");
+    setGizmoButtonActive(document.getElementById("colorPickerButton"), true);
 
     // Add C shortcut to pick current colour
     KeyboardDispatcher.on("*", "KeyC", (e) => {
@@ -2099,7 +2099,7 @@ class CustomColorPicker {
     this.container.style.display = "none";
     this.isOpen = false;
     document.body.classList.remove("color-picker-open");
-    document.getElementById("colorPickerButton")?.classList.remove("active");
+    setGizmoButtonActive(document.getElementById("colorPickerButton"), false);
     document.removeEventListener("click", this.outsideClickHandler, true);
     window.removeEventListener("keydown", this.globalEscapeHandler, true);
     KeyboardDispatcher.off("*", "KeyC");

--- a/ui/colourpicker.js
+++ b/ui/colourpicker.js
@@ -1636,36 +1636,51 @@ class CustomColorPicker {
     const handle = this.container.querySelector(".hue-slider-handle");
     const container = this.container.querySelector(".hue-slider-container");
     let isDragging = false;
+    let rafId = null;
+
+    const updateFromClientX = (clientX) => {
+      const rect = this.hueCanvas.getBoundingClientRect();
+      const sliderWidth = this.hueCanvas.width;
+      const x = Math.max(0, Math.min(sliderWidth, clientX - rect.left));
+      this.handleHueSliderClick(x);
+    };
 
     const startDrag = (e) => {
       isDragging = true;
       e.preventDefault();
-      document.addEventListener("mousemove", handleDrag);
-      document.addEventListener("mouseup", endDrag);
+      container.setPointerCapture?.(e.pointerId);
     };
 
     const handleDrag = (e) => {
       if (!isDragging) return;
       e.preventDefault();
-      const rect = this.hueCanvas.getBoundingClientRect();
-      const sliderWidth = this.hueCanvas.width;
-      const x = Math.max(0, Math.min(sliderWidth, e.clientX - rect.left));
-      this.handleHueSliderClick(x);
+      if (rafId) return;
+      rafId = requestAnimationFrame(() => {
+        rafId = null;
+        updateFromClientX(e.clientX);
+      });
     };
 
-    const endDrag = () => {
+    const endDrag = (e) => {
       isDragging = false;
-      document.removeEventListener("mousemove", handleDrag);
-      document.removeEventListener("mouseup", endDrag);
+      try {
+        container.releasePointerCapture?.(e.pointerId);
+      } catch (error) {
+        console.warn("Suppressed non-critical error:", error);
+      }
     };
 
-    handle.addEventListener("mousedown", startDrag);
-    container.addEventListener("mousedown", (e) => {
-      const rect = this.hueCanvas.getBoundingClientRect();
-      const x = e.clientX - rect.left;
-      this.handleHueSliderClick(x);
+    // Starting the drag exactly on the handle doesn't jump the value first;
+    // starting elsewhere on the track jumps to that position immediately.
+    handle.addEventListener("pointerdown", startDrag);
+    container.addEventListener("pointerdown", (e) => {
+      if (e.target === handle) return;
+      updateFromClientX(e.clientX);
       startDrag(e);
     });
+    container.addEventListener("pointermove", handleDrag);
+    container.addEventListener("pointerup", endDrag);
+    container.addEventListener("pointercancel", endDrag);
   }
 
   generateRandomColor() {

--- a/ui/gizmo-mobile-hud.js
+++ b/ui/gizmo-mobile-hud.js
@@ -302,6 +302,7 @@ export function createGizmoMobileHud({
       activePointer = e.pointerId;
       activeScale = b.scale;
       lastClientX = e.clientX;
+      canvas.setPointerCapture(e.pointerId);
       const clampedCSS = Math.max(-b.maxOffsetCSS, Math.min(b.maxOffsetCSS, e.clientX - b.centerX));
       rawOffsetGUI = clampedCSS / b.scale;
       const newThumbOffsetGUI = snapGUI(rawOffsetGUI);

--- a/ui/gizmo-mobile-hud.js
+++ b/ui/gizmo-mobile-hud.js
@@ -240,6 +240,7 @@ export function createGizmoMobileHud({
     let lastClientX = 0;
     let activePointer = null;
     let activeScale = 1;
+    let lastSnappedGUI = null; // GUI offset of the snap tick currently locked into, or null
 
     // Normalize any degree value into (-180, 180]
     function normalizeDeg(deg) {
@@ -271,6 +272,24 @@ export function createGizmoMobileHud({
       else if (axis === 'x') onMove(delta, 0, 0);
       else if (axis === 'y') onMove(0, delta, 0);
       else if (axis === 'z') onMove(0, 0, delta);
+    }
+
+    // Snapping is only obvious as a position change; the thumb is large relative
+    // to the track on mobile, so make the held colour itself reflect snap state
+    // (white on a tick, yellow while dragging off one) plus a haptic tick the
+    // instant a drag locks onto a new one.
+    function isSnapPoint(gui) {
+      return SNAP_DEGS.some((deg) => Math.abs(gui - (deg / MAX_DEG) * MAX_OFFSET_GUI) < 0.01);
+    }
+    function updateThumbHeldColour(newGUI) {
+      if (isSnapPoint(newGUI)) {
+        if (lastSnappedGUI !== newGUI) navigator.vibrate?.(20);
+        lastSnappedGUI = newGUI;
+        thumb.background = 'rgba(255,255,255,0.95)';
+      } else {
+        lastSnappedGUI = null;
+        thumb.background = 'rgba(255,220,50,0.95)';
+      }
     }
 
     refreshThumb = () => {
@@ -317,7 +336,7 @@ export function createGizmoMobileHud({
       }
       thumbOffsetGUI = newThumbOffsetGUI;
       thumb.left = `${HALF / 2 - THUMB_R + thumbOffsetGUI}px`;
-      thumb.background = 'rgba(255,220,50,0.95)';
+      updateThumbHeldColour(newThumbOffsetGUI);
     }
 
     function onPointerMove(e) {
@@ -333,11 +352,13 @@ export function createGizmoMobileHud({
       applyMove(thumbOffsetGUI, newThumbOffsetGUI);
       thumbOffsetGUI = newThumbOffsetGUI;
       thumb.left = `${HALF / 2 - THUMB_R + thumbOffsetGUI}px`;
+      updateThumbHeldColour(newThumbOffsetGUI);
     }
 
     function onPointerUp(e) {
       if (e.pointerId !== activePointer) return;
       activePointer = null;
+      lastSnappedGUI = null;
       thumb.background = 'rgba(255,255,255,0.85)';
     }
 

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -41,12 +41,12 @@ const blueColor = flock.BABYLON.Color3.FromHexString('#0072B2'); // Colour for X
 const greenColor = flock.BABYLON.Color3.FromHexString('#009E73'); // Colour for Y-axis
 const orangeColor = flock.BABYLON.Color3.FromHexString('#D55E00'); // Colour for Z-axis
 
-const FAST_CURSOR = 1; // Step for moving KB cursor quickly
-const DEFAULT_CURSOR = 0.1; // Step for moving KB cursor slowly (default)
-const FAST_ROTATION = 0.5;
-const DEFAULT_ROTATION = 0.05;
-const FAST_SCALE = 0.5;
-const DEFAULT_SCALE = 0.05;
+const DEFAULT_CURSOR = 1; // Step for moving KB cursor with no modifier held
+const FINE_CURSOR = 0.1; // Step for moving KB cursor precisely (Shift held)
+const DEFAULT_ROTATION = 0.5;
+const FINE_ROTATION = 0.05;
+const DEFAULT_SCALE = 0.5;
+const FINE_SCALE = 0.05;
 
 const MODEL_BLOCK_TYPES = new Set([
   'load_model',
@@ -954,8 +954,8 @@ function startMoveKeyboardHandler(mesh, savedHudAxis = null, onHudAxisSaved = nu
     onMove,
     onConfirm,
     onCancel,
-    stepNormal: DEFAULT_CURSOR,
-    stepFast: FAST_CURSOR,
+    stepNormal: FINE_CURSOR,
+    stepFast: DEFAULT_CURSOR,
     mode: 'arrows',
     stepLabelsByAxis: { x: ['◁', '▷'], y: ['▽', '△'], z: ['▽', '△'], all: ['◁', '▷'] },
     onAxisChange: (axis) => {
@@ -1062,8 +1062,8 @@ function startRotateKeyboardHandler(mesh, savedHudAxis = null, onHudAxisSaved = 
     onMove,
     onConfirm,
     onCancel,
-    stepNormal: DEFAULT_ROTATION,
-    stepFast: FAST_ROTATION,
+    stepNormal: FINE_ROTATION,
+    stepFast: DEFAULT_ROTATION,
     mode: 'slider',
     getValues,
     onHudHide: () => highlightGizmoAxis(gizmoManager.gizmos?.rotationGizmo, null),
@@ -1127,8 +1127,8 @@ function startScaleKeyboardHandler(mesh, savedHudAxis = null, onHudAxisSaved = n
     onMove,
     onConfirm,
     onCancel,
-    stepNormal: DEFAULT_SCALE,
-    stepFast: FAST_SCALE,
+    stepNormal: FINE_SCALE,
+    stepFast: DEFAULT_SCALE,
     mode: 'arrows',
     showUniform: true,
     stepLabels: ['-', '+'],

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -2246,7 +2246,6 @@ function _handleBoundsGizmo() {
 
 // Select: Allow the user to select a mesh by clicking on it
 function handleSelectGizmo() {
-  gizmoManager.selectGizmoEnabled = true;
   setGizmoButtonActive(document.getElementById('selectButton'), true);
 
   function applySelection(pickedMesh, pickedPoint) {

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -41,12 +41,12 @@ const blueColor = flock.BABYLON.Color3.FromHexString('#0072B2'); // Colour for X
 const greenColor = flock.BABYLON.Color3.FromHexString('#009E73'); // Colour for Y-axis
 const orangeColor = flock.BABYLON.Color3.FromHexString('#D55E00'); // Colour for Z-axis
 
-const DEFAULT_CURSOR = 1; // Step for moving KB cursor with no modifier held
-const FINE_CURSOR = 0.1; // Step for moving KB cursor precisely (Shift held)
-const DEFAULT_ROTATION = 0.5;
-const FINE_ROTATION = 0.05;
-const DEFAULT_SCALE = 0.5;
-const FINE_SCALE = 0.05;
+const FAST_CURSOR = 1; // Step for moving KB cursor quickly
+const DEFAULT_CURSOR = 0.1; // Step for moving KB cursor slowly (default)
+const FAST_ROTATION = 0.5;
+const DEFAULT_ROTATION = 0.05;
+const FAST_SCALE = 0.5;
+const DEFAULT_SCALE = 0.05;
 
 const MODEL_BLOCK_TYPES = new Set([
   'load_model',
@@ -954,8 +954,8 @@ function startMoveKeyboardHandler(mesh, savedHudAxis = null, onHudAxisSaved = nu
     onMove,
     onConfirm,
     onCancel,
-    stepNormal: FINE_CURSOR,
-    stepFast: DEFAULT_CURSOR,
+    stepNormal: DEFAULT_CURSOR,
+    stepFast: FAST_CURSOR,
     mode: 'arrows',
     stepLabelsByAxis: { x: ['◁', '▷'], y: ['▽', '△'], z: ['▽', '△'], all: ['◁', '▷'] },
     onAxisChange: (axis) => {
@@ -1062,8 +1062,8 @@ function startRotateKeyboardHandler(mesh, savedHudAxis = null, onHudAxisSaved = 
     onMove,
     onConfirm,
     onCancel,
-    stepNormal: FINE_ROTATION,
-    stepFast: DEFAULT_ROTATION,
+    stepNormal: DEFAULT_ROTATION,
+    stepFast: FAST_ROTATION,
     mode: 'slider',
     getValues,
     onHudHide: () => highlightGizmoAxis(gizmoManager.gizmos?.rotationGizmo, null),
@@ -1127,8 +1127,8 @@ function startScaleKeyboardHandler(mesh, savedHudAxis = null, onHudAxisSaved = n
     onMove,
     onConfirm,
     onCancel,
-    stepNormal: FINE_SCALE,
-    stepFast: DEFAULT_SCALE,
+    stepNormal: DEFAULT_SCALE,
+    stepFast: FAST_SCALE,
     mode: 'arrows',
     showUniform: true,
     stepLabels: ['-', '+'],

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -80,6 +80,15 @@ const cleanupFns = [];
 // Track DO sections and their associated blocks for cleanup
 const gizmoCreatedBlocks = new Map(); // blockId -> { parentId, createdDoSection, timestamp }
 
+// Keep the visual "active" state and its ARIA equivalent in sync — used at
+// every gizmo-button activation/deactivation site instead of touching
+// classList and aria-pressed separately.
+export function setGizmoButtonActive(btn, active) {
+  if (!btn) return;
+  btn.classList.toggle('active', active);
+  btn.setAttribute('aria-pressed', active ? 'true' : 'false');
+}
+
 function createAdaptiveInput({
   onMove,
   onConfirm,
@@ -206,7 +215,7 @@ document.addEventListener('DOMContentLoaded', function () {
       },
       onClose: () => {
         // Re-activate button: painting mode is still a gizmo action
-        document.getElementById('colorPickerButton')?.classList.add('active');
+        setGizmoButtonActive(document.getElementById('colorPickerButton'), true);
         pickMeshFromCanvas();
       },
       excludeFromClose: (target) => {
@@ -766,7 +775,7 @@ function attachOrbitView(mesh) {
   window.orbitViewActive = true;
   window.orbitBlock = window.currentBlock ?? null;
   window.orbitMesh = selectedMesh;
-  document.getElementById('eyeButton')?.classList.add('active');
+  setGizmoButtonActive(document.getElementById('eyeButton'), true);
 }
 
 // Restore the stashed free camera, disposing the orbit camera. Does not
@@ -806,7 +815,7 @@ function disconnectOrbitView() {
     window.orbitViewActive = false;
     window.orbitBlock = null;
     window.orbitMesh = null;
-    document.getElementById('eyeButton')?.classList.remove('active');
+    setGizmoButtonActive(document.getElementById('eyeButton'), false);
     return;
   }
   // Orbit camera is active — attempt a real restore. If orbitSavedCamera is
@@ -817,7 +826,7 @@ function disconnectOrbitView() {
   window.orbitViewActive = false;
   window.orbitBlock = null;
   window.orbitMesh = null;
-  document.getElementById('eyeButton')?.classList.remove('active');
+  setGizmoButtonActive(document.getElementById('eyeButton'), false);
   // BabylonJS may clear gizmoManager.attachedMesh when the orbit camera is
   // disposed or usePointerToAttachGizmos is restored. Re-attach so the mesh
   // stays selected and V can re-enter orbit without a pick prompt.
@@ -896,7 +905,7 @@ export function exitGizmoState() {
   runCleanups();
 
   // Remove active class from all buttons
-  document.querySelectorAll('.gizmo-button').forEach((btn) => btn.classList.remove('active'));
+  document.querySelectorAll('.gizmo-button').forEach((btn) => setGizmoButtonActive(btn, false));
   disableGizmos();
   document.body.style.cursor = 'default';
 }
@@ -1749,7 +1758,7 @@ export function toggleGizmo(gizmoType) {
     const activeBtn = document.querySelector('.gizmo-button.active');
     orbitPreviousGizmoType = activeBtn?.id.replace('Button', '') ?? null;
   }
-  document.querySelectorAll('.gizmo-button').forEach((btn) => btn.classList.remove('active'));
+  document.querySelectorAll('.gizmo-button').forEach((btn) => setGizmoButtonActive(btn, false));
 
   // If they abandoned a duplicate half way, remove listener
   if (gizmoType === 'duplicate' && activeDuplicatePickHandler) {
@@ -1840,7 +1849,7 @@ function handleScaleGizmo() {
 
   // Highlight scale button
   const scaleButton = document.getElementById('scaleButton');
-  scaleButton.classList.add('active');
+  setGizmoButtonActive(scaleButton, true);
 
   let savedHudAxis = null;
   const mesh = gizmoManager.attachedMesh;
@@ -2017,7 +2026,7 @@ function handleRotationGizmo() {
 
   // Show that rotation is active
   const rotationButton = document.getElementById('rotationButton');
-  rotationButton.classList.add('active');
+  setGizmoButtonActive(rotationButton, true);
 
   let savedHudAxis = null;
   const mesh = gizmoManager.attachedMesh;
@@ -2107,7 +2116,7 @@ function handlePositionGizmo() {
 
   // Highlight the move button
   const positionButton = document.getElementById('positionButton');
-  positionButton.classList.add('active');
+  setGizmoButtonActive(positionButton, true);
 
   let keyboardAttachedMesh = null;
   let savedHudAxis = null;
@@ -2238,7 +2247,7 @@ function _handleBoundsGizmo() {
 // Select: Allow the user to select a mesh by clicking on it
 function handleSelectGizmo() {
   gizmoManager.selectGizmoEnabled = true;
-  document.getElementById('selectButton')?.classList.add('active');
+  setGizmoButtonActive(document.getElementById('selectButton'), true);
 
   function applySelection(pickedMesh, pickedPoint) {
     if (pickedMesh && pickedMesh.name !== 'ground') {
@@ -2265,7 +2274,7 @@ function handleSelectGizmo() {
 function handleDuplicateGizmo() {
   // Set button active state
   const duplicateButton = document.getElementById('duplicateButton');
-  duplicateButton.classList.add('active');
+  setGizmoButtonActive(duplicateButton, true);
 
   // Check if mesh already selected, if not prompt to select
   if (!gizmoManager.attachedMesh) {
@@ -2292,7 +2301,7 @@ function handleDuplicateGizmo() {
 // Delete: Remove the selected mesh and its corresponding block
 function handleDeleteGizmo() {
   // Highlight the button
-  document.getElementById('deleteButton')?.classList.add('active');
+  setGizmoButtonActive(document.getElementById('deleteButton'), true);
 
   function applyDelete(pickedMesh) {
     if (!pickedMesh || pickedMesh.name === 'ground') {
@@ -2351,13 +2360,13 @@ function handleCameraGizmo() {
       duration: 15,
       color: 'white',
     });
-    cameraButton.classList.add('active');
+    setGizmoButtonActive(cameraButton, true);
   } else {
     cameraMode = 'play';
     flock._onScreenSource?.resume();
     flock._gamepadSource?.setFlyMode(false);
     flock._keyboardSource?.setFlyMode(false);
-    cameraButton.classList.remove('active');
+    setGizmoButtonActive(cameraButton, false);
   }
 
   const currentCamera = flock.scene.activeCamera;
@@ -2436,7 +2445,7 @@ function addUndoHandler() {
 
 // Eye: Orbit camera around selected or picked mesh
 function handleEyeGizmo() {
-  document.getElementById('eyeButton')?.classList.add('active');
+  setGizmoButtonActive(document.getElementById('eyeButton'), true);
 
   const mesh = gizmoManager.attachedMesh;
   if (mesh && mesh.name !== 'ground') {
@@ -2676,7 +2685,7 @@ export function disposeGizmoManager() {
     flock._onScreenSource?.resume();
     flock._gamepadSource?.setFlyMode(false);
     flock._keyboardSource?.setFlyMode(false);
-    document.getElementById('cameraButton')?.classList.remove('active');
+    setGizmoButtonActive(document.getElementById('cameraButton'), false);
   }
   if (gizmoManager) {
     gizmoManager.dispose();


### PR DESCRIPTION
# Summary 
Miscellaneous bugfixes resulting from Claude Fable audit and tests.

- Don't show the block context menu when you select a mesh on a phone in canvas mode. The toggle between code/canvas wasn't turning off the context menu.
- When the slider moves, it goes white when it's over a snap point. It also supposedly provides haptic feedback on Android but I can't test this as I don't have an Android phone.
- Consolidate gizmo active/inactive calls from being CSS class changes to a helper function. Also correctly sets `aria-pressed` now. 
- Fix the sliders in the colour palette which weren't working properly on Android
- Change confusing variable names for the fast/slow (holding shift or not) cursor and rotation

### AI usage
Claude Sonnet 4.6 used throughout, changes approved by a human. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Gizmo controls now expose accurate pressed/unpressed states to assistive technologies.

* **Bug Fixes**
  * Block highlighting now works whenever the code panel is visible.
  * Improved touch handling for color pickers and mobile gizmo controls.
  * Color picker and gizmo buttons now maintain consistent active states.

* **Enhancements**
  * Mobile slider feedback now indicates snap points with color changes and vibration.
  * Refined keyboard adjustment increments for positioning, rotation, and scaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->