### PR TITLE
Display picker over context

### DIFF
--- a/main/main.js
+++ b/main/main.js
@@ -259,7 +259,6 @@ function applyEmbedMode() {
   }
 
   if (mainContent) {
-    mainContent.style.transform = 'translateX(0px)';
     mainContent.style.marginTop = '0';
     mainContent.style.height = 'auto';
     mainContent.tabIndex = -1;

--- a/main/view.js
+++ b/main/view.js
@@ -260,14 +260,6 @@ function switchView(view) {
     canvasArea.style.width = '0';
     blocklyArea.style.flex = '2 1 0'; // 2/3 of the space
     canvasArea.style.flex = '1 1 0'; // 1/3 of the space
-
-    // Reset any transforms on desktop
-    if (!isNarrowScreen()) {
-      const container = document.getElementById('maincontent');
-      if (container) {
-        container.style.transform = 'translateX(0px)';
-      }
-    }
     onResize();
   } else if (view === 'canvas') {
     viewMode = 'canvas';
@@ -354,7 +346,6 @@ let currentView = 'start'; // Start with the code view
 // Function to be called once the app has fully loaded
 export { currentView, switchView, codeMode, showCodeView };
 
-const container = document.getElementById('maincontent');
 const bottomBar = document.getElementById('bottomBar');
 const canvasToggleBtn = document.getElementById('canvasToggleBtn');
 const codeToggleBtn = document.getElementById('codeToggleBtn');
@@ -570,11 +561,6 @@ export function togglePlayMode() {
 
   if (gizmosVisible) {
     savedView = currentView;
-
-    // Clear any transforms that might be applied
-    if (isNarrowScreen()) {
-      if (container) container.style.transform = 'translateX(0px)';
-    }
 
     showCanvasView();
     hideInspector();


### PR DESCRIPTION
# Summary
Display menus (e.g. the colour picker) over the top of the context bar. This should already have been the case according to z-index but there was a bug from a previous swipe implementation preventing this.

**Old behaviour**
<img width="483" height="249" alt="Screenshot 2026-08-18 150851" src="https://github.com/user-attachments/assets/21cd5d25-4a2e-4ebf-ab0e-3bc8abae6563" />

**New behaviour**
<img width="708" height="671" alt="Screenshot 2026-08-18 153208" src="https://github.com/user-attachments/assets/91e43dd5-1243-40c2-8112-86ac7138bef3" />


### AI usage
Claude Sonnet 5 diagnosed and resolved the problem. Code was removed, no code was added. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved embedded and playback views by removing obsolete layout transformations.
  * Fixed potential content positioning and sizing issues when switching views or entering embed mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->