### PR TITLE
Relocate gizmo badges when gizmos span two rows

### DIFF
--- a/accessibility/keyboardui.js
+++ b/accessibility/keyboardui.js
@@ -365,18 +365,14 @@ const GizmoMenuManager = {
         return { entry, rect: el.getBoundingClientRect() };
       })
       .filter(Boolean);
-    // When the buttons wrap into multiple rows (portrait), a below-button badge
-    // sits on top of the next row's buttons — so only the bottom row keeps its
-    // badge below; every row above it gets the badge placed above instead.
+    // If badges span two rows, put top row badges on top
     const bottomRowTop = Math.max(...visible.map(({ rect }) => rect.top));
     visible.forEach(({ entry, rect }) => {
       const badge = document.createElement('div');
       badge.className = 'gizmo-key-badge';
       badge.innerText = entry.label;
       const isBottomRow = rect.top >= bottomRowTop - rect.height / 2;
-      badge.style.top = isBottomRow
-        ? `${rect.top + rect.height + 8}px`
-        : `${rect.top - 8}px`;
+      badge.style.top = isBottomRow ? `${rect.top + rect.height + 8}px` : `${rect.top - 8}px`;
       badge.style.left = `${rect.left + rect.width / 2}px`;
       container.appendChild(badge);
     });

--- a/accessibility/keyboardui.js
+++ b/accessibility/keyboardui.js
@@ -358,14 +358,25 @@ const GizmoMenuManager = {
   renderBadges() {
     const container = document.getElementById('gizmo-menu-content');
     container.innerHTML = '';
-    this.buttons.forEach((entry) => {
-      const el = document.getElementById(entry.id);
-      if (!el || el.offsetParent === null) return;
-      const rect = el.getBoundingClientRect();
+    const visible = this.buttons
+      .map((entry) => {
+        const el = document.getElementById(entry.id);
+        if (!el || el.offsetParent === null) return null;
+        return { entry, rect: el.getBoundingClientRect() };
+      })
+      .filter(Boolean);
+    // When the buttons wrap into multiple rows (portrait), a below-button badge
+    // sits on top of the next row's buttons — so only the bottom row keeps its
+    // badge below; every row above it gets the badge placed above instead.
+    const bottomRowTop = Math.max(...visible.map(({ rect }) => rect.top));
+    visible.forEach(({ entry, rect }) => {
       const badge = document.createElement('div');
       badge.className = 'gizmo-key-badge';
       badge.innerText = entry.label;
-      badge.style.top = `${rect.top + rect.height + 8}px`;
+      const isBottomRow = rect.top >= bottomRowTop - rect.height / 2;
+      badge.style.top = isBottomRow
+        ? `${rect.top + rect.height + 8}px`
+        : `${rect.top - 8}px`;
       badge.style.left = `${rect.left + rect.width / 2}px`;
       container.appendChild(badge);
     });


### PR DESCRIPTION
# Summary

When the gizmos span two rows, the overlay badges for the upper row should be above the badge

<img width="217" height="140" alt="image" src="https://github.com/user-attachments/assets/cd2cf634-5e02-4fb6-89e9-1729ba5a686c" />


### AI usage
Claude Sonnet 5 wrote the code, designed by me. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard navigation badge placement when gizmo buttons wrap across multiple rows.
  * Prevented badges from overlapping buttons in portrait and other compact layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->