### PR TITLE
DO NOT MERGE Ratio resize bug

### DIFF
--- a/ui/blockmesh.js
+++ b/ui/blockmesh.js
@@ -1515,13 +1515,30 @@ export function updateMeshFromBlock(meshesOrMesh, block, changeEvent) {
 function moveMeshToOrigin(mesh) {
   mesh.position = flock.BABYLON.Vector3.Zero();
   mesh.rotation = flock.BABYLON.Vector3.Zero();
+  // rotationQuaternion takes priority over rotation when set, so it must be
+  // cleared too or callers that bake the transform into vertices (e.g.
+  // setAbsoluteSize) will bake in the old rotation as well.
+  mesh.rotationQuaternion = null;
   return mesh;
 }
 
 function setAbsoluteSize(mesh, width, height, depth) {
   flock.ensureUniqueGeometry(mesh);
-  const boundingInfo = mesh.getBoundingInfo();
-  const originalSize = boundingInfo.boundingBox.extendSize;
+
+  // Anchor to the true original geometry (captured once), like flock.resize().
+  mesh.metadata = mesh.metadata || {};
+  if (!mesh.metadata.originalMin || !mesh.metadata.originalMax) {
+    const bi = mesh.getBoundingInfo();
+    mesh.metadata.originalMin = bi.boundingBox.minimum.clone();
+    mesh.metadata.originalMax = bi.boundingBox.maximum.clone();
+  }
+  const origMin = mesh.metadata.originalMin;
+  const origMax = mesh.metadata.originalMax;
+  const originalSize = {
+    x: (origMax.x - origMin.x) / 2,
+    y: (origMax.y - origMin.y) / 2,
+    z: (origMax.z - origMin.z) / 2,
+  };
 
   // Store the current world matrix and decompose it
   const worldMatrix = mesh.computeWorldMatrix(true);

--- a/ui/blockmesh.js
+++ b/ui/blockmesh.js
@@ -1516,8 +1516,9 @@ function moveMeshToOrigin(mesh) {
   mesh.position = flock.BABYLON.Vector3.Zero();
   mesh.rotation = flock.BABYLON.Vector3.Zero();
   // rotationQuaternion takes priority over rotation when set, so it must be
-  // cleared too or callers that bake the transform into vertices (e.g.
-  // setAbsoluteSize) will bake in the old rotation as well.
+  // cleared too or callers that rebuild geometry at the origin (e.g.
+  // updateCylinderGeometry, updateCapsuleGeometry) will bake in the old
+  // rotation as well.
   mesh.rotationQuaternion = null;
   return mesh;
 }
@@ -1535,38 +1536,17 @@ function setAbsoluteSize(mesh, width, height, depth) {
   const origMin = mesh.metadata.originalMin;
   const origMax = mesh.metadata.originalMax;
   const originalSize = {
-    x: (origMax.x - origMin.x) / 2,
-    y: (origMax.y - origMin.y) / 2,
-    z: (origMax.z - origMin.z) / 2,
+    x: origMax.x - origMin.x,
+    y: origMax.y - origMin.y,
+    z: origMax.z - origMin.z,
   };
 
-  // Store the current world matrix and decompose it
-  const worldMatrix = mesh.computeWorldMatrix(true);
-  const currentScale = new flock.BABYLON.Vector3();
-  const currentRotationQuaternion = new flock.BABYLON.Quaternion();
-  const currentPosition = new flock.BABYLON.Vector3();
-  worldMatrix.decompose(currentScale, currentRotationQuaternion, currentPosition);
+  const newScaleX = originalSize.x ? width / originalSize.x : 1;
+  const newScaleY = originalSize.y ? height / originalSize.y : 1;
+  const newScaleZ = depth === 0 ? 1 : originalSize.z ? depth / originalSize.z : 1;
 
-  // Temporarily move mesh to origin
-  mesh = moveMeshToOrigin(mesh);
-
-  // Calculate new scaling
-  const newScaleX = width / (originalSize.x * 2);
-  const newScaleY = height / (originalSize.y * 2);
-  const newScaleZ = depth === 0 ? 1 : depth / (originalSize.z * 2);
-
-  // Apply scaling
   mesh.scaling = new flock.BABYLON.Vector3(newScaleX, newScaleY, newScaleZ);
-
-  // Bake the scaling into the vertices
-  mesh.bakeCurrentTransformIntoVertices();
-
-  // Reset scaling to 1,1,1
-  mesh.scaling = flock.BABYLON.Vector3.One();
-
-  // Restore original position and rotation from world matrix
-  mesh.position = currentPosition;
-  mesh.rotationQuaternion = currentRotationQuaternion;
+  mesh.computeWorldMatrix(true);
 
   let shapeType = null;
   if (mesh.metadata) shapeType = mesh.metadata.shapeType;


### PR DESCRIPTION
Don't merge this, just for info

While testing I found a bug:

- In a new project add a flat square object
- Select the resize gizmo
- Press the + button once to increase X size then the - button once to reset it, check that the block still has equal numbers for the side sizes
- Select uniform resize
- Make the square larger and smaller using the HUD. 

Eventually it will become non-square as the sizes get out of sync. I am pretty sure that this is to do with the resizing calculations being rounded floating point numbers and eventually the rounding errors catching up. I tried to fix this [here ](https://github.com/flipcomputing/flock/pull/747)but I don’t think that this is the right way to do it as it has lots of knock-on effects to do with textures and rotations.