### PR TITLE
Gizmo HUD improvements

### DIFF
--- a/main/view.js
+++ b/main/view.js
@@ -17,6 +17,11 @@ export function onResize(mode) {
   // First handle canvas and engine
   resizeCanvas();
   if (flock.engine) flock.engine.resize();
+  // Single choke point for every layout change that can resize the canvas
+  // (window resize, orientation change, the desktop panel resizer drag, view
+  // switches) — anything that lays out from canvas.width/height should listen
+  // for this rather than raw window 'resize', which the panel resizer never fires.
+  window.dispatchEvent(new Event('flock:canvas-resize'));
 
   requestAnimationFrame(() => {
     let scrollX = workspace?.scrollX || 0;

--- a/main/view.js
+++ b/main/view.js
@@ -17,10 +17,7 @@ export function onResize(mode) {
   // First handle canvas and engine
   resizeCanvas();
   if (flock.engine) flock.engine.resize();
-  // Single choke point for every layout change that can resize the canvas
-  // (window resize, orientation change, the desktop panel resizer drag, view
-  // switches) — anything that lays out from canvas.width/height should listen
-  // for this rather than raw window 'resize', which the panel resizer never fires.
+  // Notify listeners that layout needs updating for the new canvas size.
   window.dispatchEvent(new Event('flock:canvas-resize'));
 
   requestAnimationFrame(() => {

--- a/ui/gizmo-mobile-hud.js
+++ b/ui/gizmo-mobile-hud.js
@@ -180,6 +180,7 @@ export function createGizmoMobileHud({
       }
 
       function startRepeat() {
+        if (timeoutId !== null) return;
         pressTime = Date.now();
         step();
         timeoutId = setTimeout(() => {

--- a/ui/gizmo-mobile-hud.js
+++ b/ui/gizmo-mobile-hud.js
@@ -121,6 +121,23 @@ export function createGizmoMobileHud({
     const arrowTotalW = 2 * BTN_SIZE + 3 * GAP;
     const arrowOffsetX = (HALF - arrowTotalW) / 2;
 
+    // Shift means "fine control" — holding it should keep the step at
+    // stepNormal for the whole press, not let the hold-to-accelerate ramp
+    // override it.
+    let shiftHeld = false;
+    const onShiftKeyDown = (e) => {
+      if (e.key === 'Shift') shiftHeld = true;
+    };
+    const onShiftKeyUp = (e) => {
+      if (e.key === 'Shift') shiftHeld = false;
+    };
+    document.addEventListener('keydown', onShiftKeyDown);
+    document.addEventListener('keyup', onShiftKeyUp);
+    cleanups.push(() => {
+      document.removeEventListener('keydown', onShiftKeyDown);
+      document.removeEventListener('keyup', onShiftKeyUp);
+    });
+
     function makeArrowButton(label, sign, idx) {
       const leftPos = arrowOffsetX + GAP + idx * (BTN_SIZE + GAP);
       const btn = flock.GUI.Button.CreateSimpleButton(`gizmo-arrow-${sign}`, label);
@@ -147,6 +164,7 @@ export function createGizmoMobileHud({
       let pressTime = 0;
 
       function currentStep() {
+        if (shiftHeld) return stepNormal;
         const elapsed = Date.now() - pressTime;
         if (elapsed < 1000) return stepNormal;
         if (elapsed < 2000) return stepNormal * 5;

--- a/ui/gizmo-mobile-hud.js
+++ b/ui/gizmo-mobile-hud.js
@@ -126,7 +126,7 @@ export function createGizmoMobileHud({
       const btn = flock.GUI.Button.CreateSimpleButton(`gizmo-arrow-${sign}`, label);
       btn.width = `${BTN_SIZE}px`;
       btn.height = `${BTN_SIZE}px`;
-      btn.fontSize = `${Math.min(40 * s, Math.floor(BTN_SIZE * 0.55))}px`;
+      btn.fontSize = `${Math.min(56 * s, Math.floor(BTN_SIZE * 0.75))}px`;
       btn.fontFamily = fontFamily;
       btn.cornerRadius = 8 * s;
       btn.background = 'transparent';
@@ -138,6 +138,9 @@ export function createGizmoMobileHud({
       btn.left = `${leftPos}px`;
       btn.top = `${GAP}px`;
       container.addControl(btn);
+      // The +/- glyphs sit low within their line-box in this font; nudge up to
+      // visually re-centre them in the button.
+      btn.textBlock.top = `${-Math.round(BTN_SIZE * 0.08)}px`;
 
       let timeoutId = null;
       let intervalId = null;

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -127,11 +127,14 @@ function createAdaptiveInput({
   if (startAxis) onAxisChange?.(startAxis);
   flock.canvas?.focus();
 
-  // The HUD's layout is baked from canvas.width/height once at creation time,
-  // so rotating the device or resizing the window leaves it stale — rebuild it
-  // from scratch (restoring the current axis) rather than reflowing in place.
+  // The HUD's layout is baked from canvas.width/height once at creation time, so
+  // any layout change that resizes the canvas leaves it stale — rebuild it from
+  // scratch (restoring the current axis) rather than reflowing in place. Listen
+  // for the app's 'flock:canvas-resize' event (dispatched from view.js's onResize)
+  // rather than raw window 'resize': the desktop panel-resizer drag changes canvas
+  // size without ever firing a native window resize event.
   let resizeTimer = null;
-  const onResize = () => {
+  const handleCanvasResize = () => {
     clearTimeout(resizeTimer);
     resizeTimer = setTimeout(() => {
       resizeTimer = null;
@@ -140,13 +143,11 @@ function createAdaptiveInput({
       hud = buildHud(lastReportedAxis);
     }, 200);
   };
-  window.addEventListener('resize', onResize);
-  window.addEventListener('orientationchange', onResize);
+  window.addEventListener('flock:canvas-resize', handleCanvasResize);
 
   function stop() {
     clearTimeout(resizeTimer);
-    window.removeEventListener('resize', onResize);
-    window.removeEventListener('orientationchange', onResize);
+    window.removeEventListener('flock:canvas-resize', handleCanvasResize);
     onHudHide?.();
     hud?.();
     keyboard?.();

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -981,7 +981,7 @@ function startMoveKeyboardHandler(mesh, savedHudAxis = null, onHudAxisSaved = nu
     stepNormal: DEFAULT_CURSOR,
     stepFast: FAST_CURSOR,
     mode: 'arrows',
-    stepLabelsByAxis: { x: ['◁', '▷'], y: ['▽', '△'], z: ['▽', '△'], all: ['◁', '▷'] },
+    stepLabels: ['-', '+'],
     onAxisChange: (axis) => {
       onHudAxisSaved?.(axis);
       highlightGizmoAxis(gizmoManager.gizmos?.positionGizmo, axis);

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -117,13 +117,36 @@ function createAdaptiveInput({
     onAxisChange?.(axis);
   }
 
-  hud = createGizmoMobileHud({ onMove, stepNormal, stepFast, mode, showUniform, stepLabels, onAxisChange: onHudAxisChange, stepLabelsByAxis, getValues, initialAxis: initialHudAxis ?? initialKeyboardAxis });
+  function buildHud(initialAxis) {
+    return createGizmoMobileHud({ onMove, stepNormal, stepFast, mode, showUniform, stepLabels, onAxisChange: onHudAxisChange, stepLabelsByAxis, getValues, initialAxis });
+  }
+
+  hud = buildHud(initialHudAxis ?? initialKeyboardAxis);
   keyboard = createAxisKeyboardHandler({ onMove, onConfirm, onCancel, stepNormal, stepFast, onAxisChange: onKbAxisChange, initialAxis: initialKeyboardAxis, allowUniform: showUniform });
   const startAxis = initialKeyboardAxis ?? initialHudAxis;
   if (startAxis) onAxisChange?.(startAxis);
   flock.canvas?.focus();
 
+  // The HUD's layout is baked from canvas.width/height once at creation time,
+  // so rotating the device or resizing the window leaves it stale — rebuild it
+  // from scratch (restoring the current axis) rather than reflowing in place.
+  let resizeTimer = null;
+  const onResize = () => {
+    clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(() => {
+      resizeTimer = null;
+      if (!hud) return;
+      hud();
+      hud = buildHud(lastReportedAxis);
+    }, 200);
+  };
+  window.addEventListener('resize', onResize);
+  window.addEventListener('orientationchange', onResize);
+
   function stop() {
+    clearTimeout(resizeTimer);
+    window.removeEventListener('resize', onResize);
+    window.removeEventListener('orientationchange', onResize);
     onHudHide?.();
     hud?.();
     keyboard?.();

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -136,12 +136,8 @@ function createAdaptiveInput({
   if (startAxis) onAxisChange?.(startAxis);
   flock.canvas?.focus();
 
-  // The HUD's layout is baked from canvas.width/height once at creation time, so
-  // any layout change that resizes the canvas leaves it stale — rebuild it from
-  // scratch (restoring the current axis) rather than reflowing in place. Listen
-  // for the app's 'flock:canvas-resize' event (dispatched from view.js's onResize)
-  // rather than raw window 'resize': the desktop panel-resizer drag changes canvas
-  // size without ever firing a native window resize event.
+  // The HUD's layout is computed once at creation time from canvas.width/height,
+  // so it must be rebuilt whenever the canvas resizes.
   let resizeTimer = null;
   const handleCanvasResize = () => {
     clearTimeout(resizeTimer);


### PR DESCRIPTION
# Summary
Improvements to the mobile HUD for gizmos:

- If the size of the canvas changes (i.e. if you used the resizer, or on mobile if you changed the orientation) then the HUD resizes appropriately
- Move gizmo now uses +/- for moving along the axis rather than direction based buttons, as you could end up in the situation where you were the opposite side of the object and the button would do the opposite of what the buttons advertised! 
<img width="367" height="273" alt="image" src="https://github.com/user-attachments/assets/24e9d75f-a629-4a66-9079-7a99f6255fa3" />

- When holding shift for fine-tuning/slow cursor movement, don't speed up over time, keep the increment the same

### AI usage
Claude Sonnet 4.6 used throughout, all decisions made by a human. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added finer control for mobile gizmo adjustments while holding Shift.
  * Added automatic HUD layout updates when the canvas is resized.

* **Bug Fixes**
  * Improved arrow control styling and alignment for mobile interfaces.
  * Prevented stale HUD layouts after window or canvas size changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->