### PR TITLE
Additional messages for gizmos

### DIFF
--- a/locale/de.js
+++ b/locale/de.js
@@ -1177,6 +1177,7 @@ export default {
   fly_camera_instructions: 'ℹ️ Schau dich um mit Pfeiltasten und Bild auf/ab oder Fn + ↑ ↓',
   fly_camera_instructions_touch:
     'ℹ️ Flugkamera, nutze die Bildschirmsteuerung und ziehe zum Umsehen',
+  select_mesh_prompt: 'ℹ️ Wähle ein Objekt aus, oder nutze die Pfeiltasten, um den Cursor zu bewegen.',
   select_mesh_delete_prompt: 'ℹ️ Klicke auf ein Objekt, um es zu löschen.',
   select_mesh_duplicate_prompt: 'ℹ️ Wähle ein Objekt zum Duplizieren aus.',
   place_duplicate_prompt: 'ℹ️ Klicke, um eine Kopie zu platzieren.', // AI-generated; needs validation
@@ -1334,6 +1335,7 @@ export default {
   shortcut_toggle_hud: 'Bildschirmsteuerung ein-/ausblenden', // machine
   hud_hidden: 'Bildschirmsteuerung ausgeblendet', // machine
   hud_shown: 'Bildschirmsteuerung eingeblendet', // machine
+  gizmo_controls_hint: 'ℹ️ Klicke auf die Zahnrad-Schaltfläche, um die Steuerung ein-/auszublenden.', // machine
   shortcut_quick_colour: 'Schnellfarbauswahl im Farbwähler',
   shortcut_delete_object: 'Objekt löschen',
 

--- a/locale/en.js
+++ b/locale/en.js
@@ -1265,6 +1265,7 @@ export default {
   fly_camera_instructions: 'ℹ️ Look around with arrow keys and Pg Up/Pg Down or Fn + ↑ ↓',
   fly_camera_instructions_touch:
     'ℹ️ Fly camera, use the on-screen controls and drag to look around',
+  select_mesh_prompt: 'ℹ️ Select an object, or use arrow keys to move the cursor.',
   select_mesh_delete_prompt: 'ℹ️ Click an object to delete it.',
   select_mesh_duplicate_prompt: 'ℹ️ Select an object to duplicate.',
   place_duplicate_prompt: 'ℹ️ Click to place a copy.',
@@ -1462,6 +1463,7 @@ export default {
   shortcut_toggle_hud: 'Show/hide on-screen controls',
   hud_hidden: 'On-screen controls hidden',
   hud_shown: 'On-screen controls shown',
+  gizmo_controls_hint: 'ℹ️ Click the cog button to show/hide the controls.',
   shortcut_quick_colour: 'Quick use colour in colour picker',
   shortcut_delete_object: 'Delete object',
 

--- a/locale/es.js
+++ b/locale/es.js
@@ -1255,6 +1255,7 @@ export default {
   fly_camera_instructions: 'ℹ️ Mira alrededor con las flechas y Page Up/Down o Fn + ↑ ↓', // human
   fly_camera_instructions_touch:
     'ℹ️ Cámara en vuelo, usa los controles en pantalla y arrastra para mirar alrededor',
+  select_mesh_prompt: 'ℹ️ Selecciona un objeto, o usa las flechas para mover el cursor.',
   select_mesh_delete_prompt: 'ℹ️ Haz clic en un objeto para eliminarlo.', // Google translate
   select_mesh_duplicate_prompt: 'ℹ️ Selecciona un objeto para duplicar.', // Google (had to update it)
   place_duplicate_prompt: 'ℹ️ Haz clic para colocar una copia.', // AI-generated; needs validation
@@ -1406,6 +1407,7 @@ export default {
   shortcut_toggle_hud: 'Mostrar/ocultar controles en pantalla', // machine
   hud_hidden: 'Controles en pantalla ocultos', // machine
   hud_shown: 'Controles en pantalla visibles', // machine
+  gizmo_controls_hint: 'ℹ️ Haz clic en el botón del engranaje para mostrar/ocultar los controles.', // machine
   shortcut_quick_colour: 'Usar color rápido en el selector de color',
   shortcut_delete_object: 'Eliminar objeto',
 

--- a/locale/fr.js
+++ b/locale/fr.js
@@ -1188,6 +1188,7 @@ export default {
   fly_camera_instructions: 'ℹ️ Regardez autour avec les flèches et Page haut/bas ou Fn + ↑ ↓',
   fly_camera_instructions_touch:
     "ℹ️ Caméra en vol, utilisez les commandes à l'écran et faites glisser pour regarder autour",
+  select_mesh_prompt: 'ℹ️ Sélectionnez un objet, ou utilisez les flèches pour déplacer le curseur.',
   select_mesh_delete_prompt: 'ℹ️ Cliquez sur un objet pour le supprimer.',
   select_mesh_duplicate_prompt: 'ℹ️ Sélectionnez un objet à dupliquer.',
   place_duplicate_prompt: 'ℹ️ Cliquez pour placer une copie.', // AI-generated; needs validation
@@ -1342,6 +1343,7 @@ export default {
   shortcut_toggle_hud: "Afficher/masquer les commandes à l'écran", // machine
   hud_hidden: "Commandes à l'écran masquées", // machine
   hud_shown: "Commandes à l'écran affichées", // machine
+  gizmo_controls_hint: "ℹ️ Cliquez sur le bouton en forme d'engrenage pour afficher/masquer les commandes.", // machine
   shortcut_quick_colour: 'Utiliser rapidement une couleur dans le sélecteur',
   shortcut_delete_object: "Supprimer l'objet",
 

--- a/locale/it.js
+++ b/locale/it.js
@@ -1198,6 +1198,7 @@ export default {
   fly_camera_instructions: 'ℹ️ Guarda intorno con le frecce e Pag su/giù o Fn + ↑ ↓',
   fly_camera_instructions_touch:
     'ℹ️ Telecamera volante, usa i controlli a schermo e trascina per guardarti intorno',
+  select_mesh_prompt: 'ℹ️ Seleziona un oggetto, oppure usa le frecce per spostare il cursore.',
   select_mesh_delete_prompt: 'ℹ️ Clicca su un oggetto per eliminarlo.',
   select_mesh_duplicate_prompt: 'ℹ️ Seleziona un oggetto da duplicare.',
   place_duplicate_prompt: 'ℹ️ Fai clic per posizionare una copia.', // AI-generated; needs validation
@@ -1344,6 +1345,7 @@ export default {
   shortcut_toggle_hud: 'Mostra/nascondi i comandi a schermo', // machine
   hud_hidden: 'Comandi a schermo nascosti', // machine
   hud_shown: 'Comandi a schermo visibili', // machine
+  gizmo_controls_hint: 'ℹ️ Clicca sul pulsante a forma di ingranaggio per mostrare/nascondere i comandi.', // machine
   shortcut_quick_colour: 'Uso rapido del colore nel selettore colori',
   shortcut_delete_object: 'Elimina oggetto',
 

--- a/locale/pl.js
+++ b/locale/pl.js
@@ -1186,6 +1186,7 @@ export default {
     'ℹ️ Rozglądaj się za pomocą klawiszy strzałek i Page Up/Down lub Fn + ↑ ↓',
   fly_camera_instructions_touch:
     'ℹ️ Kamera lotu, użyj sterowania na ekranie i przeciągnij, aby się rozejrzeć',
+  select_mesh_prompt: 'ℹ️ Wybierz obiekt lub użyj klawiszy strzałek, aby przesunąć kursor.',
   select_mesh_delete_prompt: 'ℹ️ Kliknij obiekt, aby go usunąć.',
   select_mesh_duplicate_prompt: 'ℹ️ Wybierz obiekt do powielenia.',
   place_duplicate_prompt: 'ℹ️ Kliknij, aby umieścić kopię.', // AI-generated; needs validation
@@ -1336,6 +1337,7 @@ export default {
   shortcut_toggle_hud: 'Pokaż/ukryj sterowanie ekranowe', // machine
   hud_hidden: 'Sterowanie ekranowe ukryte', // machine
   hud_shown: 'Sterowanie ekranowe widoczne', // machine
+  gizmo_controls_hint: 'ℹ️ Kliknij przycisk trybika, aby pokazać/ukryć sterowanie.', // machine
   shortcut_quick_colour: 'Szybkie użycie koloru w selektorze kolorów',
   shortcut_delete_object: 'Usuń obiekt',
 

--- a/locale/pt.js
+++ b/locale/pt.js
@@ -1195,6 +1195,7 @@ export default {
   fly_camera_instructions: 'ℹ️ Olhe ao redor com as setas e Page Up/Down ou Fn + ↑ ↓',
   fly_camera_instructions_touch:
     'ℹ️ Câmera de voo, use os controles na tela e arraste para olhar em volta',
+  select_mesh_prompt: 'ℹ️ Selecione um objeto, ou use as setas para mover o cursor.',
   select_mesh_delete_prompt: 'ℹ️ Clique em um objeto para excluí-lo.',
   select_mesh_duplicate_prompt: 'ℹ️ Selecione um objeto para duplicar.',
   place_duplicate_prompt: 'ℹ️ Clique para posicionar uma cópia.', // AI-generated; needs validation
@@ -1345,6 +1346,7 @@ export default {
   shortcut_toggle_hud: 'Mostrar/ocultar controlos no ecrã', // machine
   hud_hidden: 'Controlos no ecrã ocultos', // machine
   hud_shown: 'Controlos no ecrã visíveis', // machine
+  gizmo_controls_hint: 'ℹ️ Clique no botão de engrenagem para mostrar/ocultar os controlos.', // machine
   shortcut_quick_colour: 'Uso rápido de cor no seletor de cores',
   shortcut_delete_object: 'Eliminar objeto',
 

--- a/locale/sv.js
+++ b/locale/sv.js
@@ -1171,6 +1171,7 @@ export default {
   fly_camera_instructions: 'ℹ️ Titta omkring med piltangenterna och Page Up/Down eller Fn + ↑ ↓',
   fly_camera_instructions_touch:
     'ℹ️ Flygkamera, använd skärmkontrollerna och dra för att se dig omkring',
+  select_mesh_prompt: 'ℹ️ Välj ett objekt, eller använd piltangenterna för att flytta kursorn.',
   select_mesh_delete_prompt: 'ℹ️ Klicka på ett objekt för att ta bort det.',
   select_mesh_duplicate_prompt: 'ℹ️ Välj ett objekt att duplicera.',
   place_duplicate_prompt: 'ℹ️ Klicka för att placera en kopia.', // AI-generated; needs validation
@@ -1320,6 +1321,7 @@ export default {
   shortcut_toggle_hud: 'Visa/dölj skärmkontroller', // machine
   hud_hidden: 'Skärmkontroller dolda', // machine
   hud_shown: 'Skärmkontroller visas', // machine
+  gizmo_controls_hint: 'ℹ️ Klicka på kugghjulsknappen för att visa/dölja kontrollerna.', // machine
   shortcut_quick_colour: 'Snabb färganvändning i färgväljaren',
   shortcut_delete_object: 'Ta bort objekt',
 

--- a/ui/gizmos.js
+++ b/ui/gizmos.js
@@ -965,6 +965,7 @@ export function exitGizmoState() {
   clearStatus('eye-gizmo');
   // The readout belongs to the tool that took it; the next tool doesn't move it.
   clearStatus('position-readout');
+  clearStatus('gizmo-controls-hint');
 
   // Run all queued cleanup functions
   runCleanups();
@@ -1948,14 +1949,19 @@ function handleScaleGizmo() {
     startScaleKeyboardHandler(mesh, savedHudAxis, (axis) => {
       if (axis) savedHudAxis = axis;
     });
+    showStatus(translate('gizmo_controls_hint'), { duration: 10, owner: 'gizmo-controls-hint' });
   } else {
-    pickMeshFromScene((pickedMesh) => {
-      if (!pickedMesh || pickedMesh.name === 'ground') {
-        exitGizmoState();
-        return;
-      }
-      attachMeshForActiveTool(pickedMesh);
-    });
+    pickMeshFromScene(
+      (pickedMesh) => {
+        if (!pickedMesh || pickedMesh.name === 'ground') {
+          exitGizmoState();
+          return;
+        }
+        attachMeshForActiveTool(pickedMesh);
+      },
+      false,
+      translate('select_mesh_prompt')
+    );
   }
 
   let lastScaledMesh = gizmoManager.attachedMesh;
@@ -1971,6 +1977,7 @@ function handleScaleGizmo() {
     startScaleKeyboardHandler(mesh, savedHudAxis, (axis) => {
       if (axis) savedHudAxis = axis;
     });
+    showStatus(translate('gizmo_controls_hint'), { duration: 10, owner: 'gizmo-controls-hint' });
   });
 
   onExit(() => gizmoManager.onAttachedToMeshObservable.remove(scaleObs));
@@ -2130,14 +2137,19 @@ function handleRotationGizmo() {
     startRotateKeyboardHandler(mesh, savedHudAxis, (axis) => {
       if (axis) savedHudAxis = axis;
     });
+    showStatus(translate('gizmo_controls_hint'), { duration: 10, owner: 'gizmo-controls-hint' });
   } else {
-    pickMeshFromScene((pickedMesh) => {
-      if (!pickedMesh || pickedMesh.name === 'ground') {
-        exitGizmoState();
-        return;
-      }
-      attachMeshForActiveTool(pickedMesh);
-    });
+    pickMeshFromScene(
+      (pickedMesh) => {
+        if (!pickedMesh || pickedMesh.name === 'ground') {
+          exitGizmoState();
+          return;
+        }
+        attachMeshForActiveTool(pickedMesh);
+      },
+      false,
+      translate('select_mesh_prompt')
+    );
   }
 
   let lastRotatedMesh = gizmoManager.attachedMesh;
@@ -2152,6 +2164,7 @@ function handleRotationGizmo() {
 
     lastRotatedMesh = mesh;
 
+    showStatus(translate('gizmo_controls_hint'), { duration: 10, owner: 'gizmo-controls-hint' });
     startRotateKeyboardHandler(mesh, savedHudAxis, (axis) => {
       if (axis) savedHudAxis = axis;
     });
@@ -2225,6 +2238,7 @@ function handlePositionGizmo() {
     if (keyboardAttachedMesh === mesh) return;
     keyboardAttachedMesh = mesh;
 
+    showStatus(translate('gizmo_controls_hint'), { duration: 10, owner: 'gizmo-controls-hint' });
     startMoveKeyboardHandler(mesh, savedHudAxis, (axis) => {
       if (axis) savedHudAxis = axis;
     });
@@ -2246,16 +2260,20 @@ function handlePositionGizmo() {
   if (mesh) {
     activatePositionKeyboardForMesh(mesh);
   } else {
-    pickMeshFromScene((pickedMesh) => {
-      if (!pickedMesh || pickedMesh.name === 'ground') {
-        exitGizmoState();
-        return;
-      }
-      if (pickedMesh.parent) {
-        pickedMesh = getRootMesh(pickedMesh.parent);
-      }
-      gizmoManager.attachToMesh(pickedMesh);
-    });
+    pickMeshFromScene(
+      (pickedMesh) => {
+        if (!pickedMesh || pickedMesh.name === 'ground') {
+          exitGizmoState();
+          return;
+        }
+        if (pickedMesh.parent) {
+          pickedMesh = getRootMesh(pickedMesh.parent);
+        }
+        gizmoManager.attachToMesh(pickedMesh);
+      },
+      false,
+      translate('select_mesh_prompt')
+    );
   }
 
   const posDragStart = gizmoManager.gizmos.positionGizmo.onDragStartObservable.add(() => {
@@ -2360,7 +2378,7 @@ function handleSelectGizmo() {
   }
 
   // Use helper function to pick the mesh
-  pickMeshFromScene(applySelection, true);
+  pickMeshFromScene(applySelection, true, translate('select_mesh_prompt'));
 }
 
 // Duplicate: Create a copy of the selected mesh and its corresponding block,


### PR DESCRIPTION
# Summary
- Show a message to surface the fact that the keyboard cursor can be triggered by using arrow keys

<img width="356" height="128" alt="image" src="https://github.com/user-attachments/assets/712631d8-8d88-4f4f-8301-86aeffcb7076" />

- Show a message to surface the fact that the on-screen controls can be hidden/shown with the cog button 
<img width="335" height="102" alt="image" src="https://github.com/user-attachments/assets/b8be0abd-f3c6-4637-9f3d-a822ae2fdabf" />

Translate for locales. 

### AI usage
Claude Sonnet 5 wrote the translations and added the messages in the right place. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added localized guidance for selecting objects with the keyboard across supported languages.
  - Added translated instructions explaining how to show or hide gizmo controls.
  - Scale, rotation, and position tools now display helpful controls guidance when keyboard interaction begins.
  - Selection workflows provide clearer prompts when an object must be chosen.

- **Bug Fixes**
  - Gizmo hints are now cleared when gizmo interactions end, preventing outdated messages from remaining visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->