### PR TITLE
Add tab for on-screen and gamepad controls

### DIFF
--- a/accessibility/keyboardui.js
+++ b/accessibility/keyboardui.js
@@ -991,16 +991,117 @@ const ShortcutsPanel = {
   },
 };
 
-// Touch equivalent of ShortcutsPanel: a second info panel tab. Docked-only —
-// narrow landscape hides #info-panel outright (along with this tab), so there's
-// no modal counterpart to fall back to.
-const TouchPanel = {
+const CONTROL_MARKS = {
+  up: '<path d="M12 5 20 18 4 18Z"/>',
+  down: '<path d="M12 19 4 6 20 6Z"/>',
+  left: '<path d="M5 12 18 4 18 20Z"/>',
+  right: '<path d="M19 12 6 20 6 4Z"/>',
+  triangle: '<path d="M12 4 21 19 3 19Z"/>',
+  circle: '<circle cx="12" cy="12" r="8"/>',
+  square: '<rect x="4.5" y="4.5" width="15" height="15" rx="1"/>',
+  cross: '<path d="M5 5 19 19M19 5 5 19"/>',
+  stick: '<circle cx="12" cy="8.5" r="4.5"/><path d="M12 13v4M7 20h10"/>',
+};
+
+const svgMark = (name) =>
+  `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round" stroke-linecap="round">${CONTROL_MARKS[name]}</svg>`;
+
+const svgRingedChar = (char) =>
+  `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><text x="12" y="12" text-anchor="middle" dominant-baseline="central" font-size="13" fill="currentColor" stroke="none">${char}</text></svg>`;
+
+function getPlayerControls() {
+  return [
+    {
+      section: 'player_section_onscreen',
+      entries: [
+        {
+          action: 'player_action_move',
+          marks: ['up', 'left', 'down', 'right'].map(svgMark),
+          layout: 'dpad',
+          label: translate('player_control_arrows'),
+        },
+        {
+          action: 'player_action_camera_up',
+          marks: [svgRingedChar(1)],
+          label: translate('player_control_button').replace('%1', 1),
+        },
+        {
+          action: 'player_action_camera_down',
+          marks: [svgRingedChar(3)],
+          label: translate('player_control_button').replace('%1', 3),
+        },
+        {
+          action: 'player_action_interact',
+          marks: [svgRingedChar(2)],
+          label: translate('player_control_button').replace('%1', 2),
+        },
+        {
+          action: 'player_action_spare',
+          marks: [svgRingedChar(4)],
+          label: translate('player_control_button').replace('%1', 4),
+        },
+      ],
+    },
+    {
+      section: 'player_section_gamepad',
+      entries: [
+        {
+          action: 'player_action_move',
+          keys: '"Left stick"',
+        },
+        {
+          action: 'player_action_look',
+          keys: '"Right stick"',
+        },
+        {
+          action: 'player_action_turn',
+          keys: 'L1 / R1',
+        },
+        {
+          action: 'player_action_camera_up',
+          keys: 'Triangle / Y',
+        },
+        {
+          action: 'player_action_camera_down',
+          keys: 'Square / X',
+        },
+        {
+          action: 'player_action_interact',
+          keys: 'Circle / B',
+        },
+        {
+          action: 'player_action_spare',
+          keys: 'Cross / A',
+        },
+        {
+          action: 'player_control_dpad_up',
+          keys: 'D-pad Up',
+        },
+        {
+          action: 'player_control_dpad_down',
+          keys: 'D-pad Down',
+        },
+        {
+          action: 'player_control_dpad_left',
+          keys: 'D-pad Left',
+        },
+      ],
+    },
+  ];
+}
+
+// On-screen and gamepad counterpart to ShortcutsPanel: a second info panel tab.
+// Docked-only — narrow landscape hides #info-panel outright (along with this
+// tab), so there's no modal counterpart to fall back to.
+const PlayerPanel = {
   panel: null,
+  previousFocus: null,
+  fontSize: parseFloat(localStorage.getItem(SHORTCUTS_FONT_SIZE_KEY)) || SHORTCUTS_FONT_SIZE_DEFAULT,
 
   init() {
     this.createPanel();
     this.setupListeners();
-    window.flockTouchPanel = this;
+    window.flockPlayerPanel = this;
 
     // Rotating into narrow landscape hides the info panel mid-view, which would
     // leave this panel marked active but invisible.
@@ -1010,31 +1111,89 @@ const TouchPanel = {
   },
 
   createPanel() {
-    const panel = InfoPanel.register('touch', translate('touch_panel_title'));
-    const btn = document.getElementById('info-tab-btn-touch');
+    const panel = InfoPanel.register('player', translate('player_panel_title'));
+    const btn = document.getElementById('info-tab-btn-player');
     btn.innerHTML = `<div class="icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512"><path fill="currentColor" fill-rule="evenodd" d="M60,144H516A36,36 0 0 1 552,180V332A36,36 0 0 1 516,368H60A36,36 0 0 1 24,332V180A36,36 0 0 1 60,144ZM134,180h52v50h50v52h-50v50h-52v-50h-50v-52h50ZM364,224a40,40 0 1 0 80,0a40,40 0 1 0 -80,0ZM428,296a40,40 0 1 0 80,0a40,40 0 1 0 -80,0Z"/></svg></div>`;
     panel.innerHTML = `
         <div class="shortcuts-panel-header">
-          <h2 id="touch-panel-title" class="shortcuts-panel-title"></h2>
+          <h2 id="player-panel-title" class="shortcuts-panel-title"></h2>
+          <div class="shortcuts-panel-controls">
+            <button class="bigbutton player-decrease-btn" aria-label="Decrease text size" title="Decrease text size"><span aria-hidden="true">A</span></button>
+            <button class="bigbutton player-increase-btn" aria-label="Increase text size" title="Increase text size"><span aria-hidden="true">A</span></button>
+          </div>
         </div>
-        <div id="touch-list"></div>
+        <div id="player-list"></div>
       `;
     this.panel = panel;
+    const sizes = SHORTCUTS_FONT_SIZES;
+    const decreaseBtn = panel.querySelector('.player-decrease-btn');
+    const increaseBtn = panel.querySelector('.player-increase-btn');
+    decreaseBtn.disabled = this.fontSize === sizes[0];
+    increaseBtn.disabled = this.fontSize === sizes[sizes.length - 1];
+    decreaseBtn.addEventListener('click', () => this.adjustFontSize(-1));
+    increaseBtn.addEventListener('click', () => this.adjustFontSize(1));
+    panel.querySelector('#player-list').style.fontSize = this.fontSize + 'em';
     this.renderContent();
   },
 
+  adjustFontSize(delta) {
+    const sizes = SHORTCUTS_FONT_SIZES;
+    const idx = sizes.indexOf(this.fontSize);
+    const next = sizes[Math.max(0, Math.min(sizes.length - 1, idx + delta))];
+    if (next === this.fontSize) return;
+    this.fontSize = next;
+    localStorage.setItem(SHORTCUTS_FONT_SIZE_KEY, next);
+    this.panel.querySelector('#player-list').style.fontSize = next + 'em';
+    this.panel.querySelector('.player-decrease-btn').disabled = next === sizes[0];
+    this.panel.querySelector('.player-increase-btn').disabled = next === sizes[sizes.length - 1];
+  },
+
   renderContent() {
-    const title = translate('touch_panel_title');
-    const btn = document.getElementById('info-tab-btn-touch');
+    const title = translate('player_panel_title');
+    const btn = document.getElementById('info-tab-btn-player');
     btn.setAttribute('aria-label', title);
     btn.setAttribute('title', title);
-    this.panel.querySelector('#touch-panel-title').textContent = title;
+    this.panel.querySelector('#player-panel-title').textContent = title;
+
+    const renderControl = (entry) => {
+      if (entry.marks) {
+        return `<span class="pc-keys${entry.layout ? ` pc-keys--${entry.layout}` : ''}" aria-hidden="true">${entry.marks
+          .map((m) => `<span class="pc-chip">${m}</span>`)
+          .join('')}</span><span class="sr-only">${entry.label}</span>`;
+      }
+      return formatKeys(entry.keys);
+    };
+
+    const sections = getPlayerControls()
+      .map(
+        ({ section, entries }) => `
+      <h3 class="shortcuts-category">${translate(section)}</h3>
+      <dl class="shortcuts-group">
+        ${entries
+          .map(
+            (entry) => `
+        <div class="shortcuts-entry">
+          <dt>${translate(entry.action)}</dt>
+          <dd>${renderControl(entry)}</dd>
+        </div>`
+          )
+          .join('')}
+      </dl>`
+      )
+      .join('');
+
+    const playerList = this.panel.querySelector('#player-list');
+    playerList.innerHTML = `
+        ${sections}
+        <p class="player-controls-note">${translate('player_control_dpad_note')}</p>
+      `;
+    playerList.style.fontSize = this.fontSize + 'em';
   },
 
   show() {
     this.renderContent();
     this.previousFocus = document.activeElement;
-    InfoPanel.activate('touch');
+    InfoPanel.activate('player');
   },
 
   refreshTranslations() {
@@ -1044,7 +1203,7 @@ const TouchPanel = {
   hide() {
     this.previousFocus?.focus();
     this.previousFocus = null;
-    InfoPanel.deactivate('touch');
+    InfoPanel.deactivate('player');
   },
 
   toggle() {
@@ -1057,7 +1216,7 @@ const TouchPanel = {
       e.preventDefault();
       e.stopPropagation();
       this.hide();
-      document.getElementById('info-tab-btn-touch')?.focus();
+      document.getElementById('info-tab-btn-player')?.focus();
     });
   },
 };
@@ -1068,7 +1227,7 @@ GizmoMenuManager.init();
 if (document.getElementById('info-panel-tabs')) {
   InfoPanel.init();
   ShortcutsPanel.init();
-  TouchPanel.init();
+  PlayerPanel.init();
 }
 
-export { InfoPanel, ShortcutsPanel, TouchPanel, GizmoMenuManager, AreaManager };
+export { InfoPanel, ShortcutsPanel, PlayerPanel, GizmoMenuManager, AreaManager };

--- a/accessibility/keyboardui.js
+++ b/accessibility/keyboardui.js
@@ -786,8 +786,8 @@ const ShortcutsPanel = {
         <div class="shortcuts-panel-header">
           <h2 id="shortcuts-panel-title" class="shortcuts-panel-title"></h2>
           <div class="shortcuts-panel-controls">
-            <button class="bigbutton shortcuts-decrease-btn" aria-label="Decrease text size" title="Decrease text size"><span aria-hidden="true">A</span></button>
-            <button class="bigbutton shortcuts-increase-btn" aria-label="Increase text size" title="Increase text size"><span aria-hidden="true">A</span></button>
+            <button class="bigbutton shortcuts-decrease-btn" aria-label="${translate('player_decrease_font_size')}" title="${translate('player_decrease_font_size')}"><span aria-hidden="true">A</span></button>
+            <button class="bigbutton shortcuts-increase-btn" aria-label="${translate('player_increase_font_size')}" title="${translate('player_increase_font_size')}"><span aria-hidden="true">A</span></button>
             <a href="${SHORTCUTS_HELP_URL}" target="_blank" rel="noopener noreferrer" class="help-link-button" aria-label="${translate('shortcut_panel_help_link')}"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="16" height="16" aria-hidden="true"><!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.--><path fill="currentColor" d="M320 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l82.7 0L201.4 265.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L448 109.3l0 82.7c0 17.7 14.3 32 32 32s32-14.3 32-32l0-160c0-17.7-14.3-32-32-32L320 0zM80 32C35.8 32 0 67.8 0 112L0 432c0 44.2 35.8 80 80 80l320 0c44.2 0 80-35.8 80-80l0-112c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 112c0 8.8-7.2 16-16 16L80 448c-8.8 0-16-7.2-16-16l0-320c0-8.8 7.2-16 16-16l112 0c17.7 0 32-14.3 32-32s-14.3-32-32-32L80 32z"/></svg></a>
           </div>
         </div>
@@ -1013,6 +1013,7 @@ function getPlayerControls() {
   return [
     {
       section: 'player_section_onscreen',
+      hideHeader: true,
       entries: [
         {
           action: 'player_action_move',
@@ -1047,43 +1048,48 @@ function getPlayerControls() {
       entries: [
         {
           action: 'player_action_move',
-          keys: '"Left stick"',
+          keys: `"${translate('gamepad_left_stick')}"`,
         },
         {
           action: 'player_action_look',
-          keys: '"Right stick"',
+          keys: `"${translate('gamepad_right_stick')}"`,
         },
         {
           action: 'player_action_turn',
-          keys: 'L1 / R1',
+          keys: translate('gamepad_l1_r1'),
         },
         {
           action: 'player_action_camera_up',
-          keys: 'Triangle / Y',
+          keys: translate('gamepad_triangle_y'),
         },
         {
           action: 'player_action_camera_down',
-          keys: 'Square / X',
+          keys: translate('gamepad_square_x'),
         },
         {
           action: 'player_action_interact',
-          keys: 'Circle / B',
+          keys: translate('gamepad_circle_b'),
         },
         {
           action: 'player_action_spare',
-          keys: 'Cross / A',
+          keys: translate('gamepad_cross_a'),
         },
+      ],
+    },
+    {
+      section: 'player_section_sr',
+      entries: [
         {
           action: 'player_control_dpad_up',
-          keys: 'D-pad Up',
+          keys: translate('dpad_up'),
         },
         {
           action: 'player_control_dpad_down',
-          keys: 'D-pad Down',
+          keys: translate('dpad_down'),
         },
         {
           action: 'player_control_dpad_left',
-          keys: 'D-pad Left',
+          keys: translate('dpad_left'),
         },
       ],
     },
@@ -1096,7 +1102,8 @@ function getPlayerControls() {
 const PlayerPanel = {
   panel: null,
   previousFocus: null,
-  fontSize: parseFloat(localStorage.getItem(SHORTCUTS_FONT_SIZE_KEY)) || SHORTCUTS_FONT_SIZE_DEFAULT,
+  fontSize:
+    parseFloat(localStorage.getItem(SHORTCUTS_FONT_SIZE_KEY)) || SHORTCUTS_FONT_SIZE_DEFAULT,
 
   init() {
     this.createPanel();
@@ -1111,15 +1118,15 @@ const PlayerPanel = {
   },
 
   createPanel() {
-    const panel = InfoPanel.register('player', translate('player_panel_title'));
+    const panel = InfoPanel.register('player', translate('player_section_onscreen'));
     const btn = document.getElementById('info-tab-btn-player');
     btn.innerHTML = `<div class="icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512"><path fill="currentColor" fill-rule="evenodd" d="M60,144H516A36,36 0 0 1 552,180V332A36,36 0 0 1 516,368H60A36,36 0 0 1 24,332V180A36,36 0 0 1 60,144ZM134,180h52v50h50v52h-50v50h-52v-50h-50v-52h50ZM364,224a40,40 0 1 0 80,0a40,40 0 1 0 -80,0ZM428,296a40,40 0 1 0 80,0a40,40 0 1 0 -80,0Z"/></svg></div>`;
     panel.innerHTML = `
         <div class="shortcuts-panel-header">
           <h2 id="player-panel-title" class="shortcuts-panel-title"></h2>
           <div class="shortcuts-panel-controls">
-            <button class="bigbutton player-decrease-btn" aria-label="Decrease text size" title="Decrease text size"><span aria-hidden="true">A</span></button>
-            <button class="bigbutton player-increase-btn" aria-label="Increase text size" title="Increase text size"><span aria-hidden="true">A</span></button>
+            <button class="bigbutton player-decrease-btn" aria-label="${translate('player_decrease_font_size')}" title="${translate('player_decrease_font_size')}"><span aria-hidden="true">A</span></button>
+            <button class="bigbutton player-increase-btn" aria-label="${translate('player_increase_font_size')}" title="${translate('player_increase_font_size')}"><span aria-hidden="true">A</span></button>
           </div>
         </div>
         <div id="player-list"></div>
@@ -1149,7 +1156,7 @@ const PlayerPanel = {
   },
 
   renderContent() {
-    const title = translate('player_panel_title');
+    const title = translate('player_section_onscreen');
     const btn = document.getElementById('info-tab-btn-player');
     btn.setAttribute('aria-label', title);
     btn.setAttribute('title', title);
@@ -1166,8 +1173,8 @@ const PlayerPanel = {
 
     const sections = getPlayerControls()
       .map(
-        ({ section, entries }) => `
-      <h3 class="shortcuts-category">${translate(section)}</h3>
+        ({ section, entries, hideHeader }) => `
+      ${hideHeader ? '' : `<h3 class="shortcuts-category">${translate(section)}</h3>`}
       <dl class="shortcuts-group">
         ${entries
           .map(

--- a/accessibility/keyboardui.js
+++ b/accessibility/keyboardui.js
@@ -781,7 +781,7 @@ const ShortcutsPanel = {
     const btn = document.getElementById('info-tab-btn-shortcuts');
     btn.setAttribute('aria-label', translate('shortcut_panel_title'));
     btn.setAttribute('title', translate('shortcut_panel_title'));
-    btn.innerHTML = `<div class="icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512"><path fill="currentColor" d="M64 64C28.7 64 0 92.7 0 128L0 384c0 35.3 28.7 64 64 64l448 0c35.3 0 64-28.7 64-64l0-256c0-35.3-28.7-64-64-64L64 64zM175.1 224l16 0c8.8 0 16 7.2 16 16l0 16c0 8.8-7.2 16-16 16l-16 0c-8.8 0-16-7.2-16-16l0-16c0-8.8 7.2-16 16-16zm-72 32c0 8.8-7.2 16-16 16l-16 0c-8.8 0-16-7.2-16-16l0-16c0-8.8 7.2-16 16-16l16 0c8.8 0 16 7.2 16 16l0 16zm128 0c0 8.8-7.2 16-16 16l-16 0c-8.8 0-16-7.2-16-16l0-16c0-8.8 7.2-16 16-16l16 0c8.8 0 16 7.2 16 16l0 16zm128 0c0 8.8-7.2 16-16 16l-16 0c-8.8 0-16-7.2-16-16l0-16c0-8.8 7.2-16 16-16l16 0c8.8 0 16 7.2 16 16l0 16zm72-32l16 0c8.8 0 16 7.2 16 16l0 16c0 8.8-7.2 16-16 16l-16 0c-8.8 0-16-7.2-16-16l0-16c0-8.8 7.2-16 16-16zM80 336c0-8.8 7.2-16 16-16l288 0c8.8 0 16 7.2 16 16l0 16c0 8.8-7.2 16-16 16l-288 0c-8.8 0-16-7.2-16-16l0-16zm336-16l16 0c8.8 0 16 7.2 16 16l0 16c0 8.8-7.2 16-16 16l-16 0c-8.8 0-16-7.2-16-16l0-16c0-8.8 7.2-16 16-16z"/></svg></div>`;
+    btn.innerHTML = `<div class="icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512"><path fill="currentColor" d="M64 64C28.7 64 0 92.7 0 128L0 384c0 35.3 28.7 64 64 64l448 0c35.3 0 64-28.7 64-64l0-256c0-35.3-28.7-64-64-64L64 64zm16 64l32 0c8.8 0 16 7.2 16 16l0 32c0 8.8-7.2 16-16 16l-32 0c-8.8 0-16-7.2-16-16l0-32c0-8.8 7.2-16 16-16zM64 240c0-8.8 7.2-16 16-16l32 0c8.8 0 16 7.2 16 16l0 32c0 8.8-7.2 16-16 16l-32 0c-8.8 0-16-7.2-16-16l0-32zm16 80l32 0c8.8 0 16 7.2 16 16l0 32c0 8.8-7.2 16-16 16l-32 0c-8.8 0-16-7.2-16-16l0-32c0-8.8 7.2-16 16-16zm80-176c0-8.8 7.2-16 16-16l32 0c8.8 0 16 7.2 16 16l0 32c0 8.8-7.2 16-16 16l-32 0c-8.8 0-16-7.2-16-16l0-32zm16 80l32 0c8.8 0 16 7.2 16 16l0 32c0 8.8-7.2 16-16 16l-32 0c-8.8 0-16-7.2-16-16l0-32c0-8.8 7.2-16 16-16zM160 336c0-8.8 7.2-16 16-16l224 0c8.8 0 16 7.2 16 16l0 32c0 8.8-7.2 16-16 16l-224 0c-8.8 0-16-7.2-16-16l0-32zM272 128l32 0c8.8 0 16 7.2 16 16l0 32c0 8.8-7.2 16-16 16l-32 0c-8.8 0-16-7.2-16-16l0-32c0-8.8 7.2-16 16-16zM256 240c0-8.8 7.2-16 16-16l32 0c8.8 0 16 7.2 16 16l0 32c0 8.8-7.2 16-16 16l-32 0c-8.8 0-16-7.2-16-16l0-32zM368 128l32 0c8.8 0 16 7.2 16 16l0 32c0 8.8-7.2 16-16 16l-32 0c-8.8 0-16-7.2-16-16l0-32c0-8.8 7.2-16 16-16zM352 240c0-8.8 7.2-16 16-16l32 0c8.8 0 16 7.2 16 16l0 32c0 8.8-7.2 16-16 16l-32 0c-8.8 0-16-7.2-16-16l0-32zM464 128l32 0c8.8 0 16 7.2 16 16l0 32c0 8.8-7.2 16-16 16l-32 0c-8.8 0-16-7.2-16-16l0-32c0-8.8 7.2-16 16-16zM448 240c0-8.8 7.2-16 16-16l32 0c8.8 0 16 7.2 16 16l0 32c0 8.8-7.2 16-16 16l-32 0c-8.8 0-16-7.2-16-16l0-32zm16 80l32 0c8.8 0 16 7.2 16 16l0 32c0 8.8-7.2 16-16 16l-32 0c-8.8 0-16-7.2-16-16l0-32c0-8.8 7.2-16 16-16z"/></svg></div>`;
     panel.innerHTML = `
         <div class="shortcuts-panel-header">
           <h2 id="shortcuts-panel-title" class="shortcuts-panel-title"></h2>
@@ -991,12 +991,84 @@ const ShortcutsPanel = {
   },
 };
 
+// Touch equivalent of ShortcutsPanel: a second info panel tab. Docked-only —
+// narrow landscape hides #info-panel outright (along with this tab), so there's
+// no modal counterpart to fall back to.
+const TouchPanel = {
+  panel: null,
+
+  init() {
+    this.createPanel();
+    this.setupListeners();
+    window.flockTouchPanel = this;
+
+    // Rotating into narrow landscape hides the info panel mid-view, which would
+    // leave this panel marked active but invisible.
+    window.addEventListener('resize', () => {
+      if (isNarrowLayout() && !this.panel.classList.contains('hidden')) this.hide();
+    });
+  },
+
+  createPanel() {
+    const panel = InfoPanel.register('touch', translate('touch_panel_title'));
+    const btn = document.getElementById('info-tab-btn-touch');
+    btn.innerHTML = `<div class="icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512"><path fill="currentColor" fill-rule="evenodd" d="M60,144H516A36,36 0 0 1 552,180V332A36,36 0 0 1 516,368H60A36,36 0 0 1 24,332V180A36,36 0 0 1 60,144ZM134,180h52v50h50v52h-50v50h-52v-50h-50v-52h50ZM364,224a40,40 0 1 0 80,0a40,40 0 1 0 -80,0ZM428,296a40,40 0 1 0 80,0a40,40 0 1 0 -80,0Z"/></svg></div>`;
+    panel.innerHTML = `
+        <div class="shortcuts-panel-header">
+          <h2 id="touch-panel-title" class="shortcuts-panel-title"></h2>
+        </div>
+        <div id="touch-list"></div>
+      `;
+    this.panel = panel;
+    this.renderContent();
+  },
+
+  renderContent() {
+    const title = translate('touch_panel_title');
+    const btn = document.getElementById('info-tab-btn-touch');
+    btn.setAttribute('aria-label', title);
+    btn.setAttribute('title', title);
+    this.panel.querySelector('#touch-panel-title').textContent = title;
+  },
+
+  show() {
+    this.renderContent();
+    this.previousFocus = document.activeElement;
+    InfoPanel.activate('touch');
+  },
+
+  refreshTranslations() {
+    this.renderContent();
+  },
+
+  hide() {
+    this.previousFocus?.focus();
+    this.previousFocus = null;
+    InfoPanel.deactivate('touch');
+  },
+
+  toggle() {
+    this.panel.classList.contains('hidden') ? this.show() : this.hide();
+  },
+
+  setupListeners() {
+    this.panel.addEventListener('keydown', (e) => {
+      if (e.key !== 'Escape') return;
+      e.preventDefault();
+      e.stopPropagation();
+      this.hide();
+      document.getElementById('info-tab-btn-touch')?.focus();
+    });
+  },
+};
+
 // Start it up
 AreaManager.init();
 GizmoMenuManager.init();
 if (document.getElementById('info-panel-tabs')) {
   InfoPanel.init();
   ShortcutsPanel.init();
+  TouchPanel.init();
 }
 
-export { InfoPanel, ShortcutsPanel, GizmoMenuManager, AreaManager };
+export { InfoPanel, ShortcutsPanel, TouchPanel, GizmoMenuManager, AreaManager };

--- a/locale/en.js
+++ b/locale/en.js
@@ -1344,6 +1344,9 @@ export default {
   toolbar_redo_ui: 'Redo',
   toolbar_zoom_out_ui: 'Zoom out',
   toolbar_zoom_in_ui: 'Zoom in',
+  // Touch controls panel
+  touch_panel_title: 'Touch Controls',
+
   // Keyboard shortcuts panel — title and close button
   shortcut_panel_title: 'Keyboard Controls',
   shortcut_panel_close: 'Close keyboard shortcuts',

--- a/locale/en.js
+++ b/locale/en.js
@@ -1348,6 +1348,7 @@ export default {
   player_panel_title: 'Player Controls',
   player_section_onscreen: 'On-screen controls',
   player_section_gamepad: 'Game controller',
+  player_section_sr: 'Screen reader with Game Controller',
   player_action_move: 'Move',
   player_action_look: 'Look around',
   player_action_turn: 'Turn left / right',
@@ -1366,6 +1367,22 @@ export default {
   shortcut_panel_title: 'Keyboard Controls',
   shortcut_panel_close: 'Close keyboard shortcuts',
   shortcut_panel_help_link: 'Open keyboard controls help link',
+
+  // Player panel controls
+  player_decrease_font_size: 'Decrease text size',
+  player_increase_font_size: 'Increase text size',
+
+  // Player control key labels
+  gamepad_left_stick: 'Left stick',
+  gamepad_right_stick: 'Right stick',
+  gamepad_l1_r1: 'L1 / R1',
+  gamepad_triangle_y: 'Triangle / Y',
+  gamepad_square_x: 'Square / X',
+  gamepad_circle_b: 'Circle / B',
+  gamepad_cross_a: 'Cross / A',
+  dpad_up: 'Up',
+  dpad_down: 'Down',
+  dpad_left: 'Left',
 
   // Keyboard shortcuts panel — labels
   shortcut_show_hide_help: 'Show/hide shortcut help',

--- a/locale/en.js
+++ b/locale/en.js
@@ -1344,8 +1344,23 @@ export default {
   toolbar_redo_ui: 'Redo',
   toolbar_zoom_out_ui: 'Zoom out',
   toolbar_zoom_in_ui: 'Zoom in',
-  // Touch controls panel
-  touch_panel_title: 'Touch Controls',
+  // Player controls panel — title, sections and control names
+  player_panel_title: 'Player Controls',
+  player_section_onscreen: 'On-screen controls',
+  player_section_gamepad: 'Game controller',
+  player_action_move: 'Move',
+  player_action_look: 'Look around',
+  player_action_turn: 'Turn left / right',
+  player_action_camera_up: 'Camera up',
+  player_action_interact: 'Interact',
+  player_action_camera_down: 'Camera down',
+  player_action_spare: 'General action',
+  player_control_arrows: 'Arrows',
+  player_control_button: 'Button %1',
+  player_control_dpad_note: 'On controllers without a left stick, the D-pad moves instead.',
+  player_control_dpad_up: 'Scene summary',
+  player_control_dpad_down: 'Object ahead',
+  player_control_dpad_left: 'Nearest object',
 
   // Keyboard shortcuts panel — title and close button
   shortcut_panel_title: 'Keyboard Controls',

--- a/locale/es.js
+++ b/locale/es.js
@@ -1293,6 +1293,41 @@ export default {
   shortcut_panel_close: 'Cerrar atajos de teclado',
   shortcut_panel_help_link: 'Abrir enlace de ayuda de controles de teclado',
 
+  // Player controls panel — title, sections and control names
+  player_panel_title: 'Controles del jugador',
+  player_section_onscreen: 'Controles en pantalla',
+  player_section_gamepad: 'Controlador de juego',
+  player_section_sr: 'Lector de pantalla con controlador de juego',
+  player_action_move: 'Mover',
+  player_action_look: 'Mirar alrededor',
+  player_action_turn: 'Girar izquierda / derecha',
+  player_action_camera_up: 'Cámara arriba',
+  player_action_interact: 'Interactuar',
+  player_action_camera_down: 'Cámara abajo',
+  player_action_spare: 'Acción general',
+  player_control_arrows: 'Flechas',
+  player_control_button: 'Botón %1',
+  player_control_dpad_note: 'En controles sin palanca izquierda, el D-pad se mueve en su lugar.',
+  player_control_dpad_up: 'Resumen de la escena',
+  player_control_dpad_down: 'Objeto adelante',
+  player_control_dpad_left: 'Objeto más cercano',
+
+  // Player panel controls
+  player_decrease_font_size: 'Reducir tamaño de texto',
+  player_increase_font_size: 'Aumentar tamaño de texto',
+
+  // Player control key labels
+  gamepad_left_stick: 'Palanca izquierda',
+  gamepad_right_stick: 'Palanca derecha',
+  gamepad_l1_r1: 'L1 / R1',
+  gamepad_triangle_y: 'Triángulo / Y',
+  gamepad_square_x: 'Cuadrado / X',
+  gamepad_circle_b: 'Círculo / B',
+  gamepad_cross_a: 'Cruz / A',
+  dpad_up: 'Arriba',
+  dpad_down: 'Abajo',
+  dpad_left: 'Izquierda',
+
   // Keyboard shortcuts panel — labels
   shortcut_show_hide_help: 'Mostrar/ocultar atajos de teclado',
   shortcut_move_between_areas: 'Moverse entre menús, canvas y editor',

--- a/main/input.js
+++ b/main/input.js
@@ -83,6 +83,15 @@ export function setupInput() {
         pushUnique(shortcutsTabPanel);
         shortcutsTabPanel.querySelectorAll('a[href], button:not([disabled])').forEach(pushUnique);
       }
+
+      pushUnique(document.querySelector('#info-tab-btn-player'));
+
+      const playerTabPanel = document.getElementById('info-tab-panel-player');
+      if (playerTabPanel && !playerTabPanel.classList.contains('hidden')) {
+        pushUnique(playerTabPanel);
+        playerTabPanel.querySelectorAll('a[href], button:not([disabled])').forEach(pushUnique);
+      }
+
       pushUnique(document.querySelector('#info-panel-link'));
 
       // View toggle in canvas mode — after the logo link, before the resizer

--- a/main/translation.js
+++ b/main/translation.js
@@ -133,6 +133,11 @@ export async function setLanguage(language) {
     window.flockShortcutsPanel.refreshTranslations();
   }
 
+  // Update touch controls panel if open
+  if (window.flockTouchPanel?.refreshTranslations) {
+    window.flockTouchPanel.refreshTranslations();
+  }
+
   // Refresh the workspace to show updated language
   const workspace = Blockly.getMainWorkspace();
   if (workspace) {

--- a/main/translation.js
+++ b/main/translation.js
@@ -133,9 +133,9 @@ export async function setLanguage(language) {
     window.flockShortcutsPanel.refreshTranslations();
   }
 
-  // Update touch controls panel if open
-  if (window.flockTouchPanel?.refreshTranslations) {
-    window.flockTouchPanel.refreshTranslations();
+  // Update player controls panel if open
+  if (window.flockPlayerPanel?.refreshTranslations) {
+    window.flockPlayerPanel.refreshTranslations();
   }
 
   // Refresh the workspace to show updated language

--- a/style.css
+++ b/style.css
@@ -2380,11 +2380,13 @@ kbd {
   margin-left: 0;
 }
 
-.shortcuts-decrease-btn span {
+.shortcuts-decrease-btn span,
+.player-decrease-btn span {
   font-size: 0.75em;
 }
 
-.shortcuts-increase-btn span {
+.shortcuts-increase-btn span,
+.player-increase-btn span {
   font-size: 1.1em;
 }
 
@@ -2403,10 +2405,61 @@ kbd {
   margin-bottom: 1.5em;
 }
 
-#touch-list {
+#player-list {
   font-size: 1.2em;
   user-select: text;
   margin-bottom: 1.5em;
+}
+
+.pc-keys {
+  display: flex;
+  gap: 3px;
+}
+
+/* Mirrors the on-screen pad: up centred above left / down / right. Placement is
+   explicit because auto-flow would put `left` beside `up` on the first row. */
+.pc-keys--dpad {
+  display: grid;
+  grid-template-columns: repeat(3, auto);
+  gap: 3px;
+  width: max-content;
+}
+
+.pc-keys--dpad .pc-chip:nth-child(1) {
+  grid-area: 1 / 2;
+}
+
+.pc-keys--dpad .pc-chip:nth-child(2) {
+  grid-area: 2 / 1;
+}
+
+.pc-keys--dpad .pc-chip:nth-child(3) {
+  grid-area: 2 / 2;
+}
+
+.pc-keys--dpad .pc-chip:nth-child(4) {
+  grid-area: 2 / 3;
+}
+
+.pc-chip {
+  display: grid;
+  place-items: center;
+  width: 1.4em;
+  height: 1.4em;
+  border: 1px solid currentcolor;
+  border-radius: 4px;
+}
+
+.pc-chip svg {
+  display: block;
+  width: 1.1em;
+  height: 1.1em;
+}
+
+.player-controls-note {
+  margin: 1em 0 0;
+  font-size: 0.85em;
+  color: var(--color-muted);
 }
 
 /* Error notification banner */

--- a/style.css
+++ b/style.css
@@ -2248,7 +2248,7 @@ body.color-picker-open #renderCanvas {
 
 .shortcuts-entry {
   display: grid;
-  grid-template-columns: 33% 1fr;
+  grid-template-columns: 45% 1fr;
 }
 
 .shortcuts-entry dt,

--- a/style.css
+++ b/style.css
@@ -2403,6 +2403,12 @@ kbd {
   margin-bottom: 1.5em;
 }
 
+#touch-list {
+  font-size: 1.2em;
+  user-select: text;
+  margin-bottom: 1.5em;
+}
+
 /* Error notification banner */
 .flock-banner {
   position: fixed;


### PR DESCRIPTION
# Summary
Add new on-screen and gamepad controls button next to the keyboard controls button
<img width="635" height="569" alt="image" src="https://github.com/user-attachments/assets/702a11bc-9394-4f60-83b4-a6584d765da0" />

### AI usage
Claude Opus 5 and Haiku 4.5 both used on this. Several iterations were made because I wasn't happy with the format initially. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a docked Player Controls panel displaying on-screen and gamepad controls.
  * Added control sections for movement, camera actions, interaction, buttons, and D-pad navigation.
  * Added adjustable font sizing for the Player Controls panel.
  * Added English translations for the new panel and its controls.

* **Accessibility**
  * Included Player Controls content in keyboard focus navigation.
  * Player Controls now updates when the application language changes.

* **Style**
  * Added visual styling for control chips, SVG icons, D-pad layouts, and explanatory notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->