### PR TITLE
Landscape mobile menu

### DIFF
--- a/main/view.js
+++ b/main/view.js
@@ -13,6 +13,13 @@ const isMobile = () => {
   return /Mobi|Android|iPad/i.test(navigator.userAgent);
 };
 
+// Phones in landscape dock the gizmo toolbar beside the canvas rather than
+// below it. Must match the media query of the same shape in style.css.
+const gizmosBesideCanvas = () =>
+  window.matchMedia(
+    '(max-width: 1024px) and (orientation: landscape) and (max-height: 500px)',
+  ).matches;
+
 let pendingScrollBlockId = null;
 
 export function onResize(mode) {
@@ -61,7 +68,7 @@ function resizeCanvas() {
   if (!canvasArea || !canvas) return;
 
   const areaRect = canvasArea.getBoundingClientRect();
-  const areaWidth = Math.max(1, Math.round(areaRect.width));
+  let areaWidth = Math.max(1, Math.round(areaRect.width));
   let areaHeight = Math.max(1, Math.round(areaRect.height));
 
   if (flock.embedMode) {
@@ -135,7 +142,20 @@ function resizeCanvas() {
 
   const gizmoButtons = document.getElementById('gizmoButtons');
   if (gizmoButtons && gizmoButtons.style.display != 'none') {
-    areaHeight -= 60; //Gizmos visible
+    if (gizmosBesideCanvas()) {
+      // Docked to the right, so it costs width and the canvas keeps the full
+      // height. Measure the buttons rather than #gizmoButtons itself, which
+      // grows to fill whatever the canvas leaves and so can't size it.
+      const row = gizmoButtons.querySelector('.gizmo-buttons-inner');
+      const barStyle = getComputedStyle(gizmoButtons);
+      const padding =
+        (parseFloat(barStyle.paddingLeft) || 0) +
+        (parseFloat(barStyle.paddingRight) || 0);
+      const buttons = row ? row.getBoundingClientRect().width : 0;
+      areaWidth = Math.max(1, areaWidth - Math.round(buttons + padding));
+    } else {
+      areaHeight -= 60; //Gizmos visible
+    }
   }
 
   // The bottom bar is position:fixed and #canvasArea is sized to the viewport,

--- a/style.css
+++ b/style.css
@@ -737,9 +737,11 @@ button {
    deliberate 5-per-row grid (2 tidy rows for the current 10 buttons)
    rather than letting flex-wrap overflow unevenly. Columns are sized to
    content (not 1fr) and the group is centred, so the buttons stay packed
-   together instead of spreading across the full width. Tablets (up to
-   1024px) still fit one row, so this is scoped to phones only. */
-@media (max-width: 600px) {
+   together instead of spreading across the full width. Shared by portrait
+   phones and phones in landscape (docked beside the canvas, see below);
+   tablets still fit one row in either orientation. */
+@media (max-width: 600px),
+  (max-width: 1024px) and (orientation: landscape) and (max-height: 500px) {
   .gizmo-buttons-inner {
     display: grid;
     grid-template-columns: repeat(5, auto);
@@ -1107,6 +1109,45 @@ button {
     outline: 3px solid var(--color-focus);
     outline-offset: 2px;
     border-radius: 4px;
+  }
+}
+
+/* Phones in landscape are height-starved: the 16:9 canvas is height-bound and
+   leaves unused margin on both sides, so dock the 2-row gizmo block beside the
+   canvas and give the strip's height back. Scoped by max-height to phones;
+   tablets in landscape are tall enough not to need it. `resizeCanvas()` in
+   main/view.js matches this query and must be kept in sync. */
+@media (max-width: 1024px) and (orientation: landscape) and (max-height: 500px) {
+  /* Nothing here may centre its children. #canvasArea is sized to the viewport
+     and the fixed #bottomBar overlaps its lower edge, so the box extends under
+     the bar; resizeCanvas() accounts for that when sizing the canvas, but
+     centring would place it in the full box and push it back under the bar.
+     Everything stays anchored to the top-left instead. */
+  #canvasArea {
+    flex-direction: row;
+  }
+
+  /* Grows into all the width left over beside the canvas (the buttons
+     themselves stay content-sized at its left), so the shape popup can anchor
+     to it and still reach the grey space past the buttons. resizeCanvas()
+     therefore measures .gizmo-buttons-inner, not this — this width depends on
+     the canvas width it is being used to compute. */
+  #gizmoButtons {
+    position: relative;
+    flex: 1 1 auto;
+    padding: 5px;
+    /* display:flex comes from an inline style in view.js */
+    align-items: flex-start;
+  }
+
+  .gizmo-buttons-inner {
+    width: auto;
+  }
+
+  /* The canvas is sized in px to already allow for the toolbar beside it, so it
+     must not be flexed away from that. */
+  #renderCanvas {
+    flex: 0 0 auto;
   }
 }
 
@@ -1932,6 +1973,59 @@ body.color-picker-open #renderCanvas {
   .scrollable-container .scroll-button.right {
     right: -34px;
   }
+}
+
+/* Landscape: open rightward from the plus button, across the rest of the
+   toolbar and the grey space beyond it, so the canvas stays clear. #shape-menu
+   goes static so the popup resolves against #gizmoButtons, whose left edge is
+   fixed relative to the buttons — the button's own position moves with the
+   canvas width, so anchoring to it would need JS. Tiles are 36px so the 5 rows
+   still clear the plus button (5 * (36 + 10) + 4 * 8 = 262px). */
+@media (max-width: 1024px) and (orientation: landscape) and (max-height: 500px) {
+  #shape-menu {
+    position: static;
+  }
+  #shapes-dropdown {
+    top: 5px; /* level with the top row of buttons */
+    /* Start one button in: the bar's 5px padding, a 34px button (7px padding
+       either side of a 20px icon), then the grid's 5px gap. */
+    left: calc(5px + 34px + 5px);
+    right: 5px;
+    bottom: auto;
+    width: auto;
+    padding: 10px;
+    z-index: 80;
+    box-sizing: border-box;
+  }
+  #shapes-dropdown ul li img {
+    width: 36px;
+    height: 36px;
+  }
+  /* Fit as many 46px tiles (36px img + 5px li padding either side) as the width
+     allows, up to the 5 that the gap beside the plus button is sized for. The
+     narrowest landscape phones leave less than that — the canvas alone fills
+     their width — so the count has to drop rather than the rows overflow, which
+     #canvasArea would clip. The scrolling rows keep their chevrons either way. */
+  #shapes-dropdown > ul {
+    grid-template-columns: repeat(auto-fill, 46px);
+    justify-content: center;
+    justify-items: center;
+    width: 100%;
+    max-width: 262px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+  .scrollable-container {
+    width: 100%;
+    max-width: 262px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+  /* Chevrons stay at the desktop -15px, overlapping the first and last tile.
+     Portrait nudges them out to -34px, but there's no margin to do that here:
+     the menu is sized to the gap beside the plus button and the rows fill it,
+     so out-dented chevrons would cover the plus button on the left and be
+     clipped by #canvasArea on the right. */
 }
 
 /* Style for the yellow circle to place/select using kb controls */

--- a/ui/addmenu.js
+++ b/ui/addmenu.js
@@ -884,17 +884,26 @@ function cleanupPlacementMode() {
   document.getElementById("showShapesButton")?.classList.remove("active");
 }
 
-// On phones the popup opens below the toolbar into the space beneath it.
-// That space can be shorter than the full menu, which then runs off the
-// bottom of the canvas. Cap the menu's height to the gap between its top and
-// the bottom view-toggle bar (mirroring the colour picker) and scroll inside,
-// so the whole menu is always reachable. No-op on wider layouts.
+// The two phone layouts in style.css, where the popup opens into space that can
+// be shorter than the full menu: portrait (below the toolbar) and landscape
+// (rightward from the plus button, across the docked toolbar).
+const isPhoneShapesLayout = () =>
+  window.matchMedia("(max-width: 600px)").matches ||
+  window.matchMedia(
+    "(max-width: 1024px) and (orientation: landscape) and (max-height: 500px)",
+  ).matches;
+
+// In those layouts the menu can run off the bottom of the canvas. Cap its
+// height to the gap between its top and the bottom view-toggle bar (mirroring
+// the colour picker) and scroll inside, so all of it stays reachable. No-op on
+// wider layouts.
 function fitShapesDropdownToViewport(dropdown) {
-  if (window.innerWidth > 600) {
-    dropdown.style.maxHeight = "";
-    dropdown.style.overflow = "";
-    return;
-  }
+  // Always measure unclipped: a cap left over from a previous open would hide
+  // how tall the menu actually wants to be.
+  dropdown.style.maxHeight = "";
+  dropdown.style.overflow = "";
+  if (!isPhoneShapesLayout()) return;
+
   const top = dropdown.getBoundingClientRect().top;
   const bottomBar = document.getElementById("bottomBar");
   const limit = bottomBar
@@ -904,6 +913,9 @@ function fitShapesDropdownToViewport(dropdown) {
   // the available space would push the menu's bottom down over the bar, which
   // is exactly the overlap we're avoiding. When space is tight it scrolls.
   const available = Math.max(0, limit - top - 8);
+  // Only clip when it genuinely doesn't fit: scrolling y forces x to clip too,
+  // which would cut off the row chevrons where they sit outside the menu box.
+  if (dropdown.scrollHeight <= available) return;
   dropdown.style.maxHeight = `${available}px`;
   dropdown.style.overflow = "hidden auto"; // clip x, scroll y when needed
 }
@@ -920,10 +932,12 @@ function showShapes() {
     removeKeyboardNavigation();
   } else {
     dropdown.style.display = "block";
-    fitShapesDropdownToViewport(dropdown);
     loadObjectImages();
     loadMultiImages();
     loadCharacterImages();
+    // After the rows are filled: the fit measures how tall the menu actually
+    // is, which is nothing until its tiles exist.
+    fitShapesDropdownToViewport(dropdown);
     setupKeyboardNavigation();
   }
 }


### PR DESCRIPTION
# Summary
On a mobile phone in landscape orientation, the gizmos are now positioned to the right, allowing more room for the canvas. 

<img width="636" height="293" alt="image" src="https://github.com/user-attachments/assets/0791b8c5-c7fe-4b53-a5d3-23bda30b2495" />

The 'Add object' menu now opens to the right, covering the gizmos.
<img width="635" height="292" alt="image" src="https://github.com/user-attachments/assets/8d8c4fca-9343-48c6-8c0a-89bb53b9ceda" />


### AI usage
Claude Sonnet 5 used for all code, design decisions made by a human and code inspected throughout. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Improved gizmo and shape toolbar layouts on phones, including landscape orientation.
  - Toolbars now dock beside the canvas when space allows, preserving more canvas height.
  - Updated shape menus to fit available screen space with improved positioning, sizing, and scrolling.
  - Shape dropdown content is now measured after loading, preventing clipped or oversized menus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->