### PR TITLE
Block tip hint bar

### DIFF
--- a/blocks/control.js
+++ b/blocks/control.js
@@ -441,6 +441,7 @@ export function defineControlBlocks() {
       this.setPreviousStatement(true);
       this.setNextStatement(true);
       this.setInputsInline(true);
+      this.setTooltip(getTooltip('if_clause'));
 
       this._stashedCondState = null;
 

--- a/index.html
+++ b/index.html
@@ -627,6 +627,16 @@
                         >Inspector</a
                       >
                     </li>
+                    <li role="none">
+                      <a
+                        href="#"
+                        id="block-hints-menu-item"
+                        data-i18n="hide_block_hints"
+                        role="menuitem"
+                        tabindex="-1"
+                        >Hide block hints</a
+                      >
+                    </li>
                   </ul>
                 </li>
                 <!-- About menu item -->
@@ -1267,6 +1277,9 @@
             <div id="blockly-desc" class="sr-only">
               Drag and drop code blocks to create your program. Use arrow keys and Enter to navigate
               and interact with blocks.
+            </div>
+            <div id="blockHint" class="block-hint" hidden>
+              <p id="blockHintText" class="block-hint__text" role="status"></p>
             </div>
             <div id="blocklyZoomControls" role="toolbar" aria-label="Workspace controls">
               <button

--- a/locale/de.js
+++ b/locale/de.js
@@ -1049,6 +1049,7 @@ export default {
   inspector_tool_ui: 'Inspektor',
   show_block_hints_ui: 'Blockhinweise anzeigen',
   hide_block_hints_ui: 'Blockhinweise ausblenden',
+  block_hints_menu_location_ui: 'Klicken Sie auf Menü > Werkzeuge',
   language_submenu_ui: 'Sprache',
   about_submenu_ui: 'Über',
   hub_submenu_ui: 'Hub',

--- a/locale/de.js
+++ b/locale/de.js
@@ -1047,6 +1047,8 @@ export default {
   project_save_ui: 'Speichern',
   tools_submenu_ui: 'Werkzeuge',
   inspector_tool_ui: 'Inspektor',
+  show_block_hints_ui: 'Blockhinweise anzeigen',
+  hide_block_hints_ui: 'Blockhinweise ausblenden',
   language_submenu_ui: 'Sprache',
   about_submenu_ui: 'Über',
   hub_submenu_ui: 'Hub',

--- a/locale/en.js
+++ b/locale/en.js
@@ -500,7 +500,7 @@ export default {
 
   // Tooltip translations - Events blocks
   start_tooltip:
-    'Run the blocks inside whenthe project starts. You can have multiple start blocks. \nKeyword: start',
+    'Run the blocks inside when the project starts. You can have multiple start blocks. \nKeyword: start',
   forever_tooltip:
     'Run the blocks inside every frame or when the previous iteration finishes. \nKeyword: forever',
   when_clicked_tooltip: 'Run the blocks inside when the object trigger occurs.\nKeyword: click',
@@ -544,9 +544,9 @@ export default {
     'Add a physics shape to the object. Options are object or capsule.\nKeyword:physics',
   apply_force_tooltip: 'Apply a force to an object in XYZ directions.\nKeyword: force',
   jump_tooltip:
-    'Make a character jump to a height (in blocks). Keeps your current running speed, so you leap forwards with momentum like in platform games. Needs physics.\nKeyword: jump hop leap',
+    'Make a character jump to a height (in blocks). Keeps your current running speed. Needs physics.\nKeyword: jump hop leap',
   set_speed_tooltip:
-    'Keep an object moving at a set speed in a direction. It moves just like a player does with "move" — riding up slopes, stepping over small ledges and stopping at walls, staying upright — but relative to the object or the world instead of the camera. It holds that speed until you change it. Pick a direction relative to the object (forward, sideways, up) or a world axis (x, y, z); use "look at" to aim, then drive forward. Choose "all" and 0 to stop.\nKeyword: speed',
+    'Keep an object moving at a steady speed, like "move" but continuous — handles slopes and collisions, relative to the object or world. Choose a direction (forward, sideways, up) or a world axis (x, y, z); use "all" and 0 to stop.\nKeyword: speed',
   set_bounciness_tooltip:
     'Set how bouncy an object is. 0 means no bounce, 1 means very bouncy. The object needs physics first.\nKeyword: bouncy restitution',
   show_physics_tooltip:
@@ -1101,6 +1101,8 @@ export default {
   project_save_ui: 'Save',
   tools_submenu_ui: 'Tools',
   inspector_tool_ui: 'Inspector',
+  show_block_hints_ui: 'Show block hints',
+  hide_block_hints_ui: 'Hide block hints',
   language_submenu_ui: 'Language',
   about_submenu_ui: 'About',
   hub_submenu_ui: 'Hub',

--- a/locale/en.js
+++ b/locale/en.js
@@ -1104,6 +1104,7 @@ export default {
   inspector_tool_ui: 'Inspector',
   show_block_hints_ui: 'Show block hints',
   hide_block_hints_ui: 'Hide block hints',
+  block_hints_menu_location_ui: 'Click Menu > Tools',
   language_submenu_ui: 'Language',
   about_submenu_ui: 'About',
   hub_submenu_ui: 'Hub',

--- a/locale/en.js
+++ b/locale/en.js
@@ -481,6 +481,8 @@ export default {
   export_mesh_tooltip: 'Export an object as STL, OBJ, or GLB.\nKeyword: export',
 
   // Tooltip translations - Control blocks
+  if_clause_tooltip:
+    'Run the attached blocks if the condition is true. Switch the dropdown to "else if" or "else", and connect another if block below to build if / else if / else chains.',
   wait_tooltip: 'Wait for a specified time in milliseconds.\nKeyword: milli',
   wait_seconds_tooltip: 'Wait for a specified time in seconds.\nKeyword: wait',
   wait_until_tooltip: 'Wait until the condition is true.\nKeyword:until',
@@ -656,8 +658,7 @@ export default {
     'Resize an object to the given x, y, and z and controls the origin of scaling. \nKeyword: scale',
   resize_tooltip:
     'Resize an object to the given x, y, and z and controls the origin of scaling.\nKeyword: resize',
-  rotate_model_xyz_tooltip:
-    'Rotate the object by the given x, y, z values.\nKeyword: rotate\nKeyword: rotateby',
+  rotate_model_xyz_tooltip: 'Rotate the object by the given x, y, z values.\nKeyword: rotateby',
   rotate_to_tooltip: 'Rotate the object to point towards the  coordinates.\nKeyword: rotateto',
   look_at_tooltip:
     'Rotate the first object towards the position of the second object.\nKeyword: look',

--- a/locale/es.js
+++ b/locale/es.js
@@ -247,7 +247,7 @@ export default {
   jump: 'saltar %1 altura %2', // ai
   set_speed: 'establecer velocidad de %1 %2 a %3', // ai
   set_speed_tooltip:
-    'Mantiene un objeto moviéndose a una velocidad establecida en una dirección. Se mueve igual que un personaje con "mover" — sube rampas, salva pequeños escalones, se detiene en las paredes y se mantiene erguido — pero relativo al objeto o al mundo en lugar de a la cámara. Mantiene esa velocidad hasta que la cambies. Elige una dirección relativa al objeto (adelante, al lado, arriba) o un eje del mundo (x, y, z); usa "mirar a" para apuntar y luego avanza. Elige "todos" y 0 para detener.\nKeyword: speed', // ai
+    'Mantiene un objeto moviéndose a una velocidad establecida en una dirección. Se mueve igual que un personaje con "mover" — sube rampas, salva pequeños escalones, se detiene en las paredes y se mantiene erguido — pero relativo al objeto o al mundo en lugar de a la cámara. Mantiene esa velocidad hasta que la cambies. Elige una dirección relativa al objeto (adelante, al lado, arriba) o un eje del mundo (x, y, z); usa "mirar a" para apuntar y luego avanza. Elige "todos" y 0 para detener.\nPalabra clave: speed', // ai
   show_physics: 'mostrar formas físicas %1', // human
 
   // Custom block translations - Sensing blocks
@@ -393,22 +393,22 @@ export default {
   // Add more custom block translations as needed
 
   // Tooltip translations - Scene Blocks
-  set_sky_color_tooltip: 'Establece el cielo del cielo de la escena.\nKeyword: cielo', // human
+  set_sky_color_tooltip: 'Establece el cielo del cielo de la escena.\nPalabra clave: cielo', // human
   create_ground_tooltip:
-    'Añide un plano de tierra con collisions habilitadas a la escena.\nKeyword: suelo', // human
+    'Añide un plano de tierra con collisions habilitadas a la escena.\nPalabra clave: suelo', // human
   set_background_color_tooltip:
-    'Establece el color de fondo de las escenas.\nKeyword: background', // human
-  create_map_tooltip: 'Crea un mapa con el nombre y matieral seleccionado.\nKeyword: mapa', // human
-  show_tooltip: 'mostrar el objeto seleccionado.\nKeyword: mostrar', // human
-  hide_tooltip: 'Ocultar el objeto seleccionado.\nKeyword: Oculater', // human
-  dispose_tooltip: 'Eliminar el objeto especificado de la escena.\nKeyword: disponer', // human
-  clone_mesh_tooltip: 'clonar un objeto y asignrla a una variable.\nKeyword: clonar', // human
+    'Establece el color de fondo de las escenas.\nPalabra clave: background', // human
+  create_map_tooltip: 'Crea un mapa con el nombre y matieral seleccionado.\nPalabra clave: mapa', // human
+  show_tooltip: 'mostrar el objeto seleccionado.\nPalabra clave: mostrar', // human
+  hide_tooltip: 'Ocultar el objeto seleccionado.\nPalabra clave: Oculater', // human
+  dispose_tooltip: 'Eliminar el objeto especificado de la escena.\nPalabra clave: disponer', // human
+  clone_mesh_tooltip: 'clonar un objeto y asignrla a una variable.\nPalabra clave: clonar', // human
 
   // Tooltip translations - Models blocks
-  load_character_tooltip: 'Crear un personaje configurable.\nKeyword: personaje', // human
-  load_object_tooltip: 'crear un objeto.\nKeyword: objecto', // human
-  load_multi_object_tooltip: 'crear un objeto con colores.\nKeyword: objecto', // human
-  load_model_tooltip: 'cargar un modelo.\nKeyword: modelo', // human
+  load_character_tooltip: 'Crear un personaje configurable.\nPalabra clave: personaje', // human
+  load_object_tooltip: 'crear un objeto.\nPalabra clave: objecto', // human
+  load_multi_object_tooltip: 'crear un objeto con colores.\nPalabra clave: objecto', // human
+  load_model_tooltip: 'cargar un modelo.\nPalabra clave: modelo', // human
 
   // Tooltip translations - Animate blocks
   glide_to_tooltip:
@@ -437,11 +437,11 @@ export default {
     'Controla el grupo de animación reproduciéndolo, pausándolo o parandolo.', // human
   animate_from_tooltip: 'Comienza a animar el grupo desde el tiempo especificado (en segundos).', // human
   stop_animations_tooltip:
-    'Para todas las animaciones de fotogramas clave en el objeto seleccionado.\nKeyword: para', // human
+    'Para todas las animaciones de fotogramas clave en el objeto seleccionado.\nPalabra clave: para', // human
   switch_animation_tooltip:
-    'Cambia la animación del objeto indicado a la animación dada.\nKeyword: cambia', // human
+    'Cambia la animación del objeto indicado a la animación dada.\nPalabra clave: cambia', // human
   play_animation_tooltip:
-    'Reproduce la animación seleccionada una vez en el objeto indicado.\nKeyword: Reproduce', // human
+    'Reproduce la animación seleccionada una vez en el objeto indicado.\nPalabra clave: Reproduce', // human
 
   // Tooltip translations - Base blocks
   xyz_tooltip: 'Crea un vector con coordenadas X, Y, Z', // human
@@ -449,141 +449,141 @@ export default {
   // Tooltip translations - Camera blocks
   camera_control_tooltip: 'Asocia una tecla específica a una acción de control de cámara.', // human
   camera_follow_tooltip:
-    'Haz que la cámara siga un objeto con una distancia personalizable (radio) al objetivo.\nKeyword: Sigue', // human
+    'Haz que la cámara siga un objeto con una distancia personalizable (radio) al objetivo.\nPalabra clave: Sigue', // human
   get_camera_tooltip: 'Obtén la cámara actual de la escena', // human
 
   // Tooltip translations - Combine blocks
   merge_meshes_tooltip:
-    'Fusiona una lista de objetos en uno y almacena el resultado.\nKeyword: fusiona', // human
+    'Fusiona una lista de objetos en uno y almacena el resultado.\nPalabra clave: fusiona', // human
   subtract_meshes_tooltip:
-    'Resta una lista de objetos de un objeto base y almacena el resultado.\nKeyword: Resta', // human
+    'Resta una lista de objetos de un objeto base y almacena el resultado.\nPalabra clave: Resta', // human
   intersection_meshes_tooltip:
-    'Intersecta una lista de objetos y almacena la geometría resultante.\nKeyword: intersecta', // human
+    'Intersecta una lista de objetos y almacena la geometría resultante.\nPalabra clave: intersecta', // human
   hull_meshes_tooltip:
-    'Crea una envolvente convexa de una lista de objetos y almacena el resultado.\nKeyword: envolvente', // human
+    'Crea una envolvente convexa de una lista de objetos y almacena el resultado.\nPalabra clave: envolvente', // human
 
   // Tooltip translations - Connect blocks
   parent_tooltip:
-    'Establece relación padre‑hijo entre dos objetos conservando la posición mundial del hijo.\nKeyword: padre', // human
+    'Establece relación padre‑hijo entre dos objetos conservando la posición mundial del hijo.\nPalabra clave: padre', // human
   parent_child_tooltip:
-    'Establece relación padre‑hijo entre dos objetos con desplazamiento en la dirección x, y, y z.\nKeyword: hijo', // human
+    'Establece relación padre‑hijo entre dos objetos con desplazamiento en la dirección x, y, y z.\nPalabra clave: hijo', // human
   remove_parent_tooltip:
-    'Elimina la relación de paternidad del objeto especificado.\nKeyword: elimina', // human
+    'Elimina la relación de paternidad del objeto especificado.\nPalabra clave: elimina', // human
   stop_follow_tooltip:
-    'Prevenir que el objeto especificado siga a otro.\nKeyword: paraseguir', // human
+    'Prevenir que el objeto especificado siga a otro.\nPalabra clave: paraseguir', // human
   hold_tooltip:
-    'Adjuntar un objeto al hueso especificado de otro con desplazamiento en x, y, z.\nKeyword: sostenga', // human
-  drop_tooltip: 'Desprende un objeto del hueso al que está adjunto.\nKeyword: soltar', // human
+    'Adjuntar un objeto al hueso especificado de otro con desplazamiento en x, y, z.\nPalabra clave: sostenga', // human
+  drop_tooltip: 'Desprende un objeto del hueso al que está adjunto.\nPalabra clave: soltar', // human
   follow_tooltip:
-    'Haz que un objeto siga a otro en una posición especificada (arriba, centro o abajo) con desplazamiento en dirección x, y, y z.\nKeyword: siigue', // human
-  export_mesh_tooltip: 'Exporta un objeto en STL, OBJ o GLB.\nKeyword: exporta', // human
+    'Haz que un objeto siga a otro en una posición especificada (arriba, centro o abajo) con desplazamiento en dirección x, y, y z.\nPalabra clave: siigue', // human
+  export_mesh_tooltip: 'Exporta un objeto en STL, OBJ o GLB.\nPalabra clave: exporta', // human
 
   // Tooltip translations - Control blocks
   if_clause_tooltip:
     'Ejecuta los bloques conectados si la condición es verdadera. Cambia el menú desplegable a "sino si" o "sino", y conecta otro bloque si debajo para crear cadenas de si / sino si / sino.', // ai
-  wait_tooltip: 'Espera un tiempo especificado en milisegundos.\nKeyword: mili', // human
-  wait_seconds_tooltip: 'Espera un tiempo especificado en segundos.\nKeyword: espera', // human
-  wait_until_tooltip: 'Espera hasta que la condición sea verdadera.\nKeyword: hasta', // human
+  wait_tooltip: 'Espera un tiempo especificado en milisegundos.\nPalabra clave: mili', // human
+  wait_seconds_tooltip: 'Espera un tiempo especificado en segundos.\nPalabra clave: espera', // human
+  wait_until_tooltip: 'Espera hasta que la condición sea verdadera.\nPalabra clave: hasta', // human
   local_variable_tooltip:
-    'Crea una versión local de una variable seleccionada. Oculta la variable global y puede tener un valor distinto.\nKeyword: local', // human
+    'Crea una versión local de una variable seleccionada. Oculta la variable global y puede tener un valor distinto.\nPalabra clave: local', // human
   for_loop2_tooltip: 'Bucle desde un número inicial hasta uno final usando un cierto paso.', // human
   for_loop_tooltip:
-    'Bucle desde un número inicial hasta uno final usando un cierto paso. Haz clic en el menú para seleccionar la variable del bucle para usar en tu código\nKeyword: para', // human
+    'Bucle desde un número inicial hasta uno final usando un cierto paso. Haz clic en el menú para seleccionar la variable del bucle para usar en tu código\nPalabra clave: para', // human
   get_lexical_variable_tooltip: 'Obtiene el valor de una variable léxica', // human
 
   // Tooltip translations - Effects blocks
   main_light_tooltip:
-    'Establece la intensidad de la luz principal.\nKeyword: intensidad de luz', // human
+    'Establece la intensidad de la luz principal.\nPalabra clave: intensidad de luz', // human
   set_fog_tooltip:
-    'Configura la niebla de la escena. Usa inicio y fin para definir las distancias cercana y lejana.\nKeyword: niebla', // human
-  get_light_tooltip: 'Obtén la luz principal de la escena actual.\nKeyword: luz', // human
+    'Configura la niebla de la escena. Usa inicio y fin para definir las distancias cercana y lejana.\nPalabra clave: niebla', // human
+  get_light_tooltip: 'Obtén la luz principal de la escena actual.\nPalabra clave: luz', // human
 
   // Tooltip translations - Events blocks
   start_tooltip:
-    'Ejecuta los bloques internos al iniciar el proyecto. Puede haber múltiples bloques de inicio.\nKeyword: Iniciar', // human
+    'Ejecuta los bloques internos al iniciar el proyecto. Puede haber múltiples bloques de inicio.\nPalabra clave: Iniciar', // human
   forever_tooltip:
-    'Ejecuta los bloques dentro de cada fotograma o tras finalizar la iteración anterior.\nKeyword: para siempre', // human
+    'Ejecuta los bloques dentro de cada fotograma o tras finalizar la iteración anterior.\nPalabra clave: para siempre', // human
   when_clicked_tooltip:
-    'Ejecuta los bloques en el interior cuando active el objeto.\nKeyword: clic', // human
+    'Ejecuta los bloques en el interior cuando active el objeto.\nPalabra clave: clic', // human
   on_collision_tooltip:
-    'Ejecuta los bloques internos cuando un objeto intersecta o deja de intersectar otro.\nKeyword: chocar', // human
+    'Ejecuta los bloques internos cuando un objeto intersecta o deja de intersectar otro.\nPalabra clave: chocar', // human
   when_key_event_tooltip:
     'Ejecuta los bloques internos cuando la tecla especificada se pulsa o se suelta.', // human
   when_action_event_tooltip:
     'Ejecuta los bloques internos cuando la acción elegida se pulsa o se suelta en teclado, toque o XR.', // human
   broadcast_event_tooltip:
-    "Emite un evento que es recibido por el bloque 'on event'.\nKeyword: emite", // human
+    "Emite un evento que es recibido por el bloque 'on event'.\nPalabra clave: emite", // human
   on_event_tooltip:
-    'Ejecuta el código cuando se recibe un evento emitido.\nKeyword: encender', // human
+    'Ejecuta el código cuando se recibe un evento emitido.\nPalabra clave: encender', // human
 
   // Tooltip translations - Materials blocks
-  change_color_tooltip: 'Cambia el color del objeto seleccionado.\nKeyword: color', // human
+  change_color_tooltip: 'Cambia el color del objeto seleccionado.\nPalabra clave: color', // human
   change_material_tooltip:
-    'Aplica un material seleccionado con tinte de color al objeto especificado.\nKeyword: material', // human
+    'Aplica un material seleccionado con tinte de color al objeto especificado.\nPalabra clave: material', // human
   text_material_tooltip:
     'Crea un material con texto o emoji, especificando ancho, alto, color de fondo y tamaño de texto.', // human
   place_decal_tooltip: 'Coloca una calcomanía en un objeto usando el material seleccionado.', // human
   decal_tooltip: 'Crea una calcomanía en un objeto con posición, normal, tamaño y material.', // human
-  highlight_tooltip: 'Resalta el objeto seleccionado.\nKeyword: resalta', // human
-  glow_tooltip: 'Añade un efecto de resplandor al objeto seleccionado.\nKeyword: resplandor', // human
-  tint_tooltip: 'Añade un tinte de color.\nKeyword: tinte', // human
+  highlight_tooltip: 'Resalta el objeto seleccionado.\nPalabra clave: resalta', // human
+  glow_tooltip: 'Añade un efecto de resplandor al objeto seleccionado.\nPalabra clave: resplandor', // human
+  tint_tooltip: 'Añade un tinte de color.\nPalabra clave: tinte', // human
   set_alpha_tooltip:
-    'Establece el canal alfa (transparencia) del material de un objeto. Valores entre 0 y 1.\nKeyword: alfa', // human
+    'Establece el canal alfa (transparencia) del material de un objeto. Valores entre 0 y 1.\nPalabra clave: alfa', // human
   clear_effects_tooltip:
-    'Elimina efectos visuales del objeto seleccionado.\nKeyword: elimina', // human
-  colour_tooltip: 'Selecciona un color.\nKeyword: color', // human
-  skin_colour_tooltip: 'Selecciona un color de piel.\nKeyword: piel', // human
+    'Elimina efectos visuales del objeto seleccionado.\nPalabra clave: elimina', // human
+  colour_tooltip: 'Selecciona un color.\nPalabra clave: color', // human
+  skin_colour_tooltip: 'Selecciona un color de piel.\nPalabra clave: piel', // human
   greyscale_colour_tooltip:
-    'Selecciona un color en escala de grises para elevación.\nKeyword: gris', // human
-  random_colour_tooltip: 'Genera un color aleatorio.\nKeyword: color aleatorio', // human
+    'Selecciona un color en escala de grises para elevación.\nPalabra clave: gris', // human
+  random_colour_tooltip: 'Genera un color aleatorio.\nPalabra clave: color aleatorio', // human
   material_tooltip: 'Define propiedades del material', // human
   gradient_material_tooltip: 'Define propiedades del material (gradiente)', // human
   set_material_tooltip: 'Establecer el material especificado al objeto indicado.', // human
 
   // Tooltip translations - Physics blocks
   add_physics_tooltip:
-    'Añade física al objeto. Opciones: dinámico, estático, animado o nada.\nKeyword: física', // human
+    'Añade física al objeto. Opciones: dinámico, estático, animado o nada.\nPalabra clave: física', // human
   add_physics_shape_tooltip:
-    'Añade una forma física al objeto. Opciones: objeto o cápsula.\nKeyword: física', // human
-  apply_force_tooltip: 'Aplica una fuerza a un objeto en direcciones XYZ.\nKeyword: fuerza', // human
+    'Añade una forma física al objeto. Opciones: objeto o cápsula.\nPalabra clave: física', // human
+  apply_force_tooltip: 'Aplica una fuerza a un objeto en direcciones XYZ.\nPalabra clave: fuerza', // human
   jump_tooltip:
-    'Hace que un personaje salte a una altura (en bloques). Mantiene tu velocidad de carrera actual, así que saltas hacia adelante con impulso como en los juegos de plataformas. Necesita física.\nKeyword: saltar brincar', // ai
+    'Hace que un personaje salte a una altura (en bloques). Mantiene tu velocidad de carrera actual. Necesita física.\nKeyword: saltar brincar', // ai
   show_physics_tooltip:
-    'Mostrar u ocultar colisionadores físicos para depuración. Marque para mostrar, desmarque para ocultar.\nKeyword: depuración de coliionador de física', // human
+    'Mostrar u ocultar colisionadores físicos para depuración. Marque para mostrar, desmarque para ocultar.\nPalabra clave: depuración de coliionador de física', // human
 
   // Tooltip translations - Sensing blocks
   key_pressed_tooltip:
-    'Devuelve verdadero si la tecla especificada está pulsado.\nKeyword: estápulsado', // human
+    'Devuelve verdadero si la tecla especificada está pulsado.\nPalabra clave: estápulsado', // human
   action_pressed_tooltip:
     'Devuelve verdadero si el control de movimiento o acción specificado está activo en teclado, toque o XR.', // human
   set_action_key: 'establecer tecla %1 a %2', // human
   set_action_key_tooltip:
     'Establece la tecla que activa una acción específica (adelante, atrás, izquierda, derecha o botones).', // ai
   meshes_touching_tooltip:
-    'Devuelve verdadero si los dos objetos seleccionados se están tocando.\nKeyword: estántocando', // human
+    'Devuelve verdadero si los dos objetos seleccionados se están tocando.\nPalabra clave: estántocando', // human
   time_tooltip:
     'Devuelve el tiempo transcurrido. Se pausa mientras la pestaña está oculta, ideal para temporizadores y cuentas atrás.', // ai
   ground_level_tooltip: 'Devuelve la altura del suelo a la posición x/z actual.', // human
   distance_to_tooltip: 'Calcula la distancia entre dos objetos.', // human
   touching_surface_tooltip:
-    'Comprueba si el objeto está tocando una superficie.\nKeyword: superficie', // human
+    'Comprueba si el objeto está tocando una superficie.\nPalabra clave: superficie', // human
   mesh_exists_tooltip: 'devuelve verdadero si el objeto con este nombre está presente en la escena', // human
   get_property_tooltip:
-    'Obtiene el valor de la propiedad seleccionada de un objeto.\nKeyword: obtiene', // human
+    'Obtiene el valor de la propiedad seleccionada de un objeto.\nPalabra clave: obtiene', // human
   canvas_controls_tooltip:
-    'Añade o elimina controles de movimiento en el lienzo.\nKeyword: lienzo', // human
+    'Añade o elimina controles de movimiento en el lienzo.\nPalabra clave: lienzo', // human
   interact_indicator_tooltip:
-    'Muestra u oculta el indicador de interacción junto a los objetos cercanos.\nKeyword: indicator', // ai
-  button_controls_tooltip: 'Configura controles de botónes.\nKeyword: botón', // human
-  on_screen_controls_tooltip: 'Configura los controles en pantalla.\nKeyword: onscreen', // ai
+    'Muestra u oculta el indicador de interacción junto a los objetos cercanos.\nPalabra clave: indicator', // ai
+  button_controls_tooltip: 'Configura controles de botónes.\nPalabra clave: botón', // human
+  on_screen_controls_tooltip: 'Configura los controles en pantalla.\nPalabra clave: onscreen', // ai
   microbit_input_tooltip:
     'Ejecuta los bloques dentro cuando se desencadena un evento micro:bit especificado.', // human
   add_microbit_tooltip:
     'Conecta un micro:bit y haz referencia a él con esta variable. Haz clic en el icono de estado para conectar un micro:bit por USB. Los micro:bit desenchufados envían eventos por radio a través de cualquier micro:bit enchufado en el mismo canal.', // ai
   microbit_show_image_tooltip:
-    'Muestra una imagen en la pantalla LED de un micro:bit conectado por USB. Haz clic en la imagen para editarla.\nKeyword: leds', // ai
+    'Muestra una imagen en la pantalla LED de un micro:bit conectado por USB. Haz clic en la imagen para editarla.\nPalabra clave: leds', // ai
   microbit_scroll_text_tooltip:
-    'Desplaza un texto por la pantalla LED de un micro:bit conectado por USB. Los textos largos se recortan a 16 caracteres.\nKeyword: scroll', // ai
+    'Desplaza un texto por la pantalla LED de un micro:bit conectado por USB. Los textos largos se recortan a 16 caracteres.\nPalabra clave: scroll', // ai
   ui_slider_tooltip:
     'Añade un control deslizante 2D en la UI y almacena su referencia en una variable.', // human
 
@@ -593,23 +593,23 @@ export default {
   control_particle_system_tooltip:
     'Controla el sistema de partículas iniciándolo, deteniéndolo o reiniciándolo.', // human
   create_box_tooltip:
-    'Crea una caja de color con dimensiones y posición especificadas.\nKeyword: caja', // human
+    'Crea una caja de color con dimensiones y posición especificadas.\nPalabra clave: caja', // human
   create_sphere_tooltip:
-    'Crea una esfera de color con dimensiones y posición especificadas.\nKeyword: esfera', // human
+    'Crea una esfera de color con dimensiones y posición especificadas.\nPalabra clave: esfera', // human
   create_cylinder_tooltip:
-    'Crea un cilindro de color con dimensiones y posición especificadas.\nKeyword: cilindro', // human
+    'Crea un cilindro de color con dimensiones y posición especificadas.\nPalabra clave: cilindro', // human
   create_capsule_tooltip:
-    'Crea una cápsula de color con dimensiones y posición especificadas.\nKeyword: cápsula', // human
+    'Crea una cápsula de color con dimensiones y posición especificadas.\nPalabra clave: cápsula', // human
   create_plane_tooltip:
-    'Crea un plano 2D de color con ancho, alto y posición especificadas.\nKeyword: plano', // human
+    'Crea un plano 2D de color con ancho, alto y posición especificadas.\nPalabra clave: plano', // human
 
   // Tooltip translations - Sound blocks
   play_theme_tooltip:
-    'Reproduce un tema musical en un objeto con velocidad, volumen y modo ajustables.\nKeyword: tema', // human
+    'Reproduce un tema musical en un objeto con velocidad, volumen y modo ajustables.\nPalabra clave: tema', // human
   play_sound_tooltip:
-    'Reproduce el sonido seleccionado en un objeto con velocidad, volumen y modo ajustables.\nKeyword: sonido', // human
+    'Reproduce el sonido seleccionado en un objeto con velocidad, volumen y modo ajustables.\nPalabra clave: sonido', // human
   stop_all_sounds_tooltip:
-    'Para todos los sonidos que estén reproduciendo en la escena.\nKeyword: nosonido', // human
+    'Para todos los sonidos que estén reproduciendo en la escena.\nPalabra clave: nosonido', // human
   midi_note_tooltip: 'Un valor de nota MIDI entre 0 y 127.', // human
   rest_tooltip: 'Un pausa (silencio) en una secuencia musical.', // human
   play_notes_tooltip:
@@ -619,18 +619,18 @@ export default {
   create_instrument_tooltip: 'Crea un instrumento y lo asigna a la variable seleccionada.', // human
   instrument_tooltip: 'Selecciona un instrumento para reproducir notas.', // human
   speak_tooltip:
-    'Convierte texto en voz usando el Web Speech API (API de voz web) con posicionamiento 3D opcional.\nKeyword: hablar', // human
+    'Convierte texto en voz usando el Web Speech API (API de voz web) con posicionamiento 3D opcional.\nPalabra clave: hablar', // human
   enable_subtitles_tooltip:
-    'Muestra subtítulos en pantalla para el texto hablado.\nKeyword: subtitles', // ai
+    'Muestra subtítulos en pantalla para el texto hablado.\nPalabra clave: subtitles', // ai
 
   // Tooltip translations - Text blocks
   comment_tooltip: 'Una línea de comentario para ayudar la comprensión de tu código.', // human
-  print_text_tooltip: 'Texto en el panel de salida.\nKeyword: imprimir', // human
+  print_text_tooltip: 'Texto en el panel de salida.\nPalabra clave: imprimir', // human
   subtitle_tooltip:
-    'Muestra el texto como subtítulo en pantalla. 0 segundos permanece hasta el siguiente.\nKeyword: subtitle', // ai
-  say_tooltip: 'Muestra un texto como burbuja de diálogo en un objeto.\nKeyword: di', // human
+    'Muestra el texto como subtítulo en pantalla. 0 segundos permanece hasta el siguiente.\nPalabra clave: subtitle', // ai
+  say_tooltip: 'Muestra un texto como burbuja de diálogo en un objeto.\nPalabra clave: di', // human
   describe_tooltip:
-    'Establece el nombre visible de un objeto. Actualiza los metadatos para accesibilidad.\nKeyword: describe', // human
+    'Establece el nombre visible de un objeto. Actualiza los metadatos para accesibilidad.\nPalabra clave: describe', // human
   ui_text_tooltip:
     'Añade texto a la pantalla UI y almacena el control en una variable para usar o eliminar luego.', // human
   ui_button_tooltip:
@@ -641,37 +641,37 @@ export default {
 
   // Tooltip translations - Math blocks
   random_seeded_int_tooltip:
-    'Generar un numero entero aleatorio con una semilla.\nKeyword: semilla', // human
+    'Generar un numero entero aleatorio con una semilla.\nPalabra clave: semilla', // human
   to_number_tooltip: 'Convertir una cadena a un numero entero o un flotante', // human
 
   // Tooltip translations - Transform blocks
   move_by_xyz_tooltip:
-    'Mueve un objeto cierta cantidad en direcciones x, y, y z.\nKeyword: mueve', // human
+    'Mueve un objeto cierta cantidad en direcciones x, y, y z.\nPalabra clave: mueve', // human
   move_by_xyz_single_tooltip:
-    'Mueve un objeto una cantidad en cualquiera dirección x, y, o z.\nKeyword: mueve', // human
+    'Mueve un objeto una cantidad en cualquiera dirección x, y, o z.\nPalabra clave: mueve', // human
   move_to_xyz_tooltip:
-    'Teletransporta el objeto a las coordenadas. Opcionalmente, usa el eje Y.\nKeyword: muevepor', // human
+    'Teletransporta el objeto a las coordenadas. Opcionalmente, usa el eje Y.\nPalabra clave: muevepor', // human
   move_to_xyz_single_tooltip:
-    'Teletransporta el objeto a la coordenada única especificada.\nKeyword: muevepor', // human
+    'Teletransporta el objeto a la coordenada única especificada.\nPalabra clave: muevepor', // human
   move_to_tooltip:
-    'Teletransporta el primer objeto a la ubicación del segundo.\nKeyword: muevea', // human
+    'Teletransporta el primer objeto a la ubicación del segundo.\nPalabra clave: muevea', // human
   scale_tooltip:
-    'Redimensiona un objeto a los valores x, y, y z y controla el origen del escalado.\nKeyword: escala', // human
+    'Redimensiona un objeto a los valores x, y, y z y controla el origen del escalado.\nPalabra clave: escala', // human
   resize_tooltip:
-    'Redimensiona un objeto a los valores x, y, y z y controla el origen del escalado.\nKeyword: redimensiona', // human
+    'Redimensiona un objeto a los valores x, y, y z y controla el origen del escalado.\nPalabra clave: redimensiona', // human
   rotate_model_xyz_tooltip:
-    'Rota el objeto por los valores x, y, z indicados.\nKeyword: rota\nKeyword: rotapor', // human
-  rotate_to_tooltip: 'Rota el objeto para q apunte hacia las coordenadas.\nKeyword: rotaa', // human
-  look_at_tooltip: 'Rota el primer objeto hacia la posición de la segunda.\nKeyword: mira', // human
+    'Rota el objeto por los valores x, y, z indicados.\nPalabra clave: rota\nPalabra clave: rotapor', // human
+  rotate_to_tooltip: 'Rota el objeto para q apunte hacia las coordenadas.\nPalabra clave: rotaa', // human
+  look_at_tooltip: 'Rota el primer objeto hacia la posición de la segunda.\nPalabra clave: mira', // human
   move_forward_tooltip:
-    "Mueve el objeto en la dirección especificada. 'adelante' sigue su dirección, 'al lado' lo mueve relativo a la posición de la cámara, y 'strafear' lo mueve al lado relative a la posición de la cámara.\nKeyword: empuja", // human
+    "Mueve el objeto en la dirección especificada. 'adelante' sigue su dirección, 'al lado' lo mueve relativo a la posición de la cámara, y 'strafear' lo mueve al lado relative a la posición de la cámara.\nPalabra clave: empuja", // human
   rotate_camera_tooltip:
-    'Rota la cámara a la izquierda o derecha los grados indicados.\nKeyword: rotate', // human
-  up_tooltip: 'Aplica la fuerza especificada hacia arriba .\nKeyword: up', // human
+    'Rota la cámara a la izquierda o derecha los grados indicados.\nPalabra clave: rotate', // human
+  up_tooltip: 'Aplica la fuerza especificada hacia arriba .\nPalabra clave: up', // human
   set_pivot_tooltip:
-    'Establece el punto de anclaje para un objeto en los ejes X, Y, y Z.\nKeyword: ancla', // human
+    'Establece el punto de anclaje para un objeto en los ejes X, Y, y Z.\nPalabra clave: ancla', // human
   min_centre_max_tooltip:
-    'Elige minimo, centro o maximo para el punto de pivote.\nKeyword: minmax', // human
+    'Elige minimo, centro o maximo para el punto de pivote.\nPalabra clave: minmax', // human
 
   // Tooltip translations - XR blocks
   device_camera_background_tooltip:
@@ -682,11 +682,11 @@ export default {
   remove_teleport_target_tooltip:
     'Impide teletransportarse al suelo, a un objeto o a todos los objetos.',
   play_rumble_pattern_tooltip:
-    'Reproduce un patrón de vibración predefinido en todos los mandos conectados.\nKeyword: rumble preset', // human
+    'Reproduce un patrón de vibración predefinido en todos los mandos conectados.\nPalabra clave: rumble preset', // human
   controller_rumble_tooltip:
-    'Hace vibrar un mando conectado. Elige todos, el izquierdo o el derecho motor, establece la fuerza (0 a 1) y cuánto tiempo para vibrar en milisegundos.\nKeyword: vibrar', // human
+    'Hace vibrar un mando conectado. Elige todos, el izquierdo o el derecho motor, establece la fuerza (0 a 1) y cuánto tiempo para vibrar en milisegundos.\nPalabra clave: vibrar', // human
   controller_rumble_pattern_tooltip:
-    'Hace vibrar un mando conectado en un patrón repetido. Establece el motor, la fuerza (0 a 1), el tiempo encendido, el tiempo apagado y el número de repeticiones.\nKeyword: patrón de vibrar', // human
+    'Hace vibrar un mando conectado en un patrón repetido. Establece el motor, la fuerza (0 a 1), el tiempo encendido, el tiempo apagado y el número de repeticiones.\nPalabra clave: patrón de vibrar', // human
 
   // Dropdown option translations
   AWAIT_option: 'esperar', // human
@@ -1098,6 +1098,7 @@ export default {
   inspector_tool_ui: 'Inspector', // ai
   show_block_hints_ui: 'Mostrar sugerencias de bloques',
   hide_block_hints_ui: 'Ocultar sugerencias de bloques',
+  block_hints_menu_location_ui: 'Haz clic en Menú > Herramientas',
   language_submenu_ui: 'Idioma', // human
   about_submenu_ui: 'Sobre nosotros', // human
   hub_submenu_ui: 'Centro', // human

--- a/locale/es.js
+++ b/locale/es.js
@@ -479,6 +479,8 @@ export default {
   export_mesh_tooltip: 'Exporta un objeto en STL, OBJ o GLB.\nKeyword: exporta', // human
 
   // Tooltip translations - Control blocks
+  if_clause_tooltip:
+    'Ejecuta los bloques conectados si la condición es verdadera. Cambia el menú desplegable a "sino si" o "sino", y conecta otro bloque si debajo para crear cadenas de si / sino si / sino.', // ai
   wait_tooltip: 'Espera un tiempo especificado en milisegundos.\nKeyword: mili', // human
   wait_seconds_tooltip: 'Espera un tiempo especificado en segundos.\nKeyword: espera', // human
   wait_until_tooltip: 'Espera hasta que la condición sea verdadera.\nKeyword: hasta', // human

--- a/locale/es.js
+++ b/locale/es.js
@@ -1094,6 +1094,8 @@ export default {
   project_save_ui: 'Guardar', // human
   tools_submenu_ui: 'Herramientas', // ai
   inspector_tool_ui: 'Inspector', // ai
+  show_block_hints_ui: 'Mostrar sugerencias de bloques',
+  hide_block_hints_ui: 'Ocultar sugerencias de bloques',
   language_submenu_ui: 'Idioma', // human
   about_submenu_ui: 'Sobre nosotros', // human
   hub_submenu_ui: 'Centro', // human

--- a/locale/es.js
+++ b/locale/es.js
@@ -247,7 +247,7 @@ export default {
   jump: 'saltar %1 altura %2', // ai
   set_speed: 'establecer velocidad de %1 %2 a %3', // ai
   set_speed_tooltip:
-    'Mantiene un objeto moviéndose a una velocidad establecida en una dirección. Se mueve igual que un personaje con "mover" — sube rampas, salva pequeños escalones, se detiene en las paredes y se mantiene erguido — pero relativo al objeto o al mundo en lugar de a la cámara. Mantiene esa velocidad hasta que la cambies. Elige una dirección relativa al objeto (adelante, al lado, arriba) o un eje del mundo (x, y, z); usa "mirar a" para apuntar y luego avanza. Elige "todos" y 0 para detener.\nPalabra clave: speed', // ai
+    'Mantiene un objeto moviéndose a una velocidad establecida en una dirección. Se mueve igual que un personaje con "mover" — sube rampas, salva pequeños escalones, se detiene en las paredes y se mantiene erguido — pero relativo al objeto o al mundo en lugar de a la cámara. Mantiene esa velocidad hasta que la cambies. Elige una dirección relativa al objeto (adelante, al lado, arriba) o un eje del mundo (x, y, z); usa "mirar a" para apuntar y luego avanza. Elige "todos" y 0 para detener.\nKeyword: speed', // ai
   show_physics: 'mostrar formas físicas %1', // human
 
   // Custom block translations - Sensing blocks
@@ -393,22 +393,22 @@ export default {
   // Add more custom block translations as needed
 
   // Tooltip translations - Scene Blocks
-  set_sky_color_tooltip: 'Establece el cielo del cielo de la escena.\nPalabra clave: cielo', // human
+  set_sky_color_tooltip: 'Establece el cielo del cielo de la escena.\nKeyword: cielo', // human
   create_ground_tooltip:
-    'Añide un plano de tierra con collisions habilitadas a la escena.\nPalabra clave: suelo', // human
+    'Añide un plano de tierra con collisions habilitadas a la escena.\nKeyword: suelo', // human
   set_background_color_tooltip:
-    'Establece el color de fondo de las escenas.\nPalabra clave: background', // human
-  create_map_tooltip: 'Crea un mapa con el nombre y matieral seleccionado.\nPalabra clave: mapa', // human
-  show_tooltip: 'mostrar el objeto seleccionado.\nPalabra clave: mostrar', // human
-  hide_tooltip: 'Ocultar el objeto seleccionado.\nPalabra clave: Oculater', // human
-  dispose_tooltip: 'Eliminar el objeto especificado de la escena.\nPalabra clave: disponer', // human
-  clone_mesh_tooltip: 'clonar un objeto y asignrla a una variable.\nPalabra clave: clonar', // human
+    'Establece el color de fondo de las escenas.\nKeyword: background', // human
+  create_map_tooltip: 'Crea un mapa con el nombre y matieral seleccionado.\nKeyword: mapa', // human
+  show_tooltip: 'mostrar el objeto seleccionado.\nKeyword: mostrar', // human
+  hide_tooltip: 'Ocultar el objeto seleccionado.\nKeyword: Oculater', // human
+  dispose_tooltip: 'Eliminar el objeto especificado de la escena.\nKeyword: disponer', // human
+  clone_mesh_tooltip: 'clonar un objeto y asignrla a una variable.\nKeyword: clonar', // human
 
   // Tooltip translations - Models blocks
-  load_character_tooltip: 'Crear un personaje configurable.\nPalabra clave: personaje', // human
-  load_object_tooltip: 'crear un objeto.\nPalabra clave: objecto', // human
-  load_multi_object_tooltip: 'crear un objeto con colores.\nPalabra clave: objecto', // human
-  load_model_tooltip: 'cargar un modelo.\nPalabra clave: modelo', // human
+  load_character_tooltip: 'Crear un personaje configurable.\nKeyword: personaje', // human
+  load_object_tooltip: 'crear un objeto.\nKeyword: objecto', // human
+  load_multi_object_tooltip: 'crear un objeto con colores.\nKeyword: objecto', // human
+  load_model_tooltip: 'cargar un modelo.\nKeyword: modelo', // human
 
   // Tooltip translations - Animate blocks
   glide_to_tooltip:
@@ -437,11 +437,11 @@ export default {
     'Controla el grupo de animación reproduciéndolo, pausándolo o parandolo.', // human
   animate_from_tooltip: 'Comienza a animar el grupo desde el tiempo especificado (en segundos).', // human
   stop_animations_tooltip:
-    'Para todas las animaciones de fotogramas clave en el objeto seleccionado.\nPalabra clave: para', // human
+    'Para todas las animaciones de fotogramas clave en el objeto seleccionado.\nKeyword: para', // human
   switch_animation_tooltip:
-    'Cambia la animación del objeto indicado a la animación dada.\nPalabra clave: cambia', // human
+    'Cambia la animación del objeto indicado a la animación dada.\nKeyword: cambia', // human
   play_animation_tooltip:
-    'Reproduce la animación seleccionada una vez en el objeto indicado.\nPalabra clave: Reproduce', // human
+    'Reproduce la animación seleccionada una vez en el objeto indicado.\nKeyword: Reproduce', // human
 
   // Tooltip translations - Base blocks
   xyz_tooltip: 'Crea un vector con coordenadas X, Y, Z', // human
@@ -449,139 +449,139 @@ export default {
   // Tooltip translations - Camera blocks
   camera_control_tooltip: 'Asocia una tecla específica a una acción de control de cámara.', // human
   camera_follow_tooltip:
-    'Haz que la cámara siga un objeto con una distancia personalizable (radio) al objetivo.\nPalabra clave: Sigue', // human
+    'Haz que la cámara siga un objeto con una distancia personalizable (radio) al objetivo.\nKeyword: Sigue', // human
   get_camera_tooltip: 'Obtén la cámara actual de la escena', // human
 
   // Tooltip translations - Combine blocks
   merge_meshes_tooltip:
-    'Fusiona una lista de objetos en uno y almacena el resultado.\nPalabra clave: fusiona', // human
+    'Fusiona una lista de objetos en uno y almacena el resultado.\nKeyword: fusiona', // human
   subtract_meshes_tooltip:
-    'Resta una lista de objetos de un objeto base y almacena el resultado.\nPalabra clave: Resta', // human
+    'Resta una lista de objetos de un objeto base y almacena el resultado.\nKeyword: Resta', // human
   intersection_meshes_tooltip:
-    'Intersecta una lista de objetos y almacena la geometría resultante.\nPalabra clave: intersecta', // human
+    'Intersecta una lista de objetos y almacena la geometría resultante.\nKeyword: intersecta', // human
   hull_meshes_tooltip:
-    'Crea una envolvente convexa de una lista de objetos y almacena el resultado.\nPalabra clave: envolvente', // human
+    'Crea una envolvente convexa de una lista de objetos y almacena el resultado.\nKeyword: envolvente', // human
 
   // Tooltip translations - Connect blocks
   parent_tooltip:
-    'Establece relación padre‑hijo entre dos objetos conservando la posición mundial del hijo.\nPalabra clave: padre', // human
+    'Establece relación padre‑hijo entre dos objetos conservando la posición mundial del hijo.\nKeyword: padre', // human
   parent_child_tooltip:
-    'Establece relación padre‑hijo entre dos objetos con desplazamiento en la dirección x, y, y z.\nPalabra clave: hijo', // human
+    'Establece relación padre‑hijo entre dos objetos con desplazamiento en la dirección x, y, y z.\nKeyword: hijo', // human
   remove_parent_tooltip:
-    'Elimina la relación de paternidad del objeto especificado.\nPalabra clave: elimina', // human
+    'Elimina la relación de paternidad del objeto especificado.\nKeyword: elimina', // human
   stop_follow_tooltip:
-    'Prevenir que el objeto especificado siga a otro.\nPalabra clave: paraseguir', // human
+    'Prevenir que el objeto especificado siga a otro.\nKeyword: paraseguir', // human
   hold_tooltip:
-    'Adjuntar un objeto al hueso especificado de otro con desplazamiento en x, y, z.\nPalabra clave: sostenga', // human
-  drop_tooltip: 'Desprende un objeto del hueso al que está adjunto.\nPalabra clave: soltar', // human
+    'Adjuntar un objeto al hueso especificado de otro con desplazamiento en x, y, z.\nKeyword: sostenga', // human
+  drop_tooltip: 'Desprende un objeto del hueso al que está adjunto.\nKeyword: soltar', // human
   follow_tooltip:
-    'Haz que un objeto siga a otro en una posición especificada (arriba, centro o abajo) con desplazamiento en dirección x, y, y z.\nPalabra clave: siigue', // human
-  export_mesh_tooltip: 'Exporta un objeto en STL, OBJ o GLB.\nPalabra clave: exporta', // human
+    'Haz que un objeto siga a otro en una posición especificada (arriba, centro o abajo) con desplazamiento en dirección x, y, y z.\nKeyword: siigue', // human
+  export_mesh_tooltip: 'Exporta un objeto en STL, OBJ o GLB.\nKeyword: exporta', // human
 
   // Tooltip translations - Control blocks
-  wait_tooltip: 'Espera un tiempo especificado en milisegundos.\nPalabra clave: mili', // human
-  wait_seconds_tooltip: 'Espera un tiempo especificado en segundos.\nPalabra clave: espera', // human
-  wait_until_tooltip: 'Espera hasta que la condición sea verdadera.\nPalabra clave: hasta', // human
+  wait_tooltip: 'Espera un tiempo especificado en milisegundos.\nKeyword: mili', // human
+  wait_seconds_tooltip: 'Espera un tiempo especificado en segundos.\nKeyword: espera', // human
+  wait_until_tooltip: 'Espera hasta que la condición sea verdadera.\nKeyword: hasta', // human
   local_variable_tooltip:
-    'Crea una versión local de una variable seleccionada. Oculta la variable global y puede tener un valor distinto.\nPalabra clave: local', // human
+    'Crea una versión local de una variable seleccionada. Oculta la variable global y puede tener un valor distinto.\nKeyword: local', // human
   for_loop2_tooltip: 'Bucle desde un número inicial hasta uno final usando un cierto paso.', // human
   for_loop_tooltip:
-    'Bucle desde un número inicial hasta uno final usando un cierto paso. Haz clic en el menú para seleccionar la variable del bucle para usar en tu código\nPalabra clave: para', // human
+    'Bucle desde un número inicial hasta uno final usando un cierto paso. Haz clic en el menú para seleccionar la variable del bucle para usar en tu código\nKeyword: para', // human
   get_lexical_variable_tooltip: 'Obtiene el valor de una variable léxica', // human
 
   // Tooltip translations - Effects blocks
   main_light_tooltip:
-    'Establece la intensidad de la luz principal.\nPalabra clave: intensidad de luz', // human
+    'Establece la intensidad de la luz principal.\nKeyword: intensidad de luz', // human
   set_fog_tooltip:
-    'Configura la niebla de la escena. Usa inicio y fin para definir las distancias cercana y lejana.\nPalabra clave: niebla', // human
-  get_light_tooltip: 'Obtén la luz principal de la escena actual.\nPalabra clave: luz', // human
+    'Configura la niebla de la escena. Usa inicio y fin para definir las distancias cercana y lejana.\nKeyword: niebla', // human
+  get_light_tooltip: 'Obtén la luz principal de la escena actual.\nKeyword: luz', // human
 
   // Tooltip translations - Events blocks
   start_tooltip:
-    'Ejecuta los bloques internos al iniciar el proyecto. Puede haber múltiples bloques de inicio.\nPalabra clave: Iniciar', // human
+    'Ejecuta los bloques internos al iniciar el proyecto. Puede haber múltiples bloques de inicio.\nKeyword: Iniciar', // human
   forever_tooltip:
-    'Ejecuta los bloques dentro de cada fotograma o tras finalizar la iteración anterior.\nPalabra clave: para siempre', // human
+    'Ejecuta los bloques dentro de cada fotograma o tras finalizar la iteración anterior.\nKeyword: para siempre', // human
   when_clicked_tooltip:
-    'Ejecuta los bloques en el interior cuando active el objeto.\nPalabra clave: clic', // human
+    'Ejecuta los bloques en el interior cuando active el objeto.\nKeyword: clic', // human
   on_collision_tooltip:
-    'Ejecuta los bloques internos cuando un objeto intersecta o deja de intersectar otro.\nPalabra clave: chocar', // human
+    'Ejecuta los bloques internos cuando un objeto intersecta o deja de intersectar otro.\nKeyword: chocar', // human
   when_key_event_tooltip:
     'Ejecuta los bloques internos cuando la tecla especificada se pulsa o se suelta.', // human
   when_action_event_tooltip:
     'Ejecuta los bloques internos cuando la acción elegida se pulsa o se suelta en teclado, toque o XR.', // human
   broadcast_event_tooltip:
-    "Emite un evento que es recibido por el bloque 'on event'.\nPalabra clave: emite", // human
+    "Emite un evento que es recibido por el bloque 'on event'.\nKeyword: emite", // human
   on_event_tooltip:
-    'Ejecuta el código cuando se recibe un evento emitido.\nPalabra clave: encender', // human
+    'Ejecuta el código cuando se recibe un evento emitido.\nKeyword: encender', // human
 
   // Tooltip translations - Materials blocks
-  change_color_tooltip: 'Cambia el color del objeto seleccionado.\nPalabra clave: color', // human
+  change_color_tooltip: 'Cambia el color del objeto seleccionado.\nKeyword: color', // human
   change_material_tooltip:
-    'Aplica un material seleccionado con tinte de color al objeto especificado.\nPalabra clave: material', // human
+    'Aplica un material seleccionado con tinte de color al objeto especificado.\nKeyword: material', // human
   text_material_tooltip:
     'Crea un material con texto o emoji, especificando ancho, alto, color de fondo y tamaño de texto.', // human
   place_decal_tooltip: 'Coloca una calcomanía en un objeto usando el material seleccionado.', // human
   decal_tooltip: 'Crea una calcomanía en un objeto con posición, normal, tamaño y material.', // human
-  highlight_tooltip: 'Resalta el objeto seleccionado.\nPalabra clave: resalta', // human
-  glow_tooltip: 'Añade un efecto de resplandor al objeto seleccionado.\nPalabra clave: resplandor', // human
-  tint_tooltip: 'Añade un tinte de color.\nPalabra clave: tinte', // human
+  highlight_tooltip: 'Resalta el objeto seleccionado.\nKeyword: resalta', // human
+  glow_tooltip: 'Añade un efecto de resplandor al objeto seleccionado.\nKeyword: resplandor', // human
+  tint_tooltip: 'Añade un tinte de color.\nKeyword: tinte', // human
   set_alpha_tooltip:
-    'Establece el canal alfa (transparencia) del material de un objeto. Valores entre 0 y 1.\nPalabra clave: alfa', // human
+    'Establece el canal alfa (transparencia) del material de un objeto. Valores entre 0 y 1.\nKeyword: alfa', // human
   clear_effects_tooltip:
-    'Elimina efectos visuales del objeto seleccionado.\nPalabra clave: elimina', // human
-  colour_tooltip: 'Selecciona un color.\nPalabra clave: color', // human
-  skin_colour_tooltip: 'Selecciona un color de piel.\nPalabra clave: piel', // human
+    'Elimina efectos visuales del objeto seleccionado.\nKeyword: elimina', // human
+  colour_tooltip: 'Selecciona un color.\nKeyword: color', // human
+  skin_colour_tooltip: 'Selecciona un color de piel.\nKeyword: piel', // human
   greyscale_colour_tooltip:
-    'Selecciona un color en escala de grises para elevación.\nPalabra clave: gris', // human
-  random_colour_tooltip: 'Genera un color aleatorio.\nPalabra clave: color aleatorio', // human
+    'Selecciona un color en escala de grises para elevación.\nKeyword: gris', // human
+  random_colour_tooltip: 'Genera un color aleatorio.\nKeyword: color aleatorio', // human
   material_tooltip: 'Define propiedades del material', // human
   gradient_material_tooltip: 'Define propiedades del material (gradiente)', // human
   set_material_tooltip: 'Establecer el material especificado al objeto indicado.', // human
 
   // Tooltip translations - Physics blocks
   add_physics_tooltip:
-    'Añade física al objeto. Opciones: dinámico, estático, animado o nada.\nPalabra clave: física', // human
+    'Añade física al objeto. Opciones: dinámico, estático, animado o nada.\nKeyword: física', // human
   add_physics_shape_tooltip:
-    'Añade una forma física al objeto. Opciones: objeto o cápsula.\nPalabra clave: física', // human
-  apply_force_tooltip: 'Aplica una fuerza a un objeto en direcciones XYZ.\nPalabra clave: fuerza', // human
+    'Añade una forma física al objeto. Opciones: objeto o cápsula.\nKeyword: física', // human
+  apply_force_tooltip: 'Aplica una fuerza a un objeto en direcciones XYZ.\nKeyword: fuerza', // human
   jump_tooltip:
-    'Hace que un personaje salte a una altura (en bloques). Mantiene tu velocidad de carrera actual, así que saltas hacia adelante con impulso como en los juegos de plataformas. Necesita física.\nPalabra clave: saltar brincar', // ai
+    'Hace que un personaje salte a una altura (en bloques). Mantiene tu velocidad de carrera actual, así que saltas hacia adelante con impulso como en los juegos de plataformas. Necesita física.\nKeyword: saltar brincar', // ai
   show_physics_tooltip:
-    'Mostrar u ocultar colisionadores físicos para depuración. Marque para mostrar, desmarque para ocultar.\nPalabra clave: depuración de coliionador de física', // human
+    'Mostrar u ocultar colisionadores físicos para depuración. Marque para mostrar, desmarque para ocultar.\nKeyword: depuración de coliionador de física', // human
 
   // Tooltip translations - Sensing blocks
   key_pressed_tooltip:
-    'Devuelve verdadero si la tecla especificada está pulsado.\nPalabra clave: estápulsado', // human
+    'Devuelve verdadero si la tecla especificada está pulsado.\nKeyword: estápulsado', // human
   action_pressed_tooltip:
     'Devuelve verdadero si el control de movimiento o acción specificado está activo en teclado, toque o XR.', // human
   set_action_key: 'establecer tecla %1 a %2', // human
   set_action_key_tooltip:
     'Establece la tecla que activa una acción específica (adelante, atrás, izquierda, derecha o botones).', // ai
   meshes_touching_tooltip:
-    'Devuelve verdadero si los dos objetos seleccionados se están tocando.\nPalabra clave: estántocando', // human
+    'Devuelve verdadero si los dos objetos seleccionados se están tocando.\nKeyword: estántocando', // human
   time_tooltip:
     'Devuelve el tiempo transcurrido. Se pausa mientras la pestaña está oculta, ideal para temporizadores y cuentas atrás.', // ai
   ground_level_tooltip: 'Devuelve la altura del suelo a la posición x/z actual.', // human
   distance_to_tooltip: 'Calcula la distancia entre dos objetos.', // human
   touching_surface_tooltip:
-    'Comprueba si el objeto está tocando una superficie.\nPalabra clave: superficie', // human
+    'Comprueba si el objeto está tocando una superficie.\nKeyword: superficie', // human
   mesh_exists_tooltip: 'devuelve verdadero si el objeto con este nombre está presente en la escena', // human
   get_property_tooltip:
-    'Obtiene el valor de la propiedad seleccionada de un objeto.\nPalabra clave: obtiene', // human
+    'Obtiene el valor de la propiedad seleccionada de un objeto.\nKeyword: obtiene', // human
   canvas_controls_tooltip:
-    'Añade o elimina controles de movimiento en el lienzo.\nPalabra clave: lienzo', // human
+    'Añade o elimina controles de movimiento en el lienzo.\nKeyword: lienzo', // human
   interact_indicator_tooltip:
-    'Muestra u oculta el indicador de interacción junto a los objetos cercanos.\nPalabra clave: indicator', // ai
-  button_controls_tooltip: 'Configura controles de botónes.\nPalabra clave: botón', // human
-  on_screen_controls_tooltip: 'Configura los controles en pantalla.\nPalabra clave: onscreen', // ai
+    'Muestra u oculta el indicador de interacción junto a los objetos cercanos.\nKeyword: indicator', // ai
+  button_controls_tooltip: 'Configura controles de botónes.\nKeyword: botón', // human
+  on_screen_controls_tooltip: 'Configura los controles en pantalla.\nKeyword: onscreen', // ai
   microbit_input_tooltip:
     'Ejecuta los bloques dentro cuando se desencadena un evento micro:bit especificado.', // human
   add_microbit_tooltip:
     'Conecta un micro:bit y haz referencia a él con esta variable. Haz clic en el icono de estado para conectar un micro:bit por USB. Los micro:bit desenchufados envían eventos por radio a través de cualquier micro:bit enchufado en el mismo canal.', // ai
   microbit_show_image_tooltip:
-    'Muestra una imagen en la pantalla LED de un micro:bit conectado por USB. Haz clic en la imagen para editarla.\nPalabra clave: leds', // ai
+    'Muestra una imagen en la pantalla LED de un micro:bit conectado por USB. Haz clic en la imagen para editarla.\nKeyword: leds', // ai
   microbit_scroll_text_tooltip:
-    'Desplaza un texto por la pantalla LED de un micro:bit conectado por USB. Los textos largos se recortan a 16 caracteres.\nPalabra clave: scroll', // ai
+    'Desplaza un texto por la pantalla LED de un micro:bit conectado por USB. Los textos largos se recortan a 16 caracteres.\nKeyword: scroll', // ai
   ui_slider_tooltip:
     'Añade un control deslizante 2D en la UI y almacena su referencia en una variable.', // human
 
@@ -591,23 +591,23 @@ export default {
   control_particle_system_tooltip:
     'Controla el sistema de partículas iniciándolo, deteniéndolo o reiniciándolo.', // human
   create_box_tooltip:
-    'Crea una caja de color con dimensiones y posición especificadas.\nPalabra clave: caja', // human
+    'Crea una caja de color con dimensiones y posición especificadas.\nKeyword: caja', // human
   create_sphere_tooltip:
-    'Crea una esfera de color con dimensiones y posición especificadas.\nPalabra clave: esfera', // human
+    'Crea una esfera de color con dimensiones y posición especificadas.\nKeyword: esfera', // human
   create_cylinder_tooltip:
-    'Crea un cilindro de color con dimensiones y posición especificadas.\nPalabra clave: cilindro', // human
+    'Crea un cilindro de color con dimensiones y posición especificadas.\nKeyword: cilindro', // human
   create_capsule_tooltip:
-    'Crea una cápsula de color con dimensiones y posición especificadas.\nPalabra clave: cápsula', // human
+    'Crea una cápsula de color con dimensiones y posición especificadas.\nKeyword: cápsula', // human
   create_plane_tooltip:
-    'Crea un plano 2D de color con ancho, alto y posición especificadas.\nPalabra clave: plano', // human
+    'Crea un plano 2D de color con ancho, alto y posición especificadas.\nKeyword: plano', // human
 
   // Tooltip translations - Sound blocks
   play_theme_tooltip:
-    'Reproduce un tema musical en un objeto con velocidad, volumen y modo ajustables.\nPalabra clave: tema', // human
+    'Reproduce un tema musical en un objeto con velocidad, volumen y modo ajustables.\nKeyword: tema', // human
   play_sound_tooltip:
-    'Reproduce el sonido seleccionado en un objeto con velocidad, volumen y modo ajustables.\nPalabra clave: sonido', // human
+    'Reproduce el sonido seleccionado en un objeto con velocidad, volumen y modo ajustables.\nKeyword: sonido', // human
   stop_all_sounds_tooltip:
-    'Para todos los sonidos que estén reproduciendo en la escena.\nPalabra clave: nosonido', // human
+    'Para todos los sonidos que estén reproduciendo en la escena.\nKeyword: nosonido', // human
   midi_note_tooltip: 'Un valor de nota MIDI entre 0 y 127.', // human
   rest_tooltip: 'Un pausa (silencio) en una secuencia musical.', // human
   play_notes_tooltip:
@@ -617,18 +617,18 @@ export default {
   create_instrument_tooltip: 'Crea un instrumento y lo asigna a la variable seleccionada.', // human
   instrument_tooltip: 'Selecciona un instrumento para reproducir notas.', // human
   speak_tooltip:
-    'Convierte texto en voz usando el Web Speech API (API de voz web) con posicionamiento 3D opcional.\nPalabra clave: hablar', // human
+    'Convierte texto en voz usando el Web Speech API (API de voz web) con posicionamiento 3D opcional.\nKeyword: hablar', // human
   enable_subtitles_tooltip:
-    'Muestra subtítulos en pantalla para el texto hablado.\nPalabra clave: subtitles', // ai
+    'Muestra subtítulos en pantalla para el texto hablado.\nKeyword: subtitles', // ai
 
   // Tooltip translations - Text blocks
   comment_tooltip: 'Una línea de comentario para ayudar la comprensión de tu código.', // human
-  print_text_tooltip: 'Texto en el panel de salida.\nPalabra clave: imprimir', // human
+  print_text_tooltip: 'Texto en el panel de salida.\nKeyword: imprimir', // human
   subtitle_tooltip:
-    'Muestra el texto como subtítulo en pantalla. 0 segundos permanece hasta el siguiente.\nPalabra clave: subtitle', // ai
-  say_tooltip: 'Muestra un texto como burbuja de diálogo en un objeto.\nPalabra clave: di', // human
+    'Muestra el texto como subtítulo en pantalla. 0 segundos permanece hasta el siguiente.\nKeyword: subtitle', // ai
+  say_tooltip: 'Muestra un texto como burbuja de diálogo en un objeto.\nKeyword: di', // human
   describe_tooltip:
-    'Establece el nombre visible de un objeto. Actualiza los metadatos para accesibilidad.\nPalabra clave: describe', // human
+    'Establece el nombre visible de un objeto. Actualiza los metadatos para accesibilidad.\nKeyword: describe', // human
   ui_text_tooltip:
     'Añade texto a la pantalla UI y almacena el control en una variable para usar o eliminar luego.', // human
   ui_button_tooltip:
@@ -639,37 +639,37 @@ export default {
 
   // Tooltip translations - Math blocks
   random_seeded_int_tooltip:
-    'Generar un numero entero aleatorio con una semilla.\nPalabra clave: semilla', // human
+    'Generar un numero entero aleatorio con una semilla.\nKeyword: semilla', // human
   to_number_tooltip: 'Convertir una cadena a un numero entero o un flotante', // human
 
   // Tooltip translations - Transform blocks
   move_by_xyz_tooltip:
-    'Mueve un objeto cierta cantidad en direcciones x, y, y z.\nPalabra clave: mueve', // human
+    'Mueve un objeto cierta cantidad en direcciones x, y, y z.\nKeyword: mueve', // human
   move_by_xyz_single_tooltip:
-    'Mueve un objeto una cantidad en cualquiera dirección x, y, o z.\nPalabra clave: mueve', // human
+    'Mueve un objeto una cantidad en cualquiera dirección x, y, o z.\nKeyword: mueve', // human
   move_to_xyz_tooltip:
-    'Teletransporta el objeto a las coordenadas. Opcionalmente, usa el eje Y.\nPalabra clave: muevepor', // human
+    'Teletransporta el objeto a las coordenadas. Opcionalmente, usa el eje Y.\nKeyword: muevepor', // human
   move_to_xyz_single_tooltip:
-    'Teletransporta el objeto a la coordenada única especificada.\nPalabra clave: muevepor', // human
+    'Teletransporta el objeto a la coordenada única especificada.\nKeyword: muevepor', // human
   move_to_tooltip:
-    'Teletransporta el primer objeto a la ubicación del segundo.\nPalabra clave: muevea', // human
+    'Teletransporta el primer objeto a la ubicación del segundo.\nKeyword: muevea', // human
   scale_tooltip:
-    'Redimensiona un objeto a los valores x, y, y z y controla el origen del escalado.\nPalabra clave: escala', // human
+    'Redimensiona un objeto a los valores x, y, y z y controla el origen del escalado.\nKeyword: escala', // human
   resize_tooltip:
-    'Redimensiona un objeto a los valores x, y, y z y controla el origen del escalado.\nPalabra clave: redimensiona', // human
+    'Redimensiona un objeto a los valores x, y, y z y controla el origen del escalado.\nKeyword: redimensiona', // human
   rotate_model_xyz_tooltip:
-    'Rota el objeto por los valores x, y, z indicados.\nPalabra clave: rota\nKeyword: rotapor', // human
-  rotate_to_tooltip: 'Rota el objeto para q apunte hacia las coordenadas.\nPalabra clave: rotaa', // human
-  look_at_tooltip: 'Rota el primer objeto hacia la posición de la segunda.\nPalabra clave: mira', // human
+    'Rota el objeto por los valores x, y, z indicados.\nKeyword: rota\nKeyword: rotapor', // human
+  rotate_to_tooltip: 'Rota el objeto para q apunte hacia las coordenadas.\nKeyword: rotaa', // human
+  look_at_tooltip: 'Rota el primer objeto hacia la posición de la segunda.\nKeyword: mira', // human
   move_forward_tooltip:
-    "Mueve el objeto en la dirección especificada. 'adelante' sigue su dirección, 'al lado' lo mueve relativo a la posición de la cámara, y 'strafear' lo mueve al lado relative a la posición de la cámara.\nPalabra clave: empuja", // human
+    "Mueve el objeto en la dirección especificada. 'adelante' sigue su dirección, 'al lado' lo mueve relativo a la posición de la cámara, y 'strafear' lo mueve al lado relative a la posición de la cámara.\nKeyword: empuja", // human
   rotate_camera_tooltip:
-    'Rota la cámara a la izquierda o derecha los grados indicados.\nPalabra clave: rotate', // human
-  up_tooltip: 'Aplica la fuerza especificada hacia arriba .\nPalabra clave: up', // human
+    'Rota la cámara a la izquierda o derecha los grados indicados.\nKeyword: rotate', // human
+  up_tooltip: 'Aplica la fuerza especificada hacia arriba .\nKeyword: up', // human
   set_pivot_tooltip:
-    'Establece el punto de anclaje para un objeto en los ejes X, Y, y Z.\nPalabra clave: ancla', // human
+    'Establece el punto de anclaje para un objeto en los ejes X, Y, y Z.\nKeyword: ancla', // human
   min_centre_max_tooltip:
-    'Elige minimo, centro o maximo para el punto de pivote.\nPalabra clave: minmax', // human
+    'Elige minimo, centro o maximo para el punto de pivote.\nKeyword: minmax', // human
 
   // Tooltip translations - XR blocks
   device_camera_background_tooltip:
@@ -680,11 +680,11 @@ export default {
   remove_teleport_target_tooltip:
     'Impide teletransportarse al suelo, a un objeto o a todos los objetos.',
   play_rumble_pattern_tooltip:
-    'Reproduce un patrón de vibración predefinido en todos los mandos conectados.\nPalabra clave: rumble preset', // human
+    'Reproduce un patrón de vibración predefinido en todos los mandos conectados.\nKeyword: rumble preset', // human
   controller_rumble_tooltip:
-    'Hace vibrar un mando conectado. Elige todos, el izquierdo o el derecho motor, establece la fuerza (0 a 1) y cuánto tiempo para vibrar en milisegundos.\nPalabra clave: vibrar', // human
+    'Hace vibrar un mando conectado. Elige todos, el izquierdo o el derecho motor, establece la fuerza (0 a 1) y cuánto tiempo para vibrar en milisegundos.\nKeyword: vibrar', // human
   controller_rumble_pattern_tooltip:
-    'Hace vibrar un mando conectado en un patrón repetido. Establece el motor, la fuerza (0 a 1), el tiempo encendido, el tiempo apagado y el número de repeticiones.\nPalabra clave: patrón de vibrar', // human
+    'Hace vibrar un mando conectado en un patrón repetido. Establece el motor, la fuerza (0 a 1), el tiempo encendido, el tiempo apagado y el número de repeticiones.\nKeyword: patrón de vibrar', // human
 
   // Dropdown option translations
   AWAIT_option: 'esperar', // human

--- a/locale/fr.js
+++ b/locale/fr.js
@@ -1037,6 +1037,8 @@ export default {
   project_save_ui: 'Enregistrer',
   tools_submenu_ui: 'Outils',
   inspector_tool_ui: 'Inspecteur',
+  show_block_hints_ui: 'Afficher les astuces des blocs',
+  hide_block_hints_ui: 'Masquer les astuces des blocs',
   language_submenu_ui: 'Langue',
   about_submenu_ui: 'À propos',
   hub_submenu_ui: 'Hub',

--- a/locale/fr.js
+++ b/locale/fr.js
@@ -1039,6 +1039,7 @@ export default {
   inspector_tool_ui: 'Inspecteur',
   show_block_hints_ui: 'Afficher les astuces des blocs',
   hide_block_hints_ui: 'Masquer les astuces des blocs',
+  block_hints_menu_location_ui: 'Cliquez sur Menu > Outils',
   language_submenu_ui: 'Langue',
   about_submenu_ui: 'À propos',
   hub_submenu_ui: 'Hub',

--- a/locale/it.js
+++ b/locale/it.js
@@ -1047,6 +1047,7 @@ export default {
   inspector_tool_ui: 'Ispettore',
   show_block_hints_ui: 'Mostra suggerimenti dei blocchi',
   hide_block_hints_ui: 'Nascondi suggerimenti dei blocchi',
+  block_hints_menu_location_ui: 'Fai clic su Menu > Strumenti',
   language_submenu_ui: 'Lingua',
   about_submenu_ui: 'Informazioni',
   hub_submenu_ui: 'Hub',

--- a/locale/it.js
+++ b/locale/it.js
@@ -1045,6 +1045,8 @@ export default {
   project_save_ui: 'Salva',
   tools_submenu_ui: 'Strumenti',
   inspector_tool_ui: 'Ispettore',
+  show_block_hints_ui: 'Mostra suggerimenti dei blocchi',
+  hide_block_hints_ui: 'Nascondi suggerimenti dei blocchi',
   language_submenu_ui: 'Lingua',
   about_submenu_ui: 'Informazioni',
   hub_submenu_ui: 'Hub',

--- a/locale/pl.js
+++ b/locale/pl.js
@@ -1037,6 +1037,7 @@ export default {
   inspector_tool_ui: 'Inspektor',
   show_block_hints_ui: 'Pokaż podpowiedzi bloków',
   hide_block_hints_ui: 'Ukryj podpowiedzi bloków',
+  block_hints_menu_location_ui: 'Kliknij Menu > Narzędzia',
   language_submenu_ui: 'Język',
   about_submenu_ui: 'O programie',
   hub_submenu_ui: 'Hub',

--- a/locale/pl.js
+++ b/locale/pl.js
@@ -1035,6 +1035,8 @@ export default {
   project_save_ui: 'Zapisz',
   tools_submenu_ui: 'Narzędzia',
   inspector_tool_ui: 'Inspektor',
+  show_block_hints_ui: 'Pokaż podpowiedzi bloków',
+  hide_block_hints_ui: 'Ukryj podpowiedzi bloków',
   language_submenu_ui: 'Język',
   about_submenu_ui: 'O programie',
   hub_submenu_ui: 'Hub',

--- a/locale/pt.js
+++ b/locale/pt.js
@@ -1047,6 +1047,7 @@ export default {
   inspector_tool_ui: 'Inspetor',
   show_block_hints_ui: 'Mostrar dicas de blocos',
   hide_block_hints_ui: 'Ocultar dicas de blocos',
+  block_hints_menu_location_ui: 'Clique em Menu > Ferramentas',
   language_submenu_ui: 'Idioma',
   about_submenu_ui: 'Sobre',
   hub_submenu_ui: 'Hub',

--- a/locale/pt.js
+++ b/locale/pt.js
@@ -1045,6 +1045,8 @@ export default {
   project_save_ui: 'Guardar',
   tools_submenu_ui: 'Ferramentas',
   inspector_tool_ui: 'Inspetor',
+  show_block_hints_ui: 'Mostrar dicas de blocos',
+  hide_block_hints_ui: 'Ocultar dicas de blocos',
   language_submenu_ui: 'Idioma',
   about_submenu_ui: 'Sobre',
   hub_submenu_ui: 'Hub',

--- a/locale/sv.js
+++ b/locale/sv.js
@@ -1023,6 +1023,8 @@ export default {
   project_save_ui: 'Spara',
   tools_submenu_ui: 'Verktyg',
   inspector_tool_ui: 'Inspektör',
+  show_block_hints_ui: 'Visa blocktips',
+  hide_block_hints_ui: 'Dölj blocktips',
   language_submenu_ui: 'Språk',
   about_submenu_ui: 'Om',
   hub_submenu_ui: 'Nav',

--- a/locale/sv.js
+++ b/locale/sv.js
@@ -1025,6 +1025,7 @@ export default {
   inspector_tool_ui: 'Inspektör',
   show_block_hints_ui: 'Visa blocktips',
   hide_block_hints_ui: 'Dölj blocktips',
+  block_hints_menu_location_ui: 'Klicka på Meny > Verktyg',
   language_submenu_ui: 'Språk',
   about_submenu_ui: 'Om',
   hub_submenu_ui: 'Nav',

--- a/main/blockhandling.js
+++ b/main/blockhandling.js
@@ -4,6 +4,7 @@ import { translate } from './translation.js';
 import { blockHandlerRegistry, refreshReporterAriaLabels } from '../blocks/blocks.js';
 import { announceToScreenReader } from './input.js';
 import { TOP_BLOCK_TYPES } from '../config.js';
+import { showBlockHint, clearBlockHint } from '../ui/blockHint.js';
 
 function asBlocklyBlock(candidate) {
   if (!candidate || typeof candidate !== 'object') {
@@ -323,6 +324,11 @@ export function initializeBlockHandling() {
     // Track the currently selected block.
     if (event.type === Blockly.Events.SELECTED) {
       window.currentBlock = event.newElementId ? workspace.getBlockById(event.newElementId) : null;
+      if (window.currentBlock) {
+        showBlockHint(Blockly.Tooltip.getTooltipOfObject(window.currentBlock));
+      } else {
+        clearBlockHint();
+      }
     }
 
     // Workaround for Blockly not checking for orphans on key

--- a/main/loading.js
+++ b/main/loading.js
@@ -1,4 +1,5 @@
 import { translate } from './translation.js';
+import { areBlockHintsEnabled, showBlockHintMessage } from '../ui/blockHint.js';
 
 // Function to hide loading screen
 export function hideLoadingScreen() {
@@ -17,6 +18,12 @@ export function hideLoadingScreen() {
         announcements.textContent = translate('loading_success_ui');
       }, 20);
     }
+
+    const hintsLabelKey = areBlockHintsEnabled() ? 'hide_block_hints_ui' : 'show_block_hints_ui';
+    const hintsLabel = translate(hintsLabelKey);
+    showBlockHintMessage(`ℹ️ ${hintsLabel}: ${translate('block_hints_menu_location_ui')}`, {
+      boldPart: hintsLabel,
+    });
 
     // Then show main content after a brief delay
     setTimeout(() => {

--- a/main/main.js
+++ b/main/main.js
@@ -47,6 +47,7 @@ import {
 import { ShortcutsPanel } from '../accessibility/keyboardui.js';
 import { KeyboardDispatcher } from './keyboardDispatcher.js';
 import { ContextManager } from './context.js';
+import { areBlockHintsEnabled, setBlockHintsEnabled } from '../ui/blockHint.js';
 
 function isEmbedModeEnabled() {
   const embedParam = new URLSearchParams(window.location.search).get('embed');
@@ -729,6 +730,7 @@ function initializeApp() {
   // Add event listeners for menu buttons and controls
   const runCodeButton = document.getElementById('runCodeButton');
   const inspectorMenuItem = document.getElementById('inspector-menu-item');
+  const blockHintsMenuItem = document.getElementById('block-hints-menu-item');
   const togglePlayButton = document.getElementById('togglePlay');
   const stopCodeButton = document.getElementById('stopCodeButton');
   const fileInput = document.getElementById('fileInput');
@@ -837,6 +839,19 @@ function initializeApp() {
       );
       announceToScreenReader(focusedMessage, { requireCanvasFocus: false });
     }
+  });
+
+  const updateBlockHintsMenuLabel = () => {
+    if (!blockHintsMenuItem) return;
+    const key = areBlockHintsEnabled() ? 'hide_block_hints' : 'show_block_hints';
+    blockHintsMenuItem.dataset.i18n = key;
+    blockHintsMenuItem.textContent = translate(`${key}_ui`);
+  };
+  updateBlockHintsMenuLabel();
+  blockHintsMenuItem?.addEventListener('click', (event) => {
+    event.preventDefault();
+    setBlockHintsEnabled(!areBlockHintsEnabled());
+    updateBlockHintsMenuLabel();
   });
 
   if (togglePlayButton) {

--- a/main/translation.js
+++ b/main/translation.js
@@ -200,7 +200,7 @@ export function getBlocklyMessage(key) {
 
 const keywordHintLabels = {
   en: 'Keyword',
-  es: 'Palabra clave',
+  es: 'Keyword',
 };
 
 function getTooltipKeywordLabel() {

--- a/main/translation.js
+++ b/main/translation.js
@@ -200,7 +200,7 @@ export function getBlocklyMessage(key) {
 
 const keywordHintLabels = {
   en: 'Keyword',
-  es: 'Keyword',
+  es: 'Palabra clave',
 };
 
 function getTooltipKeywordLabel() {

--- a/style.css
+++ b/style.css
@@ -638,10 +638,6 @@ button {
   margin: 0;
 }
 
-.block-hint__keyword {
-  font-weight: bold;
-}
-
 #blocklyZoomControls .toolbar-divider,
 #info-panel-tabs .toolbar-divider {
   width: 1px;

--- a/style.css
+++ b/style.css
@@ -628,6 +628,7 @@ button {
   border-radius: 8px;
   z-index: 90;
   text-align: left;
+  pointer-events: none;
 }
 
 .block-hint[hidden] {

--- a/style.css
+++ b/style.css
@@ -621,8 +621,9 @@ button {
   padding: 6px 12px;
   font-size: 0.9rem;
   line-height: 1.3;
-  color: var(--color-text);
+  color: var(--color-text-primary);
   background-color: var(--color-bg);
+  border: 1px solid var(--color-border);
   box-shadow: 0px 0px 10px var(--color-shadow);
   border-radius: 8px;
   z-index: 90;

--- a/style.css
+++ b/style.css
@@ -612,6 +612,35 @@ button {
   z-index: 100;
 }
 
+.block-hint {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: min(320px, calc(100% - 16px));
+  margin: 0;
+  padding: 6px 12px;
+  font-size: 0.9rem;
+  line-height: 1.3;
+  color: var(--color-text);
+  background-color: var(--color-bg);
+  box-shadow: 0px 0px 10px var(--color-shadow);
+  border-radius: 8px;
+  z-index: 90;
+  text-align: left;
+}
+
+.block-hint[hidden] {
+  display: none;
+}
+
+.block-hint__text {
+  margin: 0;
+}
+
+.block-hint__keyword {
+  font-weight: bold;
+}
+
 #blocklyZoomControls .toolbar-divider,
 #info-panel-tabs .toolbar-divider {
   width: 1px;

--- a/style.css
+++ b/style.css
@@ -1021,7 +1021,7 @@ button {
   }
 
   #babylon-inspector-container,
-  #menuDropdown #tools-menu-item {
+  #menuDropdown #inspector-menu-item {
     display: none !important;
   }
 

--- a/ui/blockHint.js
+++ b/ui/blockHint.js
@@ -21,6 +21,7 @@ function isMobileLayout() {
 }
 
 let enabled = !isMobileLayout();
+let lastHintText = '';
 
 export function areBlockHintsEnabled() {
   return enabled;
@@ -28,7 +29,11 @@ export function areBlockHintsEnabled() {
 
 export function setBlockHintsEnabled(value) {
   enabled = value;
-  if (!enabled) hideBlockHint();
+  if (!enabled) {
+    hideBlockHint();
+  } else {
+    renderBlockHint(lastHintText);
+  }
 }
 
 function renderBlockHint(text) {
@@ -50,6 +55,7 @@ function renderBlockHint(text) {
 }
 
 export function showBlockHint(text) {
+  lastHintText = text || '';
   renderBlockHint(enabled ? text : '');
 }
 

--- a/ui/blockHint.js
+++ b/ui/blockHint.js
@@ -9,9 +9,9 @@ function getTextElement() {
   return typeof document === 'undefined' ? null : document.getElementById('blockHintText');
 }
 
-// Matches "Keyword: word" (or "Keyword:word") so it can be pulled out to the
-// front as "[key emoji]word - rest of the description".
-const KEYWORD_RE = /Keyword:\s*(\S+)/;
+// Strips the "Keyword: word" suffix — that's a toolbox search term, only
+// useful before a block is placed, not for a hint about one already selected.
+const KEYWORD_RE = /\s*Keyword:\s*\S+/;
 
 // Matches the app's mobile breakpoint (style.css: @media (max-width: 1024px)):
 // hints default off there, since screen space is tight, but stay toggleable
@@ -44,20 +44,7 @@ export function showBlockHint(text) {
   }
 
   element.replaceChildren();
-  const match = KEYWORD_RE.exec(content);
-  if (!match) {
-    element.append(content);
-  } else {
-    const description = (
-      content.slice(0, match.index) + content.slice(match.index + match[0].length)
-    ).trim();
-
-    const word = document.createElement('span');
-    word.className = 'block-hint__keyword';
-    word.textContent = match[1];
-    element.append('🔑', word);
-    if (description) element.append(` - ${description}`);
-  }
+  element.append(content.replace(KEYWORD_RE, '').trim());
 
   container.hidden = false;
 }

--- a/ui/blockHint.js
+++ b/ui/blockHint.js
@@ -31,12 +31,12 @@ export function setBlockHintsEnabled(value) {
   if (!enabled) hideBlockHint();
 }
 
-export function showBlockHint(text) {
+function renderBlockHint(text) {
   const container = getContainer();
   const element = getTextElement();
   if (!container || !element) return;
 
-  const content = enabled ? text || '' : '';
+  const content = text || '';
   if (!content) {
     container.hidden = true;
     element.replaceChildren();
@@ -45,6 +45,41 @@ export function showBlockHint(text) {
 
   element.replaceChildren();
   element.append(content.replace(KEYWORD_RE, '').trim());
+
+  container.hidden = false;
+}
+
+export function showBlockHint(text) {
+  renderBlockHint(enabled ? text : '');
+}
+
+// Shows a one-off message in the same box regardless of the enabled/disabled
+// toggle — e.g. the startup tip, which needs to appear even when hints are
+// off (that's exactly when it's telling the user how to turn them on).
+// boldPart, if given and found in text, renders as <strong> instead of plain text.
+export function showBlockHintMessage(text, { boldPart } = {}) {
+  const container = getContainer();
+  const element = getTextElement();
+  if (!container || !element) return;
+
+  const content = text || '';
+  if (!content) {
+    container.hidden = true;
+    element.replaceChildren();
+    return;
+  }
+
+  element.replaceChildren();
+  const boldIndex = boldPart ? content.indexOf(boldPart) : -1;
+  if (boldIndex === -1) {
+    element.append(content);
+  } else {
+    const before = content.slice(0, boldIndex);
+    const after = content.slice(boldIndex + boldPart.length);
+    const strong = document.createElement('strong');
+    strong.textContent = boldPart;
+    element.append(before, strong, after);
+  }
 
   container.hidden = false;
 }

--- a/ui/blockHint.js
+++ b/ui/blockHint.js
@@ -13,7 +13,14 @@ function getTextElement() {
 // front as "[key emoji]word - rest of the description".
 const KEYWORD_RE = /Keyword:\s*(\S+)/;
 
-let enabled = true;
+// Matches the app's mobile breakpoint (style.css: @media (max-width: 1024px)):
+// hints default off there, since screen space is tight, but stay toggleable
+// from the Tools menu.
+function isMobileLayout() {
+  return typeof window !== 'undefined' && !!window.matchMedia?.('(max-width: 1024px)').matches;
+}
+
+let enabled = !isMobileLayout();
 
 export function areBlockHintsEnabled() {
   return enabled;

--- a/ui/blockHint.js
+++ b/ui/blockHint.js
@@ -1,0 +1,67 @@
+// Shows the focused/selected block's tooltip text in a floating box over the
+// top-right of the workspace.
+
+function getContainer() {
+  return typeof document === 'undefined' ? null : document.getElementById('blockHint');
+}
+
+function getTextElement() {
+  return typeof document === 'undefined' ? null : document.getElementById('blockHintText');
+}
+
+// Matches "Keyword: word" (or "Keyword:word") so it can be pulled out to the
+// front as "[key emoji]word - rest of the description".
+const KEYWORD_RE = /Keyword:\s*(\S+)/;
+
+let enabled = true;
+
+export function areBlockHintsEnabled() {
+  return enabled;
+}
+
+export function setBlockHintsEnabled(value) {
+  enabled = value;
+  if (!enabled) hideBlockHint();
+}
+
+export function showBlockHint(text) {
+  const container = getContainer();
+  const element = getTextElement();
+  if (!container || !element) return;
+
+  const content = enabled ? text || '' : '';
+  if (!content) {
+    container.hidden = true;
+    element.replaceChildren();
+    return;
+  }
+
+  element.replaceChildren();
+  const match = KEYWORD_RE.exec(content);
+  if (!match) {
+    element.append(content);
+  } else {
+    const description = (
+      content.slice(0, match.index) + content.slice(match.index + match[0].length)
+    ).trim();
+
+    const word = document.createElement('span');
+    word.className = 'block-hint__keyword';
+    word.textContent = match[1];
+    element.append('🔑', word);
+    if (description) element.append(` - ${description}`);
+  }
+
+  container.hidden = false;
+}
+
+export function clearBlockHint() {
+  showBlockHint('');
+}
+
+// Hides the current hint without clearing its text, so a future caller could
+// still wire this up to a dismiss control.
+export function hideBlockHint() {
+  const container = getContainer();
+  if (container) container.hidden = true;
+}


### PR DESCRIPTION
# Summary
Users are shown block hints on the top right corner of the workspace. These come from the locale files. 
<img width="603" height="148" alt="image" src="https://github.com/user-attachments/assets/61d8d3d5-7274-465d-b064-fed151739263" />

Desktop users are shown a one-time message on startup for how to **hide the hints**:
<img width="301" height="87" alt="image" src="https://github.com/user-attachments/assets/c6fd67ba-f9a1-4fa7-8b7f-3d34a308c63f" />

Mobile users are shown a one-time message for how to **enable the hints**:
<img width="372" height="113" alt="image" src="https://github.com/user-attachments/assets/5d6fbb7b-9d5c-4940-a5bb-f73880631f89" />

Toggle setting appears on the tools menu
<img width="331" height="257" alt="image" src="https://github.com/user-attachments/assets/22177045-8f6b-4181-93ab-4c35fd43eab9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional block hints that display helpful tooltips when selecting blocks.
  - Added Tools menu controls to show or hide block hints.
  - Added contextual guidance during loading, including the hint setting and menu location.
  - Block hints are disabled by default on mobile layouts.

- **Localization**
  - Added translated hint controls for German, Spanish, French, Italian, Polish, Portuguese, and Swedish.

- **Bug Fixes**
  - Improved and corrected several block tooltips, including conditional, start, jump, speed, and rotation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->