### PR TITLE
Bugfix: Apply transformations to correct mesh when duplicated

### DIFF
--- a/blocks/blocks.js
+++ b/blocks/blocks.js
@@ -752,17 +752,20 @@ function createFreshVariable(workspace, prefix, type, nextVariableIndexes) {
 function retargetDescendantsVariables(rootBlock, fromVarId, toVarId, BlocklyNS, createdIds = null) {
   if (!fromVarId || !toVarId || fromVarId === toVarId) return 0;
 
-  // Get descendants but ONLY through input connections, not next/previous
+  // Get descendants but ONLY through input connections, not the root's own next/previous
   const descendants = [];
 
   function collectInputDescendants(block) {
     for (const input of block.inputList || []) {
       if (input.connection && input.connection.targetBlock()) {
-        const childBlock = input.connection.targetBlock();
-        // Only include if it was created in the same event (if createdIds is provided)
-        if (!createdIds || createdIds.has(childBlock.id)) {
-          descendants.push(childBlock);
-          collectInputDescendants(childBlock);
+        let childBlock = input.connection.targetBlock();
+        while (childBlock) {
+          // Only include if it was created in the same event (if createdIds is provided)
+          if (!createdIds || createdIds.has(childBlock.id)) {
+            descendants.push(childBlock);
+            collectInputDescendants(childBlock);
+          }
+          childBlock = childBlock.getNextBlock();
         }
       }
     }
@@ -834,9 +837,10 @@ function adoptIsolatedDefaultVarsTo(
     const descendants = [];
     for (const input of block.inputList || []) {
       if (input.connection && input.connection.targetBlock()) {
-        const childBlock = input.connection.targetBlock();
-        descendants.push(childBlock);
-        descendants.push(...collectInputDescendants(childBlock));
+        for (let childBlock = input.connection.targetBlock(); childBlock; childBlock = childBlock.getNextBlock()) {
+          descendants.push(childBlock);
+          descendants.push(...collectInputDescendants(childBlock));
+        }
       }
     }
     return descendants;


### PR DESCRIPTION
# Summary
Fixed a bug where if you duplicated a mesh which had >1 transformation applied (e.g. resize and rotate), the copy would have two transform blocks applied but the second would target the original mesh.

Previous behaviour:
<img width="443" height="370" alt="image" src="https://github.com/user-attachments/assets/a63fdbe5-b680-4646-84df-0b6459f9110e" />

### AI usage
Claude Sonnet 5 found the bug and fixed. I identified it during manual testing. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved variable handling across connected block sequences.
  * Ensured variable retargeting consistently respects creation filters throughout nested blocks.
  * Fixed adoption of isolated default variables when blocks are linked in sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->