### PR TITLE
Hide context when workspace hidden

### DIFF
--- a/main/view.js
+++ b/main/view.js
@@ -548,6 +548,7 @@ export function togglePlayMode() {
       window.flockShortcutsPanel?.panel?.classList.contains('hidden') ?? true
     );
     window.flockShortcutsPanel?.hide();
+    window.flockBlockToolbar?.hide();
     blocklyArea.style.display = 'none';
     gizmoButtons.style.display = 'none';
     bottomBar.style.display = 'none';

--- a/tests/contextmenu.test.js
+++ b/tests/contextmenu.test.js
@@ -13,6 +13,7 @@ export function runContextMenuTests(_flock) {
     let container;
     let createdBlocks;
     let previousMainWorkspace;
+    let blockToolbar;
 
     before(function () {
       // The full app registers block types during its Blockly-init sequence,
@@ -30,6 +31,8 @@ export function runContextMenuTests(_flock) {
       document.body.appendChild(container);
       workspace = Blockly.inject(container, { collapse: true });
       initContextMenus(workspace);
+      // initContextMenus appends its toolbar to <body>; ours is the newest.
+      blockToolbar = [...document.querySelectorAll('.fc-block-toolbar')].pop();
     });
 
     after(function () {
@@ -270,6 +273,36 @@ export function runContextMenuTests(_flock) {
 
         // It should have landed connected below the target, not floating loose.
         expect(target.nextConnection.isConnected()).to.equal(true);
+      });
+    });
+
+    describe('floating block toolbar', function () {
+      // Blockly fires its change events asynchronously.
+      const flush = () => new Promise((resolve) => setTimeout(resolve, 50));
+
+      it('dismisses itself when repositioned against a collapsed workspace', async function () {
+        const block = makeBlock();
+        // Keyboard modality shows the toolbar at once; pointer waits for a hover.
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+        block.select();
+        await flush();
+        expect(blockToolbar.classList.contains('visible')).to.equal(true);
+
+        // Collapse rather than display:none — the toolbar survives this, so the
+        // dismissal below is the visibility guard rather than a Blockly deselect.
+        container.style.width = '0px';
+        container.style.height = '0px';
+        try {
+          await flush();
+          expect(blockToolbar.classList.contains('visible')).to.equal(true);
+
+          block.moveBy(1, 1); // any event that repositions the toolbar
+          await flush();
+          expect(blockToolbar.classList.contains('visible')).to.equal(false);
+        } finally {
+          container.style.width = '300px';
+          container.style.height = '200px';
+        }
       });
     });
   });

--- a/ui/contextmenu.js
+++ b/ui/contextmenu.js
@@ -884,10 +884,20 @@ export function initContextMenus(workspace) {
       };
     }
 
+    // Play mode hides #codePanel without deselecting the block (main/view.js).
+    const workspaceIsVisible = () => {
+      const div = workspace.getInjectionDiv?.();
+      return !!div && div.clientWidth > 0 && div.clientHeight > 0;
+    };
+
     function positionBlockToolbar() {
       if (!toolbarBlock) return;
       const svgRoot = toolbarBlock.getSvgRoot?.();
       if (!svgRoot) return;
+      if (!workspaceIsVisible()) {
+        hideBlockToolbar();
+        return;
+      }
       const rect = getOwnBlockScreenRect(toolbarBlock) ?? svgRoot.getBoundingClientRect();
       const blockCenterX = Math.round(rect.left + rect.width / 2);
       blockToolbar.style.left = `${blockCenterX}px`;
@@ -1005,6 +1015,8 @@ export function initContextMenus(workspace) {
       blockToolbar.classList.remove('visible');
       clearBadges();
     }
+
+    window.flockBlockToolbar = { hide: hideBlockToolbar };
 
     const isToolbarBlock = (block) => block && !block.isInFlyout && !block.isShadow();
 


### PR DESCRIPTION
# Summary
Don't show the block context toolbar when the workspace isn't visible. Previously, if the toolbar was visible, you entered a mode (e.g. game mode) where the workspace was not visible, and then resized the screen, the block toolbar would appear over the top. 

### AI usage
Claude Sonnet 5 used throughout, guided by a human. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Floating block toolbars now hide correctly when the workspace or code panel is not visible.
  - Entering play mode no longer leaves the block toolbar displayed.
  - Toolbar positioning now responds correctly when the workspace is collapsed or resized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->