### PR TITLE
Wrap gizmo menu on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -1007,6 +1007,7 @@
               id="gizmoButtons"
               aria-label="Design tools"
             >
+              <div class="gizmo-buttons-inner">
               <div id="shape-menu">
                 <!-- Gizmo button to toggle the shape menu -->
                 <button
@@ -1308,6 +1309,7 @@
                   />
                 </svg>
               </button>
+              </div>
             </aside>
             <!-- Info panel collapse starts -->
 

--- a/main/view.js
+++ b/main/view.js
@@ -954,22 +954,29 @@ class PanelResizer {
   }
 
   // Smallest canvas-panel width that still fits the gizmo toolbar on one line.
-  // Sums the toolbar's direct children (plus gaps and horizontal padding) so the
-  // result is the single-line row width regardless of current wrapping. Reading
-  // each child's own width avoids counting the absolutely-positioned shape-menu
+  // Sums the toolbar buttons (plus gaps and horizontal padding) so the result is
+  // the single-line row width regardless of current wrapping. Reading each
+  // button's own width avoids counting the absolutely-positioned shape-menu
   // dropdown nested inside #shape-menu, which would otherwise inflate the min.
+  // The buttons live in an inner wrapper (.gizmo-buttons-inner) that carries the
+  // flex layout + gap; #gizmoButtons itself carries the horizontal padding.
   getMinCanvasWidth() {
     const gizmo = document.getElementById('gizmoButtons');
     if (!gizmo) return this.minPanelFloor;
 
-    const style = window.getComputedStyle(gizmo);
-    const gap = parseFloat(style.columnGap || style.gap) || 0;
+    const row = gizmo.querySelector('.gizmo-buttons-inner') || gizmo;
+
+    const paddingStyle = window.getComputedStyle(gizmo);
     const paddingX =
-      (parseFloat(style.paddingLeft) || 0) + (parseFloat(style.paddingRight) || 0);
+      (parseFloat(paddingStyle.paddingLeft) || 0) +
+      (parseFloat(paddingStyle.paddingRight) || 0);
+
+    const rowStyle = window.getComputedStyle(row);
+    const gap = parseFloat(rowStyle.columnGap || rowStyle.gap) || 0;
 
     let total = paddingX;
     let visibleChildren = 0;
-    for (const child of gizmo.children) {
+    for (const child of row.children) {
       const childStyle = window.getComputedStyle(child);
       if (childStyle.display === 'none') continue;
       // getBoundingClientRect excludes margins, so add them explicitly.

--- a/style.css
+++ b/style.css
@@ -692,11 +692,19 @@ button {
 /* Gizmo Buttons */
 .gizmo-buttons {
   font-family: 'Atkinson Hyperlegible Next', 'Asap', Helvetica, Arial, Lucida, sans-serif;
+  padding: 5px 5px 25px 0px;
+  margin: 0;
+  box-sizing: border-box;
+}
+
+/* Separate from #gizmoButtons's own display (toggled directly via inline
+   style in view.js for show/hide) so the mobile layout below can safely
+   switch this to a grid without an inline style winning the cascade. */
+.gizmo-buttons-inner {
   display: flex;
   flex-wrap: wrap;
   gap: 5px;
-  padding: 5px 5px 25px 0px;
-  margin: 0;
+  width: 100%;
   box-sizing: border-box;
 }
 
@@ -723,6 +731,26 @@ button {
 
 .gizmo-button.active {
   background-color: var(--color-focus);
+}
+
+/* On phone widths the toolbar no longer fits on one line. Force a
+   deliberate 5-per-row grid (2 tidy rows for the current 10 buttons)
+   rather than letting flex-wrap overflow unevenly. Columns are sized to
+   content (not 1fr) and the group is centred, so the buttons stay packed
+   together instead of spreading across the full width. Tablets (up to
+   1024px) still fit one row, so this is scoped to phones only. */
+@media (max-width: 600px) {
+  .gizmo-buttons-inner {
+    display: grid;
+    grid-template-columns: repeat(5, auto);
+    justify-content: center;
+    gap: 5px;
+  }
+  /* Neutralise the shape button's desktop left margin, which would
+     otherwise nudge the first column out of line with the row below. */
+  .gizmo-buttons-inner #shape-menu {
+    margin-left: 0;
+  }
 }
 
 .bigbutton.active {

--- a/style.css
+++ b/style.css
@@ -1872,6 +1872,68 @@ body.color-picker-open #renderCanvas {
   list-style: none;
 }
 
+/* On phones the shape button is centred in the 2-row gizmo grid, so the
+   popup's old anchor (bottom-left of that button) ran partway off the right
+   edge. Instead anchor it to the whole gizmo bar and span full width,
+   dropping straight down into the space below the toolbar (its height is
+   capped to that space with an internal scroll in addmenu.js). The rows are
+   stretched to fill the full width so there's no empty grey band on the
+   right, and the tiles are shrunk to suit the smaller screen. Placed after
+   the desktop rules above so these overrides win on source order. */
+@media (max-width: 600px) {
+  #gizmoButtons {
+    position: relative;
+  }
+  #shape-menu {
+    position: static; /* let the popup resolve against #gizmoButtons */
+  }
+  #shapes-dropdown {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 100%; /* directly below the toolbar */
+    bottom: auto;
+    /* top:100% lands below the toolbar's 25px bottom padding, leaving a wide
+       gap; pull the menu back up to sit just under the buttons. */
+    margin-top: -20px;
+    width: auto;
+    max-width: 100%;
+    padding: 10px; /* symmetric so the grey side gaps match */
+    z-index: 80;
+    box-sizing: border-box;
+  }
+  /* Smaller tiles for the smaller screen. */
+  #shapes-dropdown ul li img {
+    width: 40px;
+    height: 40px;
+  }
+  /* Size every row to show exactly 5 tiles, then centre it, so a matching
+     grey margin is left on both sides rather than a single band on the
+     right. 5 * (40px img + 10px li padding) + 4 * 8px gap = 282px. */
+  #shapes-dropdown > ul {
+    grid-template-columns: repeat(5, 1fr);
+    justify-items: center;
+    width: 282px;
+    max-width: 100%;
+    margin-left: auto;
+    margin-right: auto;
+  }
+  .scrollable-container {
+    width: 282px;
+    max-width: 100%;
+    margin-left: auto;
+    margin-right: auto;
+  }
+  /* Nudge the chevrons out past the tiles into the grey side margins so they
+     no longer overlap the first/last tile (30px button + 4px gap). */
+  .scrollable-container .scroll-button.left {
+    left: -34px;
+  }
+  .scrollable-container .scroll-button.right {
+    right: -34px;
+  }
+}
+
 /* Style for the yellow circle to place/select using kb controls */
 .canvas-selector-circle {
   position: fixed;

--- a/ui/addmenu.js
+++ b/ui/addmenu.js
@@ -884,6 +884,30 @@ function cleanupPlacementMode() {
   document.getElementById("showShapesButton")?.classList.remove("active");
 }
 
+// On phones the popup opens below the toolbar into the space beneath it.
+// That space can be shorter than the full menu, which then runs off the
+// bottom of the canvas. Cap the menu's height to the gap between its top and
+// the bottom view-toggle bar (mirroring the colour picker) and scroll inside,
+// so the whole menu is always reachable. No-op on wider layouts.
+function fitShapesDropdownToViewport(dropdown) {
+  if (window.innerWidth > 600) {
+    dropdown.style.maxHeight = "";
+    dropdown.style.overflow = "";
+    return;
+  }
+  const top = dropdown.getBoundingClientRect().top;
+  const bottomBar = document.getElementById("bottomBar");
+  const limit = bottomBar
+    ? bottomBar.getBoundingClientRect().top
+    : window.innerHeight;
+  // Stop the menu just above the bar. No lower floor here: a floor taller than
+  // the available space would push the menu's bottom down over the bar, which
+  // is exactly the overlap we're avoiding. When space is tight it scrolls.
+  const available = Math.max(0, limit - top - 8);
+  dropdown.style.maxHeight = `${available}px`;
+  dropdown.style.overflow = "hidden auto"; // clip x, scroll y when needed
+}
+
 function showShapes() {
   cancelPlacement(); // Always remove all placement modes when menu is opened/closed
 
@@ -896,6 +920,7 @@ function showShapes() {
     removeKeyboardNavigation();
   } else {
     dropdown.style.display = "block";
+    fitShapesDropdownToViewport(dropdown);
     loadObjectImages();
     loadMultiImages();
     loadCharacterImages();
@@ -1048,7 +1073,12 @@ function handleShapeMenuKeydown(event) {
 function startPlacementKeyboardMode() {
   const canvas = flock.scene?.getEngine?.().getRenderingCanvas?.();
   if (!flock.scene || !canvas) return;
-  GizmoMenuManager.toggle(true);
+  // The gizmo overlay shows number-key badges as a keyboard-placement aid.
+  // In the narrow/mobile view there's no keyboard and it would just cover the
+  // 2-row toolbar, so only open it on the wide desktop layout.
+  if (window.innerWidth > 1024) {
+    GizmoMenuManager.toggle(true);
+  }
   const isValidHit = (x, y) =>
     !!flock.scene.pick(x, y, (mesh) => mesh.isPickable)?.hit;
 


### PR DESCRIPTION
# Summary
Wrap the gizmo menu to two lines on mobile phones (very narrow screens). As a consequence of this, also reformat the add shapes popup at narrow screen sizes to make sure it is properly visible. 

<img width="292" height="605" alt="image" src="https://github.com/user-attachments/assets/d9589d0a-9757-4723-8655-2b1631045daa" />

### AI usage
Claude Sonnet 5 used throughout, design decisions made by me and code approved individually. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved the mobile gizmo toolbar with a consistent five-column layout.
  - Repositioned and resized the shape dropdown for better alignment and visibility on small screens.
  - Added responsive scrolling when the shape menu exceeds the available screen height.
  - Adjusted navigation controls to avoid overlapping shape tiles.
  - Prevented the gizmo overlay from covering the toolbar on narrower displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->