### PR TITLE
Bugfix - hide separators with nothing in between

### DIFF
--- a/ui/contextmenu.js
+++ b/ui/contextmenu.js
@@ -27,6 +27,18 @@ function renderShortcut(label, shortcut) {
   return wrapper;
 }
 
+// Hide separators with no items between them
+function collapseSeparators(options) {
+  if (!Array.isArray(options)) return options;
+  const out = [];
+  for (const option of options) {
+    if (!option?.separator) out.push(option);
+    else if (out.length && !out[out.length - 1].separator) out.push(option);
+  }
+  while (out.length && out[out.length - 1].separator) out.pop();
+  return out;
+}
+
 export function initContextMenus(workspace) {
   // ------- Pointer tracking for "paste at pointer" -------
   let lastCM = { x: 0, y: 0 };
@@ -192,8 +204,7 @@ export function initContextMenus(workspace) {
 
     const origDisplayText = item.displayText;
     item.displayText = (scope) => {
-      const text =
-        typeof origDisplayText === 'function' ? origDisplayText(scope) : origDisplayText;
+      const text = typeof origDisplayText === 'function' ? origDisplayText(scope) : origDisplayText;
       const hasComment = scope?.block?.getCommentText?.() != null;
       return renderShortcut(text, hasComment ? 'Shift+K' : 'K');
     };
@@ -423,6 +434,26 @@ export function initContextMenus(workspace) {
     }
   })();
 
+  // Drop separators left stranded
+  (function filterStrandedSeparators() {
+    const proto = Blockly.BlockSvg.prototype;
+    if (!proto.__flockSeparatorFilter) {
+      const origGenerate = proto.generateContextMenu;
+      proto.generateContextMenu = function (...args) {
+        return collapseSeparators(origGenerate.apply(this, args));
+      };
+      proto.__flockSeparatorFilter = true;
+    }
+
+    // Workspace scope has no equivalent method; configureContextMenu is the
+    // documented hook and mutates the array in place.
+    const origConfigure = workspace.configureContextMenu;
+    workspace.configureContextMenu = function (options, e) {
+      origConfigure?.call(this, options, e);
+      options.splice(0, options.length, ...collapseSeparators(options));
+    };
+  })();
+
   // ===== OVERRIDE CLIPBOARD METHODS =====
   const origCopy = Blockly.clipboard.copy;
   const origToastShow = Blockly.Toast?.show;
@@ -493,38 +524,6 @@ export function initContextMenus(workspace) {
   }
 
   const host = workspace.getInjectionDiv() || document;
-  let __fcLastPointer = { x: 0, y: 0 };
-  let __fcLastPointerType = 'mouse'; // 'mouse' | 'touch' | 'pen'
-  let __fcMenuPoint = null;
-  let __fcMenuPointerType = 'mouse';
-
-  host.addEventListener(
-    'pointerdown',
-    (e) => {
-      if (!e.isPrimary) return;
-      __fcLastPointer = { x: e.clientX, y: e.clientY };
-      __fcLastPointerType = e.pointerType || 'mouse';
-    },
-    { capture: true }
-  );
-
-  host.addEventListener(
-    'pointermove',
-    (e) => {
-      if (!e.isPrimary) return;
-      __fcLastPointer = { x: e.clientX, y: e.clientY };
-      __fcLastPointerType = e.pointerType || __fcLastPointerType;
-    },
-    { capture: true }
-  );
-
-  // Capture the *actual* coordinates that opened the context menu (works for long-press)
-  const __origShow = Blockly.ContextMenu.show;
-  Blockly.ContextMenu.show = function (e, options, rtl) {
-    __fcMenuPoint = { x: e.clientX, y: e.clientY };
-    __fcMenuPointerType = e.pointerType || __fcLastPointerType || 'mouse';
-    return __origShow.call(Blockly.ContextMenu, e, options, rtl);
-  };
   host.addEventListener(
     'contextmenu',
     (e) => {
@@ -988,7 +987,9 @@ export function initContextMenus(workspace) {
       }
       let meshRoot = mesh;
       while (meshRoot?.parent) meshRoot = meshRoot.parent;
-      const exitMode = !!window.orbitViewActive && (window.orbitBlock === block || (meshRoot && window.orbitMesh === meshRoot));
+      const exitMode =
+        !!window.orbitViewActive &&
+        (window.orbitBlock === block || (meshRoot && window.orbitMesh === meshRoot));
       viewBtn.innerHTML = exitMode ? viewExitSvg : viewEnterSvg;
       viewBtn.setAttribute(
         'aria-label',

--- a/ui/contextmenu.js
+++ b/ui/contextmenu.js
@@ -33,9 +33,9 @@ function collapseSeparators(options) {
   const out = [];
   for (const option of options) {
     if (!option?.separator) out.push(option);
-    else if (out.length && !out[out.length - 1].separator) out.push(option);
+    else if (out.length && !out[out.length - 1]?.separator) out.push(option);
   }
-  while (out.length && out[out.length - 1].separator) out.pop();
+  while (out.length && out[out.length - 1]?.separator) out.pop();
   return out;
 }
 


### PR DESCRIPTION
# Summary
Don't show separators in right click menu that have no items in between them

**Old behaviour**
<img width="443" height="166" alt="image" src="https://github.com/user-attachments/assets/45ec3619-f136-4210-a2b9-4a00ec2a25cc" />

**New behaviour**
<img width="339" height="188" alt="image" src="https://github.com/user-attachments/assets/a7ed1ab5-754f-4b28-b11e-6615a52b1e8c" />

### AI usage
Claude Opus 4.6 wrote the code, and also removed some dead code from a previous edit. I supervised. 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed redundant, leading, trailing, and consecutive separators from block and workspace context menus.
  - Prevented empty separator rows from appearing in context menus.
  - Simplified pointer tracking for “Paste at pointer” without changing its behavior.

- **Improvements**
  - Preserved localized comment menu labels and keyboard shortcut behavior.
  - Maintained consistent canvas-view enter/exit controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->