### PR TITLE
Document pg up/down on mac

### DIFF
--- a/accessibility/keyboardui.js
+++ b/accessibility/keyboardui.js
@@ -398,6 +398,7 @@ function isMac() {
 // List of shortcuts to show in the panel, with categories for grouping
 function getShortcuts() {
   const mod = isMac() ? '⌘' : 'Ctrl';
+  const pgUpDn = isMac() ? 'Fn + ↑ ↓' : 'PgUp PgDn';
   return [
     {
       label: translate('shortcut_show_hide_help'),
@@ -627,7 +628,7 @@ function getShortcuts() {
     },
     {
       label: translate('shortcut_transform_3d'),
-      keys: `↑ ↓ ← → PgUp PgDn`,
+      keys: `↑ ↓ ← → ${pgUpDn}`,
       category: translate('shortcut_category_gizmos'),
     },
     {


### PR DESCRIPTION
# Summary
Page Up and Page Down keys don't exist on Mac. Add a modifier in the keyboard controls documentation to document the correct keys on Mac. 

### AI usage
Claude Sonnet 5 was my wingman today but all it really did was write the line, I did everything else. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated shortcut instructions to display the correct Page Up/Page Down key labels based on the user’s platform.
  * macOS now shows `Fn + ↑ ↓`, while other platforms show `PgUp PgDn`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->