### PR TITLE
Add visible shadow to workspace comments

### DIFF
--- a/style/blockly.css
+++ b/style/blockly.css
@@ -164,6 +164,18 @@ textarea.blocklyCommentText::placeholder {
   color: #000 !important;
 }
 
+.blocklySelected .blocklyCommentHighlight,
+.blocklyCollapsed.blocklySelected .blocklyCommentTopbarBackground {
+  stroke: #511d91 !important;
+  stroke-width: 5px !important;
+  vector-effect: non-scaling-stroke !important;
+  filter:
+    drop-shadow(2px 0 0 #fff)
+    drop-shadow(-2px 0 0 #fff)
+    drop-shadow(0 2px 0 #fff)
+    drop-shadow(0 -2px 0 #fff) !important;
+}
+
 .blocklyTreeRow {
   border-left: none !important;
 }


### PR DESCRIPTION
# Summary
Make the highlight outline when a workspace comment is focused actually visible in all themes. 

<img width="165" height="112" alt="image" src="https://github.com/user-attachments/assets/d9f6c1ae-fe31-47de-b02f-2bc062746c14" />

<img width="197" height="132" alt="image" src="https://github.com/user-attachments/assets/ff5c9a34-0eaa-494a-8159-481b240ad57b" />

### AI usage
Claude Sonnet 5 worked out why the outline was displaying as a very thin line and suggested adding the drop shadow to combat the problem of contrast against something light and something dark simultaneously. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added a purple highlight with a white outline for selected comments.
  * Applied the highlight consistently to both expanded and collapsed comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->