### PR TITLE
Update demo text to include on-screen and KB controls

### DIFF
--- a/examples/ball_pit.flock
+++ b/examples/ball_pit.flock
@@ -192,7 +192,7 @@
                             "type": "text",
                             "id": ")FcQIapGh59L9(4I]%.9",
                             "fields": {
-                              "TEXT": "Press e, r, f, or space (or buttons) to drop a ball"
+                              "TEXT": "Press R/E/F/Space or ①②③④ to drop a ball"
                             }
                           }
                         },

--- a/examples/beetle.flock
+++ b/examples/beetle.flock
@@ -110,7 +110,7 @@
                     "type": "text",
                     "id": "CU]5kM)QUQ1-K/p}MR+R",
                     "fields": {
-                      "TEXT": "🎲Click to roll the dice when it's your turn."
+                      "TEXT": "🎲Click/tap or E to roll the dice on your turn."
                     }
                   }
                 },

--- a/examples/boat_trip.flock
+++ b/examples/boat_trip.flock
@@ -1597,7 +1597,7 @@
                             "type": "text",
                             "id": "u,9!XafV3W,d!SW-*A{V",
                             "fields": {
-                              "TEXT": "Press space to board"
+                              "TEXT": "Press space or ④ to board"
                             }
                           }
                         },
@@ -1878,7 +1878,7 @@
                                                                     "type": "text",
                                                                     "id": "00YArH^y9!.NPet*ajJ6",
                                                                     "fields": {
-                                                                      "TEXT": "Find my home. Use WASD to move and drag mouse to pan."
+                                                                      "TEXT": "Find my home. WASD or △▽ to move; drag to pan."
                                                                     }
                                                                   }
                                                                 },

--- a/examples/candy_dash.flock
+++ b/examples/candy_dash.flock
@@ -1212,7 +1212,7 @@
                                 "type": "text",
                                 "id": "@N`:B5!j4l/?Gx+Js9hE",
                                 "fields": {
-                                  "TEXT": "Hold left mouse button down to look around"
+                                  "TEXT": "Drag to look around"
                                 }
                               }
                             },
@@ -1245,7 +1245,7 @@
                                     "type": "text",
                                     "id": "}:U[8XaR4Q$he+oL;;9d",
                                     "fields": {
-                                      "TEXT": "W - forward; S backward; "
+                                      "TEXT": "W/S or the △▽ pad to move"
                                     }
                                   }
                                 },

--- a/examples/collect_the_gems.flock
+++ b/examples/collect_the_gems.flock
@@ -171,7 +171,7 @@
                         "type": "text",
                         "id": "T?sc#:tAwv8d}YXDnwYc",
                         "fields": {
-                          "TEXT": "Hold left mouse button to look around"
+                          "TEXT": "Drag to look around"
                         }
                       }
                     },
@@ -204,7 +204,7 @@
                             "type": "text",
                             "id": "SdNP7^jBWZ_1?}p/=/Vq",
                             "fields": {
-                              "TEXT": "W - Forward, S - Back, Space - Jump"
+                              "TEXT": "W/S or △▽ to move; Space or ④ to jump"
                             }
                           }
                         },

--- a/examples/flockenspiel.flock
+++ b/examples/flockenspiel.flock
@@ -110,7 +110,7 @@
                     "type": "text",
                     "id": "!=aovUp;2c7|ODv+GR]*",
                     "fields": {
-                      "TEXT": "Hold left mouse button down to look around"
+                      "TEXT": "Drag to look around"
                     }
                   }
                 },
@@ -143,7 +143,7 @@
                         "type": "text",
                         "id": "BE:cc!,h7o}U34sk,Fd5",
                         "fields": {
-                          "TEXT": "W - forward; S backward; Space - Jump"
+                          "TEXT": "W/S or △▽ to move; Space or ④ to jump"
                         }
                       }
                     },

--- a/examples/forest_base.flock
+++ b/examples/forest_base.flock
@@ -292,7 +292,7 @@
                     "type": "text",
                     "id": ",RmOh]r6cN`Zy0pE[!@L",
                     "fields": {
-                      "TEXT": "Hold left mouse button down to look around"
+                      "TEXT": "Drag to look around"
                     }
                   }
                 },
@@ -325,7 +325,7 @@
                         "type": "text",
                         "id": "V8;_4T!B,V:$GY2AWQ*t",
                         "fields": {
-                          "TEXT": "W - forward; S - backward"
+                          "TEXT": "W/S or the △▽ pad to move"
                         }
                       }
                     },

--- a/examples/my_place.flock
+++ b/examples/my_place.flock
@@ -395,7 +395,7 @@
                     "type": "text",
                     "id": "Z2g^Bt(0*TmNc}^nbNZe",
                     "fields": {
-                      "TEXT": "Hold left mouse button down to look around"
+                      "TEXT": "Drag to look around"
                     }
                   }
                 },
@@ -428,7 +428,7 @@
                         "type": "text",
                         "id": "~?E$MF%owP=H8id=32=Z",
                         "fields": {
-                          "TEXT": "W - forward; S - backward; Space - Jump"
+                          "TEXT": "W/S or △▽ to move; Space or ④ to jump"
                         }
                       }
                     },
@@ -461,7 +461,7 @@
                             "type": "text",
                             "id": "3RA3-2iiSB%|d;5z7jEX",
                             "fields": {
-                              "TEXT": "Click on the musicbox to play music"
+                              "TEXT": "Click or tap the musicbox to play music"
                             }
                           }
                         },

--- a/examples/physics_fun.flock
+++ b/examples/physics_fun.flock
@@ -143,7 +143,7 @@
                         "type": "text",
                         "id": "gI+Y:?g)#|^}Za8|YGH9",
                         "fields": {
-                          "TEXT": "Click them in different orders"
+                          "TEXT": "Click or tap them in different orders"
                         }
                       }
                     },

--- a/examples/roominator.flock
+++ b/examples/roominator.flock
@@ -61,7 +61,7 @@
                         "type": "text",
                         "id": "q#2HdQVy5|iCa}/7.qj4",
                         "fields": {
-                          "TEXT": "Hold left mouse button down to look around"
+                          "TEXT": "Drag to look around"
                         }
                       }
                     },
@@ -94,7 +94,7 @@
                             "type": "text",
                             "id": "_~xhmp6j9|RPs_!8A|8z",
                             "fields": {
-                              "TEXT": "W: Forward, S: Backward, Space: Jump"
+                              "TEXT": "W/S or △▽ to move; Space or ④ to jump"
                             }
                           }
                         },

--- a/examples/shape_push.flock
+++ b/examples/shape_push.flock
@@ -1063,7 +1063,7 @@
                     "type": "text",
                     "id": "Pp(7b$ZpWQ#Rx9_eL!yW",
                     "fields": {
-                      "TEXT": "WASD to move, push the colored shapes onto the grey shapes"
+                      "TEXT": "WASD or the △▽ pad to move. Push shapes onto the grey ones."
                     }
                   }
                 },

--- a/examples/sit_down.flock
+++ b/examples/sit_down.flock
@@ -272,7 +272,7 @@
                                         "type": "text",
                                         "id": "dJc6LI4EGx*5S46FH16x",
                                         "fields": {
-                                          "TEXT": "👇🏾Click to sit 👇🏾"
+                                          "TEXT": "👇🏾Click/tap or E to sit 👇🏾"
                                         }
                                       }
                                     },
@@ -901,7 +901,7 @@
                             "type": "text",
                             "id": "=L-/-1HT`]edbp63Mo8Q",
                             "fields": {
-                              "TEXT": "Hold left mouse button down to look around"
+                              "TEXT": "Drag to look around"
                             }
                           }
                         },
@@ -934,7 +934,7 @@
                                 "type": "text",
                                 "id": "rDKLD?S[.4^HZ(g*vX^y",
                                 "fields": {
-                                  "TEXT": "W - forward; S backward; Space - Jump"
+                                  "TEXT": "W/S or △▽ to move; Space or ④ to jump"
                                 }
                               }
                             },

--- a/examples/skittles.flock
+++ b/examples/skittles.flock
@@ -110,7 +110,7 @@
                     "type": "text",
                     "id": "tu226(eQzlW@;(uN)]~=",
                     "fields": {
-                      "TEXT": "🎳 A - left; D - right; SPACE  (4) - launch"
+                      "TEXT": "🎳 A/D or◁/▷ to move, Space/④ to launch"
                     }
                   }
                 },

--- a/examples/snow_globe.flock
+++ b/examples/snow_globe.flock
@@ -176,7 +176,7 @@
                             "type": "text",
                             "id": "/e`D|mM5~.MTw.k/+z{,",
                             "fields": {
-                              "TEXT": "WASD to move"
+                              "TEXT": "WASD or the △▽ pad to move"
                             }
                           }
                         },

--- a/examples/tallest_buildings.flock
+++ b/examples/tallest_buildings.flock
@@ -101,7 +101,7 @@
         "y": 254,
         "icons": {
           "comment": {
-            "text": "Watch the worlds \ntallest buildings\nbeing build in order. \n\nAt the end you can use the \narrow keys to move \nthe camera around. ",
+            "text": "Watch the worlds \ntallest buildings\nbeing build in order. \n\nAt the end you can use the \narrow keys or the on-screen \npad to move the camera. ",
             "pinned": false,
             "height": 143.47097778320312,
             "width": 246.08258056640625,

--- a/examples/tent_lights.flock
+++ b/examples/tent_lights.flock
@@ -159,7 +159,7 @@
                                 "type": "text",
                                 "id": "=L-/-1HT`]edbp63Mo8Q",
                                 "fields": {
-                                  "TEXT": "Hold left mouse button down to look around"
+                                  "TEXT": "Drag to look around"
                                 }
                               }
                             },
@@ -192,7 +192,7 @@
                                     "type": "text",
                                     "id": "rDKLD?S[.4^HZ(g*vX^y",
                                     "fields": {
-                                      "TEXT": "W - forward; S backward; Space - Jump"
+                                      "TEXT": "W/S or △▽ to move; Space or ④ to jump"
                                     }
                                   }
                                 },

--- a/examples/tree_jump.flock
+++ b/examples/tree_jump.flock
@@ -388,7 +388,7 @@
                             "type": "text",
                             "id": "rDKLD?S[.4^HZ(g*vX^y",
                             "fields": {
-                              "TEXT": "Space  (4) - Jump"
+                              "TEXT": "Space or ④ to jump"
                             }
                           }
                         },

--- a/examples/ur_enough.flock
+++ b/examples/ur_enough.flock
@@ -45,7 +45,7 @@
                         "type": "text",
                         "id": "YOTu+j{cRJ#dQ[Hh?Y7d",
                         "fields": {
-                          "TEXT": "Click to open"
+                          "TEXT": "Click or tap to open"
                         }
                       }
                     },


### PR DESCRIPTION
# Summary
Previously the instructions in some of the demo projects only applied to desktop use. Modify all to include mobile and keyboard interaction paths. 

<img width="346" height="110" alt="image" src="https://github.com/user-attachments/assets/c983ccdd-d949-4330-bd01-c0936b4b29fb" />


### AI usage
Claude Opus 5 used to scan for the strings. Edits approved by a human and some of Claude's output modified. Tested manually in each project. 