### PR TITLE
Bugfix: Gizmo button helpers

### DIFF
--- a/ui/addmenu.js
+++ b/ui/addmenu.js
@@ -1077,12 +1077,6 @@ function handleShapeMenuKeydown(event) {
 function startPlacementKeyboardMode() {
   const canvas = flock.scene?.getEngine?.().getRenderingCanvas?.();
   if (!flock.scene || !canvas) return;
-  // The gizmo overlay shows number-key badges as a keyboard-placement aid.
-  // In the narrow/mobile view there's no keyboard and it would just cover the
-  // 2-row toolbar, so only open it on the wide desktop layout.
-  if (window.innerWidth > 1024) {
-    GizmoMenuManager.toggle(true);
-  }
   const isValidHit = (x, y) =>
     !!flock.scene.pick(x, y, (mesh) => mesh.isPickable)?.hit;
 

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -289,7 +289,6 @@ document.addEventListener('DOMContentLoaded', function () {
 function pickMeshFromCanvas() {
   const canvas = flock.scene?.getEngine?.().getRenderingCanvas?.();
   if (!canvas || !flock.scene) return;
-  GizmoMenuManager.toggle(true);
 
   const onPickMesh = function (event) {
     const canvasRect = canvas.getBoundingClientRect();


### PR DESCRIPTION
# Summary

Don't show gizmo button helper numbers when you aren't using keyboard controls. 

### AI usage
Claude Sonnet 5 did this. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved keyboard-based object placement by ensuring selections only target valid, pickable items.
  - Fixed placement behavior so selected objects are positioned accurately based on the canvas location.
  - Prevented the gizmo overlay menu from appearing unexpectedly during canvas picking and keyboard navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->